### PR TITLE
al: add degree/program requirements for 9 colleges (planner unlock)

### DIFF
--- a/data/al/DEFERRED-programs.md
+++ b/data/al/DEFERRED-programs.md
@@ -1,0 +1,34 @@
+# AL programs — deferred colleges
+
+Programs were rolled out for **9 of 23** Alabama community colleges (all on
+CleanCatalog). The remaining 14 are deferred below with the reason and the
+next step, so a follow-up session can extend coverage without re-discovering.
+
+Discovery method: `scripts/lib/discover-programs.ts` probed each college's
+catalog domain (derived from the Scorecard `schoolUrl`).
+
+## Platform detected, but no parseable programs (5)
+
+| College | Platform | Catalog URL | Reason / next step |
+|---|---|---|---|
+| coastal-alabama-community-college | CleanCatalog | https://catalog.coastalalabama.edu | `/degrees` returns 200 but the crawl finds 0 program detail pages; programs sit under a `/catalog/...` structure. Inspect the DOM and set `indexPaths`. |
+| h-councill-trenholm-state-community-college | CleanCatalog | https://catalog.trenholmstate.edu | `/degrees` and `/certificate` exist but parse to 0 programs. Inspect link structure; likely a custom template variant. |
+| central-alabama-community-college | CleanCatalog | https://live-central-alabama.cleancatalog.io | Programs live under category pages (`/academic-transfer-programs`, `/career-technical-programs`) that link to intermediate pages, not program detail pages. Needs a deeper crawl depth. |
+| j-f-drake-state-community-and-technical-college | SmartCatalogIQ | (body marker on https://drakestate.edu) | Discovery matched the SmartCatalogIQ marker on the main domain; the real `*.smartcatalogiq.com` catalog URL is unresolved (`Could not discover catalog year`). Find the actual catalog host and pass it as `baseUrl`. |
+| shelton-state-community-college | Acalog | https://catalog.sheltonstate.edu | Acalog needs `programNavoids`; auto-discovery returned 0. Open the catalog, find the program-listing navoid(s), and fill them in. |
+
+## No public catalog matched a known platform (9)
+
+These returned no Acalog / CourseLeaf / SmartCatalogIQ / Coursedog /
+CleanCatalog catalog on their primary domain (likely Modern Campus, custom
+HTML, or PDF-only). Each needs manual investigation.
+
+- bishop-state-community-college
+- enterprise-state-community-college
+- jefferson-state-community-college
+- lawson-state-community-college
+- lurleen-b-wallace-community-college
+- marion-military-institute
+- northeast-alabama-community-college
+- reid-state-technical-college
+- snead-state-community-college

--- a/data/al/programs/bevill-state-community-college.json
+++ b/data/al/programs/bevill-state-community-college.json
@@ -1,0 +1,8476 @@
+{
+  "college_slug": "bevill-state-community-college",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.bscc.edu/degrees",
+  "scraped_at": "2026-06-03T21:27:04.876Z",
+  "programs": [
+    {
+      "title": "Additive Engineering Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/advanced-engineering-design-technology/additive-engineering-technology-shortterm-certificate",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "162",
+              "title": "ADDITIVE MANUFACTURING PROCESS-POLYMERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "144",
+              "title": "BASIC 3D MODELING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "233",
+              "title": "INTERMEDIATE 3D MODELING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Architectural Engineering Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/advanced-engineering-design-technology/architectural-engineering-technology-shortterm-certificate",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "127",
+              "title": "INTERMEDIATE COMPUTER AIDED DRAFTING AND DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "132",
+              "title": "ARCHITECTURAL DRAFTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "212",
+              "title": "INTERMEDIATE ARCHITECTURAL DRAFTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "238",
+              "title": "SPECIAL TOPICS IN CAD",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Advanced Engineering Design Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/advanced-engineering-design-technology/advanced-engineering-design-technology-shortterm-certificate",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "PRECISION MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "244",
+              "title": "ADVANCED 3D MODELING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "211",
+              "title": "INTERMEDIATE MACHINE DRAFTING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering Design Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/advanced-engineering-design-technology/engineering-design-technology-shortterm-certificate",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "104",
+              "title": "BASIC COMPUTER AIDED DRAFTING AND DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "127",
+              "title": "INTERMEDIATE COMPUTER AIDED DRAFTING AND DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "111",
+              "title": "FUNDAMENTALS OF DRAFTING AND DESIGN TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "124",
+              "title": "BASIC TECHNICAL DRAWING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "128",
+              "title": "INTERMEDIATE TECHNICAL DRAWING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "131",
+              "title": "MACHINE DRAFTING BASICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Associate In Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/advanced-engineering-design-technology/associate-in-applied-science-degree",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "PRECISION MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "244",
+              "title": "ADVANCED 3D MODELING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "104",
+              "title": "BASIC COMPUTER AIDED DRAFTING AND DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "111",
+              "title": "FUNDAMENTALS OF DRAFTING AND DESIGN TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "124",
+              "title": "BASIC TECHNICAL DRAWING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "127",
+              "title": "INTERMEDIATE COMPUTER AIDED DRAFTING AND DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "128",
+              "title": "INTERMEDIATE TECHNICAL DRAWING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "131",
+              "title": "MACHINE DRAFTING BASICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "132",
+              "title": "ARCHITECTURAL DRAFTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "144",
+              "title": "BASIC 3D MODELING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "211",
+              "title": "INTERMEDIATE MACHINE DRAFTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "212",
+              "title": "INTERMEDIATE ARCHITECTURAL DRAFTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "233",
+              "title": "INTERMEDIATE 3D MODELING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "238",
+              "title": "SPECIAL TOPICS IN CAD",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "162",
+              "title": "ADDITIVE MANUFACTURING PROCESS-POLYMERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "191",
+              "title": "BUILDING INFORMATION MODELING (BIM)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "236",
+              "title": "DESIGN PROJECTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "244",
+              "title": "ADVANCED 3D MODELING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "115",
+              "title": "BLUEPRINT READING FOR MACHINISTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "116",
+              "title": "BLUEPRINT READING FOR CONSTRUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "215",
+              "title": "GEOMETRIC DIMENSIONING & TOLERANCING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "133",
+              "title": "BASIC SURVEYING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/advanced-manufacturing-technology/associate-in-applied-science-degree",
+      "total_credits": 141,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Core Requirements",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MSSC Advanced Manufacturing Core Requirements",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "292",
+              "title": "MSSC QUALITY PRACTICES AND MEASUREMENT COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "293",
+              "title": "MSSC MANUFACTURING PROCESSES AND PRODUCTION COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technial Co-Operative Education",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "150",
+              "title": "TECHNICAL COOPERATIVE EDUCATION",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "151",
+              "title": "TECHNICAL COOPERATIVE EDUCATION",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "152",
+              "title": "TECHNICAL COOPERATIVE EDUCATION",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "153",
+              "title": "TECHNICAL COOPERATIVE EDUCATION",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "154",
+              "title": "TECHNICAL COOPERATIVE EDUCATION",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Advanced Manufacturing Automation Option",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "104",
+              "title": "DIGITAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "108",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "MOTOR CONTROL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "196",
+              "title": "ADVANCED PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "139",
+              "title": "INTRO TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Advanced Manufacturing Industrial Maintenance Option",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "108",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "MOTOR CONTROL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "196",
+              "title": "ADVANCED PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "COMMERCIAL/INDUSTRIAL WIRING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Advanced Manufacturing Machine Tool Technology Option",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "100",
+              "title": "MACHINING TECHNOLOGY I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "103",
+              "title": "MACHINING TECHNOLOGY II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "BASIC PRINT READING FOR MACHINISTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "INTRODUCTION TO METROLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "136",
+              "title": "MILLING OPERATIONS",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "139",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Advanced Manufacturing Welding Technology Option",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW FILLET/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "INDUSTRIAL BLUE PRINT READING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW FILLET/OFC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "SHIELDED METAL ARC WELDING GROOVE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "SHIELDED METAL ARC WELDING GROOVE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "218",
+              "title": "CERTIFICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "CERTIFICATION LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Long-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/advanced-manufacturing-technology/longterm-certificate",
+      "total_credits": 132,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Genreal Education Core Requirements",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MSSC Advanced Manufacturing Core Requirements",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "292",
+              "title": "MSSC QUALITY PRACTICES AND MEASUREMENT COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "293",
+              "title": "MSSC MANUFACTURING PROCESSES AND PRODUCTION COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Co-Operative Education",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "150",
+              "title": "TECHNICAL COOPERATIVE EDUCATION",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "151",
+              "title": "TECHNICAL COOPERATIVE EDUCATION",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "152",
+              "title": "TECHNICAL COOPERATIVE EDUCATION",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "153",
+              "title": "TECHNICAL COOPERATIVE EDUCATION",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "154",
+              "title": "TECHNICAL COOPERATIVE EDUCATION",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Advanced Manufacturing Automation Option",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "104",
+              "title": "DIGITAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "108",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "MOTOR CONTROL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "196",
+              "title": "ADVANCED PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "139",
+              "title": "INTRO TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Advanced Manufacturing Industrial Maintenance Option",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "108",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "MOTOR CONTROL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "196",
+              "title": "ADVANCED PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "COMMERCIAL/INDUSTRIAL WIRING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Advanced Manufacturing Tool Technology Option",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "100",
+              "title": "MACHINING TECHNOLOGY I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "103",
+              "title": "MACHINING TECHNOLOGY II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "BASIC PRINT READING FOR MACHINISTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "INTRODUCTION TO METROLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "136",
+              "title": "MILLING OPERATIONS",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "139",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Advanced Manufacturing Welding Technology Option",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW FILLET/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "INDUSTRIAL BLUE PRINT READING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW FILLET/OFC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "SHIELDED METAL ARC WELDING GROOVE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "SHIELDED METAL ARC WELDING GROOVE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "218",
+              "title": "CERTIFICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "CERTIFICATION LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Manufacturing Skills Standard Council (MSSC) Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/advanced-manufacturing-technology/manufacturing-skills-standard-council-mssc-shortterm-certificate",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "292",
+              "title": "MSSC QUALITY PRACTICES AND MEASUREMENT COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "293",
+              "title": "MSSC MANUFACTURING PROCESSES AND PRODUCTION COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate In Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/air-conditioning-refrigeration-technology/associate-in-applied-science-degree",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "PRINCIPLES OF REFRIGERATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVAC/R SERVICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "REFRIGERATION PIPING PRACTICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "FUNDAMENTALS OF GAS HEATING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "PRINCIPLES OF ELECTRICITY FOR HVAC/R",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVAC/R ELECTRICAL CIRCUITS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVAC/R ELECTRICAL COMPONENTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "128",
+              "title": "HEAT LOAD CALCULATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "RESIDENTIAL AIR CONDITIONING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "135",
+              "title": "MECHANICAL/GAS/SAFETY CODES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "REFRIGERATION TRANSITION & RECOVERY THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "HEAT PUMPS SYSTEMS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "203",
+              "title": "COMMERCIAL REFRIGERATION",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Electives",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "120",
+              "title": "FUNDAMENTALS OF ELECTRIC HEATING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "126",
+              "title": "COMMERCIAL HEATING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "127",
+              "title": "HVAC/R ELECTRIC MOTORS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "133",
+              "title": "DOMESTIC REFRIGERATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "144",
+              "title": "BASIC DRAWING AND BLUEPRINT READING IN HVAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "153",
+              "title": "FUNDAMENTALS OF PROPANE SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "192",
+              "title": "HVAC Apprenticeship/Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "REVIEW FOR CONTRACTORS EXAM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "COMMERCIAL AIR CONDITIONING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "TROUBLESHOOTING HVAC/R SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER CORE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "134",
+              "title": "ICE MACHINES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Long-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/air-conditioning-refrigeration-technology/longterm-certificate",
+      "total_credits": 49,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "PRINCIPLES OF REFRIGERATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVAC/R SERVICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "REFRIGERATION PIPING PRACTICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "FUNDAMENTALS OF GAS HEATING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "PRINCIPLES OF ELECTRICITY FOR HVAC/R",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVAC/R ELECTRICAL CIRCUITS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVAC/R ELECTRICAL COMPONENTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "128",
+              "title": "HEAT LOAD CALCULATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "RESIDENTIAL AIR CONDITIONING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "REFRIGERATION TRANSITION & RECOVERY THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "HEAT PUMPS SYSTEMS I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "120",
+              "title": "FUNDAMENTALS OF ELECTRIC HEATING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "126",
+              "title": "COMMERCIAL HEATING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "127",
+              "title": "HVAC/R ELECTRIC MOTORS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "133",
+              "title": "DOMESTIC REFRIGERATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "134",
+              "title": "ICE MACHINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "144",
+              "title": "BASIC DRAWING AND BLUEPRINT READING IN HVAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "153",
+              "title": "FUNDAMENTALS OF PROPANE SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "192",
+              "title": "HVAC Apprenticeship/Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "REVIEW FOR CONTRACTORS EXAM",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "COMMERCIAL AIR CONDITIONING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "TROUBLESHOOTING HVAC/R SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER CORE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Automation Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/advanced-manufacturing-technology/advanced-manufacturing-automation-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "104",
+              "title": "DIGITAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "108",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "MOTOR CONTROL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "196",
+              "title": "ADVANCED PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "139",
+              "title": "INTRO TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Machine Tool Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/advanced-manufacturing-technology/advanced-manufacturing-machine-tool-technology-shortterm",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "100",
+              "title": "MACHINING TECHNOLOGY I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "103",
+              "title": "MACHINING TECHNOLOGY II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "BASIC PRINT READING FOR MACHINISTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "INTRODUCTION TO METROLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "136",
+              "title": "MILLING OPERATIONS",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "139",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate In Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/child-development/associate-in-applied-science-degree",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "GENERAL PSYCHOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "INTRODUCTION TO EARLY CARE AND EDUCATION OF CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "CHILD GROWTH AND DEVELOPMENT PRINCIPLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "202",
+              "title": "CHILDREN’S CREATIVE EXPERIENCES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "CHILDREN’S LITERATURE AND LANGUAGE DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "METHODS AND MATERIALS FOR TEACHING CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "PROGRAM PLANNING FOR EDUCATING YOUNG CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "CHILDREN’S HEALTH AND SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "ADMINISTRATION OF CHILD DEVELOPMENT PROGRAMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "INFANT AND TODDLER EDUCATION PROGRAMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "EDUCATING EXCEPTIONAL YOUNG CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "214",
+              "title": "FAMILIES AND COMMUNITIES IN EARLY CARE AND EDUCATION PROGRAMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "215",
+              "title": "SUPERVISED PRACTICAL EXPERIENCE IN EARLY CHILDHOOD EDUCATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "103",
+              "title": "FIRST AID-CPR and AED",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "217",
+              "title": "Math & Science for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Industrial Maintenance Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/advanced-manufacturing-technology/advanced-manufacturing-industrial-maintenance-shortterm",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "108",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "MOTOR CONTROL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "196",
+              "title": "ADVANCED PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "COMMERCIAL/INDUSTRIAL WIRING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/child-development/shortterm-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "INTRODUCTION TO EARLY CARE AND EDUCATION OF CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "CHILD GROWTH AND DEVELOPMENT PRINCIPLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "CHILDREN’S LITERATURE AND LANGUAGE DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "PROGRAM PLANNING FOR EDUCATING YOUNG CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "CHILDREN’S HEALTH AND SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "ADMINISTRATION OF CHILD DEVELOPMENT PROGRAMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "INFANT AND TODDLER EDUCATION PROGRAMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "EDUCATING EXCEPTIONAL YOUNG CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "214",
+              "title": "FAMILIES AND COMMUNITIES IN EARLY CARE AND EDUCATION PROGRAMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "217",
+              "title": "Math & Science for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate In Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/electrical-systems-technology/associate-in-applied-science-degree",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Requirements",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "108",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER CORE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "COMMERCIAL/INDUSTRIAL WIRING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "241",
+              "title": "NATIONAL ELECTRIC CODE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "INTRODUCTION TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "MOTOR CONTROL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "196",
+              "title": "ADVANCED PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "WIRING METHODS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CHOOSE TWO",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "PRINCIPLES OF INDUSTRIAL MAINTENANCE WELDING AND METAL CUTTING TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "219",
+              "title": "PLC Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "103",
+              "title": "SOLID STATE FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "104",
+              "title": "DIGITAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/electrical-systems-technology/electrical-shortterm-certificate",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "241",
+              "title": "NATIONAL ELECTRIC CODE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "WIRING METHODS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "COMMERCIAL/INDUSTRIAL WIRING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER CORE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automated Manufacturing Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/electrical-systems-technology/automated-manufacturing-shortterm-certificate",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "114",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "139",
+              "title": "INTRO TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "221",
+              "title": "ADVANCED PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER CORE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Plant Technician Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/electrical-systems-technology/industrial-plant-technician-shortterm-certificate",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "108",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "MOTOR CONTROL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER CORE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/electrical-systems-technology/electronics-shortterm-certificate",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "104",
+              "title": "DIGITAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "103",
+              "title": "SOLID STATE FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER CORE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Long-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/electrical-systems-technology/longterm-certificate",
+      "total_credits": 43,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies/ORI Courses",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "108",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "MOTOR CONTROL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER CORE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "196",
+              "title": "ADVANCED PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "WIRING METHODS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "241",
+              "title": "NATIONAL ELECTRIC CODE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "COMMERCIAL/INDUSTRIAL WIRING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Long-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/industrial-systems-technology/longterm-certificate",
+      "total_credits": 47,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": 46,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "103",
+              "title": "SOLID STATE FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "104",
+              "title": "DIGITAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "MATHEMATICAL APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "108",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "COMMERCIAL/INDUSTRIAL WIRING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "192",
+              "title": "PRACTICUM/INTERNSHIP/CO-OP",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "INTRODUCTION TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "219",
+              "title": "PLC Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate In Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/facility-maintenance-technician/associate-in-applied-science-degree",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electrical Systems Skills",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "COMMERCIAL/INDUSTRIAL WIRING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "108",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Welding Technology Skills",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW FILLET/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW FILLET/OFC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Machine Tool Skills",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "INTRODUCTION TO METROLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "147",
+              "title": "INTRODUCTION TO MACHINE SHOP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "139",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "112",
+              "title": "COMPUTER NUMERICAL CONTROL TURNING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Heating Ventilation & Air Conditioning Skills",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "FUNDAMENTALS OF GAS HEATING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVAC/R ELECTRICAL COMPONENTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "REFRIGERATION TRANSITION & RECOVERY THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "TROUBLESHOOTING HVAC/R SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate In Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/industrial-systems-technology/associate-in-applied-science-degree",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Concentration Courses",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "103",
+              "title": "SOLID STATE FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "104",
+              "title": "DIGITAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "108",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "COMMERCIAL/INDUSTRIAL WIRING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "192",
+              "title": "PRACTICUM/INTERNSHIP/CO-OP",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "MOTOR CONTROL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "110",
+              "title": "ADVANCED INDUSTRIAL PROCESS CONTROL TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "INTRODUCTION TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "196",
+              "title": "ADVANCED PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "219",
+              "title": "PLC Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "MATHEMATICAL APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/industrial-systems-technology/shortterm-certificate",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETC",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "102",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "103",
+              "title": "SOLID STATE FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "104",
+              "title": "DIGITAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY COURSE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate In Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/machine-tool-technology/associate-in-applied-science-degree",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Concentration Courses",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "BASIC PRINT READING FOR MACHINISTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "INTRODUCTION TO METROLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "270",
+              "title": "MACHINING SKILLS APPLICATION",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Numerical Control Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/machine-tool-technology/computer-numerical-control-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Field of Concentration Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "109",
+              "title": "ORIENTATION TO COMPUTER ASSISTED MANUFACTURING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "139",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "270",
+              "title": "MACHINING SKILLS APPLICATION",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Machining Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/machine-tool-technology/basic-machining-technology-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Field of Concentration Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "BASIC PRINT READING FOR MACHINISTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "INTRODUCTION TO METROLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/management-and-entrepreneurship/accounting-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "PRINCIPLES OF ACCOUNTING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "PRINCIPLES OF ACCOUNTING II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "PRINCIPLES OF MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "246",
+              "title": "OFFICE GRAPHICS AND PRESENTATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "246",
+              "title": "MICROCOMPUTER ACCOUNTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "PAYROLL ACCOUNTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "253",
+              "title": "INDIVIDUAL INCOME TAX",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/air-conditioning-refrigeration-technology/shortterm-certificate",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "PRINCIPLES OF REFRIGERATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVAC/R SERVICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "PRINCIPLES OF ELECTRICITY FOR HVAC/R",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVAC/R ELECTRICAL COMPONENTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "REFRIGERATION TRANSITION & RECOVERY THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "RESIDENTIAL AIR CONDITIONING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Essentials Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/management-and-entrepreneurship/business-essentials-shortterm-certificate",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "PRINCIPLES OF ACCOUNTING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "PRINCIPLES OF MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "HUMAN RESOURCE MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "PRINCIPLES OF MARKETING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Associate In Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/management-and-entrepreneurship/associate-in-applied-science-degree",
+      "total_credits": 88,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "PRINCIPLES OF MACROECONOMICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "PRINCIPLES OF MICROECONOMICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "THE LEGAL AND SOCIAL ENVIRONMENT OF BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "286",
+              "title": "COMPUTERIZED MANAGEMENT INFO SYSTEMS (EXCEL)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "266",
+              "title": "ENTREPRENEURIAL FINANCE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "267",
+              "title": "INNOVATIONS AND CREATIVITY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "223",
+              "title": "CUSTOMER SERVICE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Accounting Certificate",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "PRINCIPLES OF ACCOUNTING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "PRINCIPLES OF ACCOUNTING II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "PRINCIPLES OF MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "246",
+              "title": "OFFICE GRAPHICS AND PRESENTATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "246",
+              "title": "MICROCOMPUTER ACCOUNTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "PAYROLL ACCOUNTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "253",
+              "title": "INDIVIDUAL INCOME TAX",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Retail Management Certificate",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "175",
+              "title": "RETAILING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "189",
+              "title": "HUMAN RELATIONSHIPS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "PRINCIPLES OF ACCOUNTING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "246",
+              "title": "OFFICE GRAPHICS AND PRESENTATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "PRINCIPLES OF MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "HUMAN RESOURCE MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "PRINCIPLES OF MARKETING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Welding Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/advanced-manufacturing-technology/advanced-manufacturing-welding-shortterm-certificate",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW FILLET/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "INDUSTRIAL BLUE PRINT READING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW FILLET/OFC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "SHIELDED METAL ARC WELDING GROOVE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "SHIELDED METAL ARC WELDING GROOVE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "218",
+              "title": "CERTIFICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "CERTIFICATION LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Entrepreneurship Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/management-and-entrepreneurship/entrepreneurship-shortterm-certificate",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "266",
+              "title": "ENTREPRENEURIAL FINANCE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "267",
+              "title": "INNOVATIONS AND CREATIVITY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "279",
+              "title": "SMALL BUSINESS MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "PRINCIPLES OF MARKETING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Retail Management Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/management-and-entrepreneurship/retail-management-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "175",
+              "title": "RETAILING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "189",
+              "title": "HUMAN RELATIONSHIPS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "PRINCIPLES OF ACCOUNTING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "PRINCIPLES OF MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "HUMAN RESOURCE MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "PRINCIPLES OF MARKETING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "246",
+              "title": "OFFICE GRAPHICS AND PRESENTATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Medical Assisting Technology AAS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/medical-assisting-technology/medical-assisting-technology-aas",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "MAT First Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAT Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "GENERAL PSYCHOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "Clinical Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Medical Administrative Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "Clinical Specialties for Medical Assistants",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAT Third Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "CARDIOPULMONARY RESUSCITATION I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Medical Business Practices I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "125",
+              "title": "Laboratory Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "128",
+              "title": "Medical Law and Ethics for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAT Fourth Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Medical Laboratory Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "211",
+              "title": "Clinical Procedures II for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "216",
+              "title": "Pharmacology for the Medical Office",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAT Fifth Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "215",
+              "title": "Laboratory Procedures II for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "228",
+              "title": "Medical Assistant Review Course",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "229",
+              "title": "Medical Assisting Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "239",
+              "title": "Phlebotomy Preceptorship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting Technology STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/medical-assisting-technology/medical-assisting-technology-stc",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Medical Assisting Technology (MAT) - Short Term Certificate",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "CARDIOPULMONARY RESUSCITATION I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "125",
+              "title": "Laboratory Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "Clinical Specialties for Medical Assistants",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "215",
+              "title": "Laboratory Procedures II for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "239",
+              "title": "Phlebotomy Preceptorship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing Mobility: LPN & Paramedic to ADN",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/nursing/nursing-mobility-lpn-paramedic-to-adn",
+      "total_credits": 52,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester — Required Pre-Requisite Classes",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "HUMAN A & P I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "INTERMEDIATE COLLEGE ALGEBRA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "HUMAN A & P II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "HUMAN GROWTH AND DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "209",
+              "title": "CONCEPTS FOR HEALTHCARE TRANSITION STUDENTS",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "GENERAL MICROBIOLOGY",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "ADVANCED NURSING CONCEPTS",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "ADVANCED EVIDENCE BASED CLINICAL REASONING",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/nursing/nursing",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "HUMAN A & P I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "INTERMEDIATE COLLEGE ALGEBRA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "FUNDAMENTAL CONCEPTS OF NURSING",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "HUMAN A & P II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "HUMAN GROWTH AND DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "NURSING CONCEPTS I",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "NURSING CONCEPTS II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "EVIDENCE BASED CLINICAL REASONING",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "GENERAL MICROBIOLOGY",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "ADVANCED NURSING CONCEPTS",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "ADVANCED EVIDENCE BASED CLINICAL REASONING",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Associate In Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/office-administration-and-technology/associate-in-applied-science-degree",
+      "total_credits": 105,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Concentration Courses",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "PRINCIPLES OF ACCOUNTING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "266",
+              "title": "ENTREPRENEURIAL FINANCE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "286",
+              "title": "COMPUTERIZED MANAGEMENT INFO SYSTEMS (EXCEL)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "INTERMEDIATE KEYBOARDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "WORD PROCESSING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing (Word)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "133",
+              "title": "BUSINESS COMMUNICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "RECORDS/INFORMATION MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "232",
+              "title": "THE COMPUTERIZED OFFICE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "223",
+              "title": "CUSTOMER SERVICE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Office Administration Option (OFF)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "246",
+              "title": "MICROCOMPUTER ACCOUNTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "PAYROLL ACCOUNTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "THE LEGAL AND SOCIAL ENVIRONMENT OF BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "189",
+              "title": "HUMAN RELATIONSHIPS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "246",
+              "title": "OFFICE GRAPHICS AND PRESENTATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "FUNDAMENTALS OF ORAL COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Medical Office Administration Option (MOA)",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "189",
+              "title": "HUMAN RELATIONSHIPS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "211",
+              "title": "MEDICAL TERMINOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "214",
+              "title": "MEDICAL OFFICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "230",
+              "title": "Medical Coding Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "231",
+              "title": "Medical Coding Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "232",
+              "title": "Medical Coding Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "236",
+              "title": "Medical Coding Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Legal Office Administration Option (LOA)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "THE LEGAL AND SOCIAL ENVIRONMENT OF BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "201",
+              "title": "Legal Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "203",
+              "title": "LEGAL OFFICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "189",
+              "title": "HUMAN RELATIONSHIPS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "HUMAN RESOURCE MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Long-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/office-administration-and-technology/longterm-certificate",
+      "total_credits": 46,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MKT",
+              "number": "223",
+              "title": "CUSTOMER SERVICE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "286",
+              "title": "COMPUTERIZED MANAGEMENT INFO SYSTEMS (EXCEL)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "INTERMEDIATE KEYBOARDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "WORD PROCESSING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "RECORDS/INFORMATION MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "232",
+              "title": "THE COMPUTERIZED OFFICE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "246",
+              "title": "MICROCOMPUTER ACCOUNTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "PAYROLL ACCOUNTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "189",
+              "title": "HUMAN RELATIONSHIPS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "THE LEGAL AND SOCIAL ENVIRONMENT OF BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "HUMAN RESOURCE MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "266",
+              "title": "ENTREPRENEURIAL FINANCE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "200",
+              "title": "MACHINE TRANSCRIPTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "202",
+              "title": "LEGAL TRANSCRIPTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "203",
+              "title": "LEGAL OFFICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "211",
+              "title": "MEDICAL TERMINOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "212",
+              "title": "MEDICAL TRANSCRIPTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "214",
+              "title": "MEDICAL OFFICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "246",
+              "title": "OFFICE GRAPHICS AND PRESENTATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/office-administration-and-technology/medical-office-shortterm-certificate",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "INTERMEDIATE KEYBOARDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "WORD PROCESSING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "RECORDS/INFORMATION MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "211",
+              "title": "MEDICAL TERMINOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "230",
+              "title": "Medical Coding Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "231",
+              "title": "Medical Coding Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "232",
+              "title": "Medical Coding Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "236",
+              "title": "Medical Coding Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "189",
+              "title": "HUMAN RELATIONSHIPS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Administration Essentials",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/office-administration-and-technology/office-administration-essentials",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "286",
+              "title": "COMPUTERIZED MANAGEMENT INFO SYSTEMS (EXCEL)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "189",
+              "title": "HUMAN RELATIONSHIPS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "INTERMEDIATE KEYBOARDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "WORD PROCESSING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing (Word)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "RECORDS/INFORMATION MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "232",
+              "title": "THE COMPUTERIZED OFFICE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "246",
+              "title": "OFFICE GRAPHICS AND PRESENTATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "133",
+              "title": "BUSINESS COMMUNICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Office Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/office-administration-and-technology/legal-office-shortterm-certificate",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "INTERMEDIATE KEYBOARDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "WORD PROCESSING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "RECORDS/INFORMATION MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "189",
+              "title": "HUMAN RELATIONSHIPS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "THE LEGAL AND SOCIAL ENVIRONMENT OF BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "201",
+              "title": "Legal Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "203",
+              "title": "LEGAL OFFICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "HUMAN RESOURCE MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician (Basic) - Short Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/paramedic/emergency-medical-technician-basic-short-term-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Field of Concentration Courses - EMT",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "EMERGENCY MEDICAL TECHNICIAN",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "EMERGENCY MEDICAL TECHNICIAN CLINICAL",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician (Advanced) - Short Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/paramedic/emergency-medical-technician-advanced-short-term-certificate",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Field of Concentration Courses - Advanced EMT",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "ADVANCED EMERGENCY MEDICAL TECHNICIAN",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "ADVANCED EMERGENCY MEDICAL TECHNICIAN CLINICAL",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/paramedic/paramedic",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Studies Courses",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "MATHEMATICAL APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "PRINCIPLES OF BIOLOGY I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "GENERAL PSYCHOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Concentration Courses",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "EMERGENCY MEDICAL TECHNICIAN",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "EMERGENCY MEDICAL TECHNICIAN CLINICAL",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "ADVANCED EMERGENCY MEDICAL TECHNICIAN",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "ADVANCED EMERGENCY MEDICAL TECHNICIAN CLINICAL",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "PARAMEDIC CARDIOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "PARAMEDIC PATIENT ASSESSMENT",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "PARAMEDIC CLINICAL I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "PARAMEDIC MEDICAL EMERGENCIES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "PARAMEDIC TRAUMA MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "PARAMEDIC SPECIAL POPULATIONS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "PARAMEDIC CLINICAL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "PARAMEDIC TRANSITION TO THE WORKFORCE",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "ADVANCED COMPETENCIES FOR THE PARAMEDIC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "PARAMEDIC FIELD PRECEPTORSHIP",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "PARAMEDIC TEAM LEADERSHIP",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "PARAMEDIC APPLIED PHARMACOLOGY",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic Short Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/paramedic/paramedic-short-term-certificate",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Field of Concentration Courses",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "PARAMEDIC CARDIOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "PARAMEDIC PATIENT ASSESSMENT",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "PARAMEDIC CLINICAL I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "PARAMEDIC MEDICAL EMERGENCIES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "PARAMEDIC TRAUMA MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "PARAMEDIC SPECIAL POPULATIONS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "PARAMEDIC CLINICAL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "PARAMEDIC TRANSITION TO THE WORKFORCE",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "ADVANCED COMPETENCIES FOR THE PARAMEDIC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "PARAMEDIC FIELD PRECEPTORSHIP",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "PARAMEDIC TEAM LEADERSHIP",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "PARAMEDIC APPLIED PHARMACOLOGY",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Applied Science Degree - Barbering",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/salon-and-spa-management/associate-in-applied-science-degree-barbering",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "SALON MANAGEMENT TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "201",
+              "title": "ENTREPRENEURSHIP FOR SALON AND SPA MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "108",
+              "title": "INTRODUCTION TO BARBERING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "111",
+              "title": "INTRODUCTION TO BARBERING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "112",
+              "title": "SCIENCE OF BARBERING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "113",
+              "title": "FUNDAMENTALS OF BARBERING APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "143",
+              "title": "STATE BOARD REVIEW",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives - Choose 9 Courses (27 Credit Hours)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAR",
+              "number": "109",
+              "title": "BACTERIOLOGY AND SANITATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "110",
+              "title": "ORIENTATION TO BARBERING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "114",
+              "title": "BARBER-STYLING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "115",
+              "title": "CUTTING AND STYLING TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "120",
+              "title": "PROPERTIES OF CHEMISTRY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "121",
+              "title": "CHEMICAL HAIR PROCESSING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "122",
+              "title": "HAIR COLORING CHEMISTRY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "124",
+              "title": "HAIR COLORING METHODOLOGY LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "130",
+              "title": "MARKETING AND BUSINESS MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "132",
+              "title": "STYLING AND DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "133",
+              "title": "STYLING AND MANAGEMENT LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "140",
+              "title": "PRACTICUM I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate In Applied Science Degree - Instructor Training",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/salon-and-spa-management/associate-in-applied-science-degree-instructor-training",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "SALON MANAGEMENT TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "201",
+              "title": "ENTREPRENEURSHIP FOR SALON AND SPA MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "211",
+              "title": "TEACHING AND CURRICULUM DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "212",
+              "title": "TEACHER MENTORSHIP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "213",
+              "title": "COSMETOLOGY INSTRUCTOR CO-OP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "214",
+              "title": "LESSON PLAN METHODS AND DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "221",
+              "title": "LESSON PLAN IMPLEMENTATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "222",
+              "title": "AUDIO VISUAL MATERIALS AND METHODS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "223",
+              "title": "AUDIO VISUAL MATERIALS AND METHODS APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "125",
+              "title": "CAREER AND PERSONAL DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "133",
+              "title": "Salon Management Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "158",
+              "title": "EMPLOYABILITY SKILLS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "190",
+              "title": "INTERNSHIP IN COSMETOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "103",
+              "title": "FIRST AID-CPR and AED",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Applied Science Degree - Salon and Spa Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/salon-and-spa-management/associate-in-applied-science-degree-salon-and-spa-management",
+      "total_credits": 118,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "SALON MANAGEMENT TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "201",
+              "title": "ENTREPRENEURSHIP FOR SALON AND SPA MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "INTRODUCTION TO COSMETOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "BASIC SPA TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "BASIC SPA TECHNIQUES LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "119",
+              "title": "BUSINESS OF COSMETOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "125",
+              "title": "CAREER AND PERSONAL DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Cosmetology Option (COS)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "INTRODUCTION TO COSMETOLOGY LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "THEORY OF CHEMICAL SERVICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "CHEMICAL SERVICES LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "HAIR COLORING THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "HAIR COLORING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "123",
+              "title": "COSMETOLOGY SALON PRACTICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "137",
+              "title": "HAIR SHAPING AND DESIGN THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Esthetics Option (EST)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "127",
+              "title": "ESTHETICS THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "134",
+              "title": "ADVANCED ESTHETICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "135",
+              "title": "ADVANCED ESTHETICS APPLICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "163",
+              "title": "FACIAL TREATMENTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "164",
+              "title": "FACIAL MACHINE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "166",
+              "title": "SKIN CARE BACTERIOLOGY AND SANITATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "169",
+              "title": "SKIN FUNCTIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Nail Technology Option (NLT)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "150",
+              "title": "Manicuring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "148",
+              "title": "NAIL CARE THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "149",
+              "title": "NAIL ART THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "152",
+              "title": "NAIL CARE APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "153",
+              "title": "NAIL ART",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "154",
+              "title": "NAIL ART APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "158",
+              "title": "EMPLOYABILITY SKILLS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Cosmetology Short Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/salon-and-spa-management/cosmetology-short-term-certificate",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "INTRODUCTION TO COSMETOLOGY LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "THEORY OF CHEMICAL SERVICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "CHEMICAL SERVICES LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "HAIR COLORING THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "HAIR COLORING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "137",
+              "title": "HAIR SHAPING AND DESIGN THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "145",
+              "title": "HAIR SHAPING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CHOOSE ONE",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "190",
+              "title": "INTERNSHIP IN COSMETOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "191",
+              "title": "CO-OP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "123",
+              "title": "COSMETOLOGY SALON PRACTICES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Long-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/machine-tool-technology/longterm-certificate",
+      "total_credits": 52,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Concentration Courses",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "BASIC PRINT READING FOR MACHINISTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "INTRODUCTION TO METROLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "270",
+              "title": "MACHINING SKILLS APPLICATION",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/surgical-technology/surgical-technology",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Field of Concentration Courses",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "107",
+              "title": "SURGICAL ANATOMY & PHYSIOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "100",
+              "title": "PRINCIPLES OF SURGICAL TECHNOLOGY",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "102",
+              "title": "APPLIED SURGICAL TECHNIQUES",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "103",
+              "title": "SURGICAL PROCEDURES",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "104",
+              "title": "SURGICAL PRACTICUM I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "105",
+              "title": "SURGICAL PRACTICUM II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "106",
+              "title": "ROLE TRANSITION IN SURGICAL TECHNOLOGY",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "208",
+              "title": "SPECIAL TOPICS IN SURGICAL TECHNOLOGY",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sterile Processing Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/surgical-technology/sterile-processing-technology",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Sterile Processing Technology - Short Term Certificate",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "HUMAN A & P I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "HUMAN A & P II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "150",
+              "title": "Central Sterile I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "151",
+              "title": "Central Sterile II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "152",
+              "title": "Central Sterile Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "App Development with Swift Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/systems-information-technology/app-development-with-swift-shortterm-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "The App Development with Swift Short-Term Certificate Program will provide students with the knowledge, fundamentals, and skills needed to develop apps for various types of Apple products using the Swift programming language. Students will learn how to build simple workflows and navigation hierarchies; write strings, functions, structures, collections, and loops to create programming code; design and create apps using the Xcode development environment to build and run projects using its iOS simulator; design and create graphics for app design; and design and architect projects for their own design. The curriculum was designed by Apple for students with no prior programming experience and is appropriate for students from many majors.",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "157",
+              "title": "Introduction to App Development with Swift",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "220",
+              "title": "App Development with Swift I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "227",
+              "title": "App Development with Swift II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/systems-information-technology/associate-in-applied-science-degree",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Requirements",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "ADVANCED MICRO APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "150",
+              "title": "INTRODUCTION TO COMPUTER LOGIC AND PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "161",
+              "title": "INTRODUCTION TO NETWORK COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "182",
+              "title": "Help Desk Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "INTRODUCTION TO WEB DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "CYBER DEFENSE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "246",
+              "title": "ETHICAL HACKING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "268",
+              "title": "SOFTWARE SUPPORT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "269",
+              "title": "HARDWARE SUPPORT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "282",
+              "title": "COMPUTER FORENSICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "222",
+              "title": "DATABASE MANAGEMENT SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "286",
+              "title": "COMPUTERIZED MANAGEMENT INFO SYSTEMS (EXCEL)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "284",
+              "title": "CIS INTERNSHIP",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nail Technology Short Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/salon-and-spa-management/nail-technology-short-term-certificate",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "150",
+              "title": "Manicuring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "148",
+              "title": "NAIL CARE THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "149",
+              "title": "NAIL ART THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "152",
+              "title": "NAIL CARE APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "153",
+              "title": "NAIL ART",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "154",
+              "title": "NAIL ART APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "158",
+              "title": "EMPLOYABILITY SKILLS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "151",
+              "title": "Nail Care",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CHOOSE ONE",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "166",
+              "title": "SKIN CARE BACTERIOLOGY AND SANITATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "190",
+              "title": "INTERNSHIP IN COSMETOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "191",
+              "title": "CO-OP",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/paramedic/emergency-medical-technician",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "EMERGENCY MEDICAL TECHNICIAN",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "EMERGENCY MEDICAL TECHNICIAN CLINICAL",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Security Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/systems-information-technology/cyber-security-shortterm-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "CYBER DEFENSE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "246",
+              "title": "ETHICAL HACKING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following electives:",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "282",
+              "title": "COMPUTER FORENSICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Programming Support Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/systems-information-technology/programming-support-shortterm-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "150",
+              "title": "INTRODUCTION TO COMPUTER LOGIC AND PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "INTRODUCTION TO WEB DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Support Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/systems-information-technology/network-support-shortterm-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "161",
+              "title": "INTRODUCTION TO NETWORK COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "182",
+              "title": "Help Desk Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer User Support Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/systems-information-technology/computer-user-support-shortterm-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "268",
+              "title": "SOFTWARE SUPPORT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "269",
+              "title": "HARDWARE SUPPORT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Windows Support Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/systems-information-technology/windows-support-shortterm-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "ADVANCED MICRO APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following electives:",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "222",
+              "title": "DATABASE MANAGEMENT SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "286",
+              "title": "COMPUTERIZED MANAGEMENT INFO SYSTEMS (EXCEL)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/truck-driver-training/shortterm-certificate",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRK",
+              "number": "111",
+              "title": "BASIC VEHICLE OPERATION",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRK",
+              "number": "112",
+              "title": "SAFE OPERATING PRACTICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRK",
+              "number": "113",
+              "title": "NON-VEHICLE ACTIVITIES",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing Mobility: Military Medic to Practical Nursing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/paramedic/nursing-mobility-military-medic-to-practical-nursing",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "HUMAN A & P I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "HUMAN A & P II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "INTERMEDIATE COLLEGE ALGEBRA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "HUMAN GROWTH AND DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "120",
+              "title": "Healthcare Transistion",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "EVIDENCE BASED CLINICAL REASONING",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Urban Forestry Technician Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/urban-forestry-technician/urban-forestry-technician-shortterm-certificate",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FOR",
+              "number": "195",
+              "title": "Utility Vegetation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FOR",
+              "number": "197",
+              "title": "Urban Forestry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FOR",
+              "number": "198",
+              "title": "Integrated Pest Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FOR",
+              "number": "199",
+              "title": "Equipment Use and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/vehicle-technology-and-repair/associate-in-applied-science-degree",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VTR",
+              "number": "112",
+              "title": "ELECTRICAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTR",
+              "number": "133",
+              "title": "HEATING AND AIR CONDITIONING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "DIESEL TECHNICIAN OPTION (VT3)",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "104",
+              "title": "BASIC ENGINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "105",
+              "title": "PREVENTIVE MAINTENANCE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "111",
+              "title": "EQUIPMENT SAFETY AND MECHANICAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "117",
+              "title": "DIESEL AND GAS TUNE-UP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "122",
+              "title": "HEAVY VEHICLE BRAKES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "123",
+              "title": "PNEUMATIC AND HYDRAULICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "124",
+              "title": "ELECTRONIC ENGINE SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "125",
+              "title": "HEAVY VEHICLE DRIVE TRAINS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "126",
+              "title": "ADVANCED ENGINE ANALYSIS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "127",
+              "title": "FUEL SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "134",
+              "title": "COMPUTER CONTROLLED ENGINE AND POWER TRAIN SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "135",
+              "title": "HEAVY VEHICLE STEERING AND SUSPENSION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "180",
+              "title": "SPECIAL PROJECTS IN COMMERCIAL VEHICLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "191",
+              "title": "Special Projects in Diesel Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Long-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/vehicle-technology-and-repair/longterm-certificate",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Studies Courses",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VTR",
+              "number": "112",
+              "title": "ELECTRICAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTR",
+              "number": "133",
+              "title": "HEATING AND AIR CONDITIONING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "DIESEL TECHNICIAN OPTION (VT3)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "104",
+              "title": "BASIC ENGINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "105",
+              "title": "PREVENTIVE MAINTENANCE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "111",
+              "title": "EQUIPMENT SAFETY AND MECHANICAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "117",
+              "title": "DIESEL AND GAS TUNE-UP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "122",
+              "title": "HEAVY VEHICLE BRAKES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "123",
+              "title": "PNEUMATIC AND HYDRAULICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "124",
+              "title": "ELECTRONIC ENGINE SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "125",
+              "title": "HEAVY VEHICLE DRIVE TRAINS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "126",
+              "title": "ADVANCED ENGINE ANALYSIS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "127",
+              "title": "FUEL SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "134",
+              "title": "COMPUTER CONTROLLED ENGINE AND POWER TRAIN SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "180",
+              "title": "SPECIAL PROJECTS IN COMMERCIAL VEHICLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "191",
+              "title": "Special Projects in Diesel Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/vehicle-technology-and-repair/shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AUTOMOTIVE SERVICE EXCELLENCE OPTION (V12)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VTR",
+              "number": "112",
+              "title": "ELECTRICAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTR",
+              "number": "133",
+              "title": "HEATING AND AIR CONDITIONING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "DIESEL TECHNICIAN OPTION (V3D)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VTR",
+              "number": "112",
+              "title": "ELECTRICAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VTR",
+              "number": "133",
+              "title": "HEATING AND AIR CONDITIONING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/welding-technology/associate-in-applied-science-degree",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW FILLET/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW FILLET/PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "SHIELDED METAL ARC WELDING GROOVE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW FILLET/OFC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW FILLET/PAC/CAC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "SHIELDED METAL ARC WELDING GROOVE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "157",
+              "title": "CONSUMABLE WELDING PROCESSES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "218",
+              "title": "CERTIFICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "229",
+              "title": "BOILER TUBE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW CARBON PIPE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "CERTIFICATION LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "INDUSTRIAL BLUE PRINT READING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "104",
+              "title": "BASIC COMPUTER AIDED DRAFTING AND DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER CORE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "221",
+              "title": "PIPEFITTING AND FABRICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "160",
+              "title": "ROBOTICS LAB I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "INTRODUCTION TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Esthetics Short Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/salon-and-spa-management/esthetics-short-term-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "127",
+              "title": "ESTHETICS THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "134",
+              "title": "ADVANCED ESTHETICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "135",
+              "title": "ADVANCED ESTHETICS APPLICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "163",
+              "title": "FACIAL TREATMENTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "164",
+              "title": "FACIAL MACHINE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "166",
+              "title": "SKIN CARE BACTERIOLOGY AND SANITATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "169",
+              "title": "SKIN FUNCTIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CHOOSE ONE",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "165",
+              "title": "RELATED SUBJECTS ESTHETICIANS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "190",
+              "title": "INTERNSHIP IN COSMETOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "191",
+              "title": "CO-OP",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "GMAW/FCAW Welding Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/welding-technology/gmawfcaw-welding-shortterm-certificate",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "SHIELDED METAL ARC WELDING GROOVE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "SHIELDED METAL ARC WELDING GROOVE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "157",
+              "title": "CONSUMABLE WELDING PROCESSES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Long-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/welding-technology/longterm-certificate",
+      "total_credits": 49,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "INDUSTRIAL BLUE PRINT READING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW FILLET/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW FILLET/PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "SHIELDED METAL ARC WELDING GROOVE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW FILLET/OFC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW FILLET/PAC/CAC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "SHIELDED METAL ARC WELDING GROOVE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "157",
+              "title": "CONSUMABLE WELDING PROCESSES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "218",
+              "title": "CERTIFICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "229",
+              "title": "BOILER TUBE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW CARBON PIPE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "CERTIFICATION LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pipe Welding Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/welding-technology/pipe-welding-shortterm-certificate",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "218",
+              "title": "CERTIFICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "229",
+              "title": "BOILER TUBE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW CARBON PIPE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "CERTIFICATION LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Fitting Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/welding-technology/fitting-shortterm-certificate",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PFT",
+              "number": "101",
+              "title": "Introduction to Pipefitting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PFT",
+              "number": "105",
+              "title": "Introduction to Pipefitting Blueprints",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PFT",
+              "number": "107",
+              "title": "Threaded Pipe and Socket Weld Pipe Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PFT",
+              "number": "109",
+              "title": "Butt Weld Pipe Fitting and Pipe Rigging",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding for Fitting Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/welding-technology/welding-for-fitting-shortterm-certificate",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW FILLET/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW FILLET/PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "INDUSTRIAL BLUE PRINT READING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "SMAW Welding Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.bscc.edu/welding-technology/smaw-welding-technology-shortterm-certificate",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Orientation",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "STUDENT SURVIVAL SKILLS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Field of Study Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW FILLET/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW FILLET/PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW FILLET/OFC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW FILLET/PAC/CAC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/al/programs/chattahoochee-valley-community-college.json
+++ b/data/al/programs/chattahoochee-valley-community-college.json
@@ -1,0 +1,1195 @@
+{
+  "college_slug": "chattahoochee-valley-community-college",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.cv.edu/degrees",
+  "scraped_at": "2026-06-03T21:27:14.099Z",
+  "programs": [
+    {
+      "title": "Applied Technology Air Conditioning and Refrigeration (HVAC) Option",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.cv.edu/air-conditioning-refrigeration-technology/certificate/applied-technology-air-conditioning-and",
+      "total_credits": 43,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Air Conditioning and Refrigeration Courses",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "102",
+              "title": "Computer-Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVAC/R",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "183",
+              "title": "Special Topics in Air Conditioning and Refrigeration",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "203",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Certificate Requirements",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "105",
+              "title": "Orientation and Student Success",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Technology: Industrial Maintenance Option",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.cv.edu/industrial-maintenance-technology/certificate/applied-technology-industrial-maintenance-option",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Industrial Maintenance Courses",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "102",
+              "title": "Computer-Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "Introduction to Programmable Logic Controllers (PLCs)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Certificate Requirements",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "105",
+              "title": "Orientation and Student Success",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.cv.edu/fire-science/certificate/fire-science",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Technical Core, Technical Concentration Electives",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "105",
+              "title": "Orientation and Student Success",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "101",
+              "title": "Introduction to the Fire Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "110",
+              "title": "Building Construction Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "130",
+              "title": "Introduction to Fire Suppression",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "151",
+              "title": "Introduction to Fire Prevention/Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "295",
+              "title": "Fire Department Safety Officer",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.cv.edu/criminal-justice/certificate/criminal-justice",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required General Education Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Criminal Justice Courses",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "Cardiopulmonary Resuscitation I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "104",
+              "title": "First Aid for Students of Health Related Professions",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Certificate Requirements",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "105",
+              "title": "Orientation and Student Success",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Applied Technology: Automotive Manufacturing Option",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.cv.edu/automotive-manufacturing-technology/certificate/applied-technology-automotive-manufacturing-option",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Automotive Manufacturing Courses",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "102",
+              "title": "Computer-Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "Introduction to Programmable Logic Controllers (PLCs)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "288",
+              "title": "Applied Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Certificate Requirements",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "105",
+              "title": "Orientation and Student Success",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Kinesiology-Exercise Science",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.cv.edu/kinesiology/certificate/kinesiology-exercise-science",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "The Short Certificate in Kinesiology-Exercise Science is designed for individuals seeking foundational knowledge and skills in the field of exercise science. This program provides a concise yet comprehensive introduction to the principles of kinesiology, preparing students for entry-level positions in fitness and wellness or further studies in related fields.",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "105",
+              "title": "Orientation and Student Success",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "226",
+              "title": "Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "First Aid",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "224",
+              "title": "Principles of Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "232",
+              "title": "Care and Prevention of Athletic Injuries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "223",
+              "title": "Methods of Instruction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "105",
+              "title": "Personal Fitness",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.cv.edu/medical-assisting/certificate/medical-assisting",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "Cardiopulmonary Resuscitation I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "102",
+              "title": "Medical Assisting Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Medical Assisting Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "Clinical Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Medical Administrative Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Medical Administrative Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "211",
+              "title": "Clinical Procedures II for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "216",
+              "title": "Medical Pharmacology for the Medical Office",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "228R",
+              "title": "Medical Assistant CCMA Review Course",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "229",
+              "title": "Medical Assisting Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.cv.edu/nursing/certificate/practical-nursing",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required General Education Courses",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Nursing Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Fundamental Concepts of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Nursing Concepts I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Nursing Concepts II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "Evidence-Based Clinical Reasoning",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Medical Assisting: EKG Technician Option",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.cv.edu/medical-assisting/certificate/medical-assisting-ekg-technician-option",
+      "total_credits": 7,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "105",
+              "title": "Orientation and Student Success",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "218",
+              "title": "EKG Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "228E",
+              "title": "Medical Assistant CET Review Course",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Wellness and Personal Trainer",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.cv.edu/wellness-and-personal-trainer/certificate/wellness-and-personal-trainer",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PED",
+              "number": "224",
+              "title": "Principles of Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "100",
+              "title": "Fundamentals of Fitness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "221",
+              "title": "Personal Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "222",
+              "title": "Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "First Aid",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "223",
+              "title": "Methods of Instruction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Technology: Welding Option",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.cv.edu/welding/certificate/applied-technology-welding-option",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Preprofessional, Major and Elective Courses",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW/Fillet OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "SMAW Groove",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW Fillet/OFC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "Shielding Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "217",
+              "title": "SMAW Carbon Pipe Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "228",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Degree Requirements",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "105",
+              "title": "Orientation and Student Success",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Emergency Medical Services Paramedic",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.cv.edu/emergency-medical-technology-technician/certificate/emergency-medical-services-paramedic",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "105",
+              "title": "Orientation and Student Success",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required EMS Courses",
+          "credits_required": 50,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "Cardiopulmonary Resuscitation I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "107",
+              "title": "Emergency Vehicle Operator Ambulance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "Advanced Emergency Medical Technician Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Cardiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic Patient Assessment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic Clinical I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "Paramedic Medical Emergencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Trauma Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "Paramedic Special Populations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "Paramedic Transition to the Workforce",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Advanced Competencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "Paramedic Field Preceptorship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "Paramedic Team Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "Paramedic Applied Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/al/programs/gadsden-state-community-college.json
+++ b/data/al/programs/gadsden-state-community-college.json
@@ -1,0 +1,13498 @@
+{
+  "college_slug": "gadsden-state-community-college",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.gadsdenstate.edu/degrees",
+  "scraped_at": "2026-06-03T21:27:19.867Z",
+  "programs": [
+    {
+      "title": "Accounting Specialist Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/accounting-technology/accounting-specialist-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Professional, Major and Elective Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "246",
+              "title": "Microcomputer Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "253",
+              "title": "Individual Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "Advanced Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Auto Collision Repair Technology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/auto-collision-repair/auto-collision-repair-technology-certificate",
+      "total_credits": 81,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V - Technical Courses",
+          "credits_required": 81,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ABR",
+              "number": "111",
+              "title": "Non-Structural Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "114",
+              "title": "Non-Structural Panel Replacement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "122",
+              "title": "Surface Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "123",
+              "title": "Paint Application and Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "151",
+              "title": "Safety and Environmental Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "154",
+              "title": "Automotive Glass and Trim",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "156",
+              "title": "Automotive Cutting and Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "157",
+              "title": "Automotive Plastic Repairs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "181",
+              "title": "Special Topics in Auto Body",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "182",
+              "title": "Special Topics in Auto Body",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "183",
+              "title": "Special Topics in Auto Body",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "213",
+              "title": "Automotive Structural Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "214",
+              "title": "Automotive Structural Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "223",
+              "title": "Automotive Mechanical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "224",
+              "title": "Automotive Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "255",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "258",
+              "title": "Heating and AC in Collision Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "261",
+              "title": "Restraint Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "265",
+              "title": "Paint Defects and Final Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "267",
+              "title": "Shop Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "269",
+              "title": "Estimating and Damage Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "281",
+              "title": "Special Topics in Auto Body",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "291A",
+              "title": "Auto Body Repair Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "291B",
+              "title": "Auto Body Repair Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "291C",
+              "title": "Auto Body Repair Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "292",
+              "title": "Auto Body Repair Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "293",
+              "title": "Auto Body Repair Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Technology A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/accounting-technology/accounting-technology-aas",
+      "total_credits": 58,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV — History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V — Pre-Professional, Pre-Major and Electives",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "246",
+              "title": "Microcomputer Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "253",
+              "title": "Individual Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "256",
+              "title": "Cost Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "146",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "Advanced Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "279",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "243",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Air Conditioning and Refrigeration A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/air-conditioning-and-refrigeration/air-conditioning-and-refrigeration-aas",
+      "total_credits": 161,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVACR Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVAC/R Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Introduction to Engineering Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 129,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "120",
+              "title": "Fundamentals of Electric Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "125",
+              "title": "Fundamentals of Gas and Electrical Heating Systems",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "126",
+              "title": "Commercial Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "127",
+              "title": "HVACR Electric Motors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "128",
+              "title": "Heat Load Calculations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Computer Assisted HVAC Troubleshooting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "133",
+              "title": "Domestic Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "134",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "135",
+              "title": "Mechanical/Gas/Safety Codes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "138",
+              "title": "Customer Relation in HVAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "144",
+              "title": "Basic Drawing and Blueprint Reading in HVAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigerant Transition and Recovery Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "149",
+              "title": "Heat Pump Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "150",
+              "title": "Basic Sheet Metal Processes",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "151",
+              "title": "Duct Design and Fabrication",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "152",
+              "title": "Heat Pump Systems",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "181",
+              "title": "Special Topics in ACR I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "182",
+              "title": "Special Topics in ACR II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "183",
+              "title": "Special Topics in ACR",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "184",
+              "title": "Special Topics In ACR",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "185",
+              "title": "Special Topics in ACR",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "186",
+              "title": "Special Topics in ACR",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "192",
+              "title": "HVAC Apprenticeship/Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "193A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "193B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "193C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "194",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "195",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Review for Contractors Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "202",
+              "title": "Special Refrigeration Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "203",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "205",
+              "title": "System Sizing and Air Distribution",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Commercial Air Conditioning Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Troubleshooting HVACR Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "211",
+              "title": "Building Automation and Engineering I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "212",
+              "title": "Building Automation and Engineering II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning and Refrigeration Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/air-conditioning-and-refrigeration/air-conditioning-and-refrigeration-shortterm-certificate",
+      "total_credits": 41,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V — Required courses",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVACR Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVAC/R Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Additional Coursework",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "120",
+              "title": "Fundamentals of Electric Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "128",
+              "title": "Heat Load Calculations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigerant Transition and Recovery Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Review for Contractors Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Troubleshooting HVACR Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning and Refrigeration Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/air-conditioning-and-refrigeration/air-conditioning-and-refrigeration-certificate",
+      "total_credits": 152,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVACR Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVAC/R Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 129,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "120",
+              "title": "Fundamentals of Electric Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "125",
+              "title": "Fundamentals of Gas and Electrical Heating Systems",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "126",
+              "title": "Commercial Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "127",
+              "title": "HVACR Electric Motors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "128",
+              "title": "Heat Load Calculations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "130",
+              "title": "Computer Assisted HVAC Troubleshooting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "133",
+              "title": "Domestic Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "134",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "135",
+              "title": "Mechanical/Gas/Safety Codes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "138",
+              "title": "Customer Relation in HVAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "144",
+              "title": "Basic Drawing and Blueprint Reading in HVAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigerant Transition and Recovery Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "149",
+              "title": "Heat Pump Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "150",
+              "title": "Basic Sheet Metal Processes",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "151",
+              "title": "Duct Design and Fabrication",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "152",
+              "title": "Heat Pump Systems",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "181",
+              "title": "Special Topics in ACR I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "182",
+              "title": "Special Topics in ACR II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "183",
+              "title": "Special Topics in ACR",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "184",
+              "title": "Special Topics In ACR",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "185",
+              "title": "Special Topics in ACR",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "186",
+              "title": "Special Topics in ACR",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "192",
+              "title": "HVAC Apprenticeship/Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "193A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "193B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "193C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "194",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "195",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Review for Contractors Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "202",
+              "title": "Special Refrigeration Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "203",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "205",
+              "title": "System Sizing and Air Distribution",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Commercial Air Conditioning Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Troubleshooting HVACR Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "211",
+              "title": "Building Automation and Engineering I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "212",
+              "title": "Building Automation and Engineering II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Auto Collision Repair Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/auto-collision-repair/auto-collision-repair-technology-shortterm-certificate",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Technical Courses",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ABR",
+              "number": "111",
+              "title": "Non-Structural Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "114",
+              "title": "Non-Structural Panel Replacement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "122",
+              "title": "Surface Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "123",
+              "title": "Paint Application and Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "151",
+              "title": "Safety and Environmental Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "154",
+              "title": "Automotive Glass and Trim",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "157",
+              "title": "Automotive Plastic Repairs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABR",
+              "number": "265",
+              "title": "Paint Defects and Final Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Manufacturing Technology A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/automotive-manufacturing-technology/automotive-manufacturing-technology-aas",
+      "total_credits": 107,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Introduction to Automotive Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "102",
+              "title": "Lean Manufacturing and Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "104",
+              "title": "Blueprint Reading for Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "114",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "118",
+              "title": "Introduction to Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "106",
+              "title": "Quality Control and Inspection Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "116",
+              "title": "Introduction to Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "121",
+              "title": "Elements of Industrial Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "122",
+              "title": "Elements of Industrial Control Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "138",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Industrial Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "150",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "151",
+              "title": "Introduction to Machine Shop I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "155",
+              "title": "Metrology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "186",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "193",
+              "title": "Special Topics (Electrical/Electronic)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "194",
+              "title": "Special Topics (Electrical/Electronic)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "221",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "230",
+              "title": "Preventive and Predictive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "234",
+              "title": "Industrial Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "262",
+              "title": "Computer Integrated Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291A",
+              "title": "Automotive Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291B",
+              "title": "Automotive Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291C",
+              "title": "Automotive Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "292",
+              "title": "Automotive Cooperative Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "293",
+              "title": "Automotive Cooperative Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "180",
+              "title": "Special Topics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Manufacturing Technology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/automotive-manufacturing-technology/automotive-manufacturing-technology-certificate",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V Required Technical Courses",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Introduction to Automotive Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "102",
+              "title": "Lean Manufacturing and Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "104",
+              "title": "Blueprint Reading for Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "114",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "150",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "118",
+              "title": "Introduction to Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "138",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "155",
+              "title": "Metrology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "234",
+              "title": "Industrial Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291A",
+              "title": "Automotive Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291B",
+              "title": "Automotive Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "291C",
+              "title": "Automotive Cooperative Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "180",
+              "title": "Special Topics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Manufacturing Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/automotive-manufacturing-technology/automotive-manufacturing-technology-shortterm-certificate",
+      "total_credits": 43,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Technical Courses",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Introduction to Automotive Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "102",
+              "title": "Lean Manufacturing and Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "104",
+              "title": "Blueprint Reading for Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "114",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "121",
+              "title": "Elements of Industrial Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "122",
+              "title": "Elements of Industrial Control Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "130",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "138",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "150",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "234",
+              "title": "Industrial Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Service Technology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/automotive-service-technology/automotive-service-technology-certificate",
+      "total_credits": 81,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "101",
+              "title": "Fundamentals of Automotive Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "121",
+              "title": "Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "122",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "124",
+              "title": "Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "130",
+              "title": "Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "162",
+              "title": "Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "230",
+              "title": "Auto Transmission and Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "239",
+              "title": "Engine Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "244",
+              "title": "Engine Performance and Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "127",
+              "title": "Car Braking, Steering, and Suspensions Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "133",
+              "title": "Motor Vehicle Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "171A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "171B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "171C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "173",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "181",
+              "title": "Special Topics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "182",
+              "title": "Special Topics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "183",
+              "title": "Special Topics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "191",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "212",
+              "title": "Advanced Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "220",
+              "title": "Advanced Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "224",
+              "title": "Man Transmission and Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "235",
+              "title": "Transmissions and Transaxles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "246",
+              "title": "Automotive Emissions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "248",
+              "title": "Engine Performance Diagnostics and Emissions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "271",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "273",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "281",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "291",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Service Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/automotive-service-technology/automotive-service-technology-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Technical Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "101",
+              "title": "Fundamentals of Automotive Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "121",
+              "title": "Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "122",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "124",
+              "title": "Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "130",
+              "title": "Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "182",
+              "title": "Special Topics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "220",
+              "title": "Advanced Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Child Development A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/child-development/child-development-aas",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV — History, Social and Behavioral Sciences",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major and Electives",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "Child Growth and Development Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "202",
+              "title": "Children's Creative Experiences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children's Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children's Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "Administration of Child Development Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "Infant and Toddler Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Educating Exceptional Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "214",
+              "title": "Families and Communities in Early Care and Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "215",
+              "title": "Supervised Practical Experience in Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "217",
+              "title": "Math and Science for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HED",
+              "number": "224",
+              "title": "Personal and Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Introductory Spanish I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "102",
+              "title": "Introductory Spanish II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Child Development Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/child-development/child-development-shortterm-certificate",
+      "total_credits": 38,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V — Required Courses",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "Child Growth and Development Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "215",
+              "title": "Supervised Practical Experience in Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "202",
+              "title": "Children's Creative Experiences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children's Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children's Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "Administration of Child Development Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "Infant and Toddler Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Educating Exceptional Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "214",
+              "title": "Families and Communities in Early Care and Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "217",
+              "title": "Math and Science for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Civil Engineering Technology A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/civil-engineering/civil-engineering-technology-aas",
+      "total_credits": 86,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "100",
+              "title": "Engineering Blueprints",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "101",
+              "title": "Introduction to Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "215",
+              "title": "Statics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "217",
+              "title": "Strength of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "146",
+              "title": "AutoCAD CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "147",
+              "title": "Inventor CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "111",
+              "title": "Fundamentals of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "112",
+              "title": "Intermediate Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "131",
+              "title": "Highway Design and Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "214",
+              "title": "Hydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "105",
+              "title": "Introduction to Microstation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "121",
+              "title": "Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "213",
+              "title": "Topographical Surveying and Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "216",
+              "title": "Advanced Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "221",
+              "title": "Construction Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "222",
+              "title": "Residential Land Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "223",
+              "title": "Site Planning and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "240",
+              "title": "Geographic Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "281A",
+              "title": "Special Topics in Civil Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "281B",
+              "title": "Special Topics in Civil Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "122",
+              "title": "Architectural Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/civil-engineering/civil-engineering-technology-shortterm-certificate",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V — Required Courses",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "100",
+              "title": "Engineering Blueprints",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "101",
+              "title": "Introduction to Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "111",
+              "title": "Fundamentals of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "112",
+              "title": "Intermediate Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "214",
+              "title": "Hydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Science Technology A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/computer-science-technology/computer-science-technology-aas",
+      "total_credits": 52,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major and Electives",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I (CompTIA Linux+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "201",
+              "title": "Introduction to Computer Programming Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "208",
+              "title": "Web Authoring Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "234",
+              "title": "Artificial Intelligence & Machine Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "255",
+              "title": "Java Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance (CompTIA A+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security (CompTIA Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Science Technology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/computer-science-technology/computer-science-technology-certificate",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Business Computing Technology Certificate",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "Advanced Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "212",
+              "title": "Visual Basic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance (CompTIA A+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Computer Support Technology Certificate",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I (CompTIA Linux+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications (CompTIA Network+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance (CompTIA A+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "276",
+              "title": "Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security (CompTIA Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Computer Programming Technology Certificate",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "201",
+              "title": "Introduction to Computer Programming Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "212",
+              "title": "Visual Basic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance (CompTIA A+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Science Technology - Networking A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/computer-science-technology/computer-science-technology-networking-aas",
+      "total_credits": 52,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major and Electives",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I (CompTIA Linux+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications (CompTIA Network+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "201",
+              "title": "Introduction to Computer Programming Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "Cyber Defense (CompTIA CySA+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "246",
+              "title": "Ethical Hacking (EC Council CEH)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance (CompTIA A+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "270",
+              "title": "Cisco CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "271",
+              "title": "Cisco CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "272",
+              "title": "Cisco CCNA III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "276",
+              "title": "Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "277",
+              "title": "Network Services Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "278",
+              "title": "Directory Services Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security (CompTIA Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Construction Technology - Basic Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/construction-technology/construction-technology-basic-shortterm-certificate",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V — Required courses",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "111",
+              "title": "Construction Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "112",
+              "title": "Floors, Walls, and Site Prep",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "113",
+              "title": "Floors, Walls, and Site Prep Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "114",
+              "title": "Construction Basics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "122",
+              "title": "Concrete and Forming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "123",
+              "title": "Concrete and Forming Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "131",
+              "title": "Roof and Ceiling Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "133",
+              "title": "Roofing and Ceiling Systems Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "204",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "205",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "206",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science Technology Short-Term Certificates",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/computer-science-technology/computer-science-technology-shortterm-certificates",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Business Computing Technology",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "Advanced Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance (CompTIA A+)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Computer Support Technology",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I (CompTIA Linux+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications (CompTIA Network+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance (CompTIA A+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security (CompTIA Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Web Development Technology",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "208",
+              "title": "Web Authoring Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "209",
+              "title": "Advanced Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "212",
+              "title": "Visual Basic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "App Development with Swift Coding",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "157",
+              "title": "Introduction to App Development with Swift",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "220",
+              "title": "App Development with Swift I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "227",
+              "title": "App Development with Swift II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Computer Networking Technology",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications (CompTIA Network+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "270",
+              "title": "Cisco CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "271",
+              "title": "Cisco CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security (CompTIA Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Cybersecurity Technology",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I (CompTIA Linux+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications (CompTIA Network+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "246",
+              "title": "Ethical Hacking (EC Council CEH)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security (CompTIA Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Construction Technology - Advanced Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/construction-technology/construction-technology-advanced-shortterm-certificate",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Technical Courses",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "121",
+              "title": "Introduction to Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "132",
+              "title": "Interior and Exterior Finishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "203",
+              "title": "Special Projects in Carpentry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "204",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "205",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "206",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "224",
+              "title": "Floor, Wall, and Ceiling Specialties",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "226",
+              "title": "Metal Framing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "228",
+              "title": "Stairs, Molding, and Trim",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "230",
+              "title": "Residential Repair and Remodeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "232",
+              "title": "Construction Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Salon and Spa Management A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/cosmetology/salon-and-spa-management-aas",
+      "total_credits": 80,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 46,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Introduction to Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Introduction to Cosmetology Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Chemical Services Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Hair Coloring Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Hair Coloring Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "Basic Spa Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "Basic Spa Techniques Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "123",
+              "title": "Cosmetology Salon Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "142",
+              "title": "Applied Chemistry for Cosmetology Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "143",
+              "title": "Specialty Hair Preparation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "145",
+              "title": "Hair Shaping Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "167",
+              "title": "State Board Review",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "Salon Management Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "201",
+              "title": "Entrepreneurship for Salon/Spa",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "106",
+              "title": "Workplace Skills",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "161",
+              "title": "Special Topics in Cosmetology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "162",
+              "title": "Special Topics in Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "181",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "182",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "191",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "192A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "192B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "192C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "193",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Court Reporting A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/court-reporting/court-reporting-aas",
+      "total_credits": 74,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Technical Courses",
+          "credits_required": 53,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "110",
+              "title": "Realtime Reporting I / Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "115",
+              "title": "Realtime Reporting Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "130",
+              "title": "Realtime Reporting II / Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "131",
+              "title": "Civil and Criminal Law and Terminology for Real Time Reporters",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "150",
+              "title": "Realtime Reporting III / Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "180",
+              "title": "Transcript Preparation for Court Reporters",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "210",
+              "title": "Realtime Reporting IV / Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "226",
+              "title": "Judicial Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "227",
+              "title": "Moot Court Practicum I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "230",
+              "title": "Realtime Application",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "257",
+              "title": "Moot Court Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "270",
+              "title": "Realtime Reporting VI / Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "275",
+              "title": "Realtime Reporting Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTR",
+              "number": "220",
+              "title": "Realtime Reporting V / Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Salon and Spa Management - Cosmetology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/cosmetology/salon-and-spa-management-cosmetology-certificate",
+      "total_credits": 74,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Introduction to Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Introduction to Cosmetology Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Chemical Services Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Hair Coloring Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Hair Coloring Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "Basic Spa Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "Basic Spa Techniques Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "123",
+              "title": "Cosmetology Salon Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "142",
+              "title": "Applied Chemistry for Cosmetology Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "143",
+              "title": "Specialty Hair Preparation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "145",
+              "title": "Hair Shaping Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "161",
+              "title": "Special Topics in Cosmetology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "162",
+              "title": "Special Topics in Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "167",
+              "title": "State Board Review",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "181",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "182",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "191",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "192A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "192B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "192C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "193",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "Salon Management Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "201",
+              "title": "Entrepreneurship for Salon/Spa",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "106",
+              "title": "Workplace Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Salon and Spa Management – Cosmetology Esthetics Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/cosmetology/salon-and-spa-management-cosmetology-esthetics-shortterm-certificate",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Technical Courses",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "134",
+              "title": "Advanced Esthetics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "135",
+              "title": "Advanced Esthetics Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "163",
+              "title": "Facial Treatments",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "164",
+              "title": "Facial Machine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "165",
+              "title": "Related Subjects Estheticians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "168",
+              "title": "Bacteriology and Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "169",
+              "title": "Skin Functions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "Salon Management Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Salon and Spa Management – Cosmetology Nail Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/cosmetology/salon-and-spa-management-cosmetology-nail-shortterm-certificate",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Technical Courses",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "150",
+              "title": "Manicuring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "151",
+              "title": "Nail Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "152",
+              "title": "Nail Care Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "153",
+              "title": "Nail Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "154",
+              "title": "Nail Art Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "181",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "182",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "Salon Management Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Court Reporting - Broadcast Captioning Specialization A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/court-reporting/court-reporting-broadcast-captioning-specialization-aas",
+      "total_credits": 77,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 51,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "110",
+              "title": "Realtime Reporting I / Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "115",
+              "title": "Realtime Reporting Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "130",
+              "title": "Realtime Reporting II / Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "131",
+              "title": "Civil and Criminal Law and Terminology for Real Time Reporters",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "150",
+              "title": "Realtime Reporting III / Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "171",
+              "title": "Broadcast Captioning I/Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "172",
+              "title": "Broadcast Captioning II/Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "173",
+              "title": "Broadcast Captioning III/Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "175",
+              "title": "Realtime Closed Captioning Technology II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "180",
+              "title": "Transcript Preparation for Court Reporters",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "226",
+              "title": "Judicial Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "230",
+              "title": "Realtime Application",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "292",
+              "title": "Broadcast Captioning Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTR",
+              "number": "227",
+              "title": "Moot Court Practicum I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "257",
+              "title": "Moot Court Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Court Reporting - Litigation Assistant Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/court-reporting/court-reporting-litigation-assistant-shortterm-certificate",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V — Required courses",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTR",
+              "number": "110",
+              "title": "Realtime Reporting I / Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "115",
+              "title": "Realtime Reporting Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "130",
+              "title": "Realtime Reporting II / Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "131",
+              "title": "Civil and Criminal Law and Terminology for Real Time Reporters",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "180",
+              "title": "Transcript Preparation for Court Reporters",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTR",
+              "number": "230",
+              "title": "Realtime Application",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/diagnostic-medical-sonography/diagnostic-medical-sonography-aas",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Technical Physics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major, & Elective Courses",
+          "credits_required": 56,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "202",
+              "title": "Foundations of Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "204",
+              "title": "Sectional Anatomy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "205",
+              "title": "Abdominal Sonography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "206",
+              "title": "Gynecologic Sonography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "207",
+              "title": "Abdominal Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "216",
+              "title": "Sonographic Principles & Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "220",
+              "title": "Obstetrical Sonography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "221",
+              "title": "Obstetrical Sonography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "225",
+              "title": "Superficial Sonography",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "229",
+              "title": "Sonography Preceptorship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "230",
+              "title": "Sonography Preceptorship II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "231",
+              "title": "Sonography Preceptorship III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "232",
+              "title": "Sonography Preceptorship IV",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "233",
+              "title": "Sonography Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "240",
+              "title": "Sonography Principles and Instrumentation Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "241",
+              "title": "Abdominal and Ob/Gyn Sonography Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "260",
+              "title": "Intro to Vascular Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "261",
+              "title": "Vascular Sonography Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/dental-assisting/dental-assisting-certificate",
+      "total_credits": 49,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area 1 - Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III - Natural Sciences and Mathematics",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Courses",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "100",
+              "title": "Introduction to Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "101",
+              "title": "Pre-Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "102",
+              "title": "Dental Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "103",
+              "title": "Dental Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "104",
+              "title": "Basic Sciences for Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "111",
+              "title": "Clinical Practice I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "112",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "113",
+              "title": "Dental Health Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "114",
+              "title": "Dental Office Administration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "116",
+              "title": "Pre-Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "122",
+              "title": "Clinical Practice II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "123",
+              "title": "Dental Assisting Seminar",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "Cardiopulmonary Resuscitation I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/dental-assisting/dental-assisting-aas",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area 1 - Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area II - Humanities and Fine Arts",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III - Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV - History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major and Elective Courses",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "Cardiopulmonary Resuscitation I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "100",
+              "title": "Introduction to Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "101",
+              "title": "Pre-Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "102",
+              "title": "Dental Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "103",
+              "title": "Dental Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "104",
+              "title": "Basic Sciences for Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "111",
+              "title": "Clinical Practice I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "112",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "113",
+              "title": "Dental Health Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "114",
+              "title": "Dental Office Administration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "116",
+              "title": "Pre-Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "122",
+              "title": "Clinical Practice II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "123",
+              "title": "Dental Assisting Seminar",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - Echocardiography Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/diagnostic-medical-sonography/diagnostic-medical-sonography-echocardiography-shortterm-certificate",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V — Required courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "270",
+              "title": "Intro to Cardiac Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "271",
+              "title": "Echocardiographic Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "273",
+              "title": "Pathology of the Cardiovascular System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "274",
+              "title": "Echo Clinical",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "275",
+              "title": "Advanced Echocardiographic Modalities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "276",
+              "title": "Intro to Cardiovascular Concepts I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/diesel-technology/diesel-technology-certificate",
+      "total_credits": 92,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "104",
+              "title": "Basic Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "105",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "122",
+              "title": "Heavy Vehicle Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "124",
+              "title": "Electronic Engine Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "125",
+              "title": "Heavy Vehicle Drive Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "130",
+              "title": "Electrical/Electronic Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "111",
+              "title": "Equipment Safety / Mechanical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "114",
+              "title": "Fluid Power Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "123",
+              "title": "Pneumatics and Hydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "127",
+              "title": "Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "128",
+              "title": "Heavy Vehicle Drive Train Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "129",
+              "title": "Diesel Engine Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "134",
+              "title": "Computer Controlled Engine and Power Train Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "135",
+              "title": "Heavy Vehicle Steering and Suspension Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "136",
+              "title": "Trailer Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "137",
+              "title": "Heating, Air Conditioning and Refrigeration Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "139",
+              "title": "Diesel Emissions and Aftertreatment Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "145",
+              "title": "Electrical Schematics and Symbols",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "154",
+              "title": "Vehicle Maintenance & Safe Operating Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "158",
+              "title": "Pneumatics and Hydraulics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "180",
+              "title": "Special Projects in Commercial Vehicles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "181",
+              "title": "Special Topics in Electrical",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "184",
+              "title": "Special Topics in Heavy Duty Brakes, Steering, and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "186",
+              "title": "Special Projects in Commercial Vehicles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "187",
+              "title": "Industrial Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "191",
+              "title": "Special Projects in Diesel Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "192",
+              "title": "Co-Op Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "196A",
+              "title": "Co-Op Elective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "196B",
+              "title": "Co-Op Elective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "196C",
+              "title": "Co-Op Elective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "197",
+              "title": "Co-Op Elective",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology Dual Enrollment Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/diesel-technology/diesel-technology-dual-enrollment-shortterm-certificate",
+      "total_credits": 14,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Technical Courses:",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "122",
+              "title": "Heavy Vehicle Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "139",
+              "title": "Diesel Emissions and Aftertreatment Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "154",
+              "title": "Vehicle Maintenance & Safe Operating Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "156",
+              "title": "CDL License Test Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/diesel-technology/diesel-technology-shortterm-certificate",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Technical Courses:",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "104",
+              "title": "Basic Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "105",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "111",
+              "title": "Equipment Safety / Mechanical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "122",
+              "title": "Heavy Vehicle Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "124",
+              "title": "Electronic Engine Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "125",
+              "title": "Heavy Vehicle Drive Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "130",
+              "title": "Electrical/Electronic Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "135",
+              "title": "Heavy Vehicle Steering and Suspension Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "137",
+              "title": "Heating, Air Conditioning and Refrigeration Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Robotics Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/electronic-engineering-technology/advanced-robotics-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses:",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "278",
+              "title": "Advanced Robotics",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "129",
+              "title": "Industrial Safety and Maintenance Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "280",
+              "title": "Special Topics in Industrial Maintenance Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronic Engineering Technology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/electronic-engineering-technology/electronic-engineering-technology-certificate",
+      "total_credits": 55,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Technical Courses",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Introduction to Engineering Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Electives",
+          "credits_required": 38,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "286A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "294",
+              "title": "Co-Op Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electrical Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/electrical-technology/electrical-technology-shortterm-certificate",
+      "total_credits": 78,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Residential Electrical Apprentice",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Residential Wiring Methods II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Industrial Electrical Technician",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Industrial Control Technician",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronic Engineering Technology - General Option A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/electronic-engineering-technology/electronic-engineering-technology-general-option-aas",
+      "total_credits": 129,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Introduction to Engineering Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "109",
+              "title": "Electrical Blueprint Reading I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "114",
+              "title": "Concepts of Solid State Electronics",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "115",
+              "title": "Concepts of Digital Electronics",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "116",
+              "title": "Concepts of Electronic Circuits",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Circuit Fabrication I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "225",
+              "title": "Electronics Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "260",
+              "title": "Microprocessors Interfacing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "261",
+              "title": "Microprocessors Interfacing Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework:",
+          "credits_required": 83,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "192",
+              "title": "Installation Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "195",
+              "title": "Selected Topics in EET",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "196",
+              "title": "Selected Topics in EET",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "197",
+              "title": "Selected Topics in EET",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "207",
+              "title": "Intro to Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "208",
+              "title": "Fiber Optics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "212",
+              "title": "Intro to Robotics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "213",
+              "title": "Process Control and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "224",
+              "title": "Elements of Industrial Controls with PLCs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "229",
+              "title": "Elements of Industrial Controls with PLCs Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "234",
+              "title": "Robotic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "238",
+              "title": "Process Control and Instrumentation Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "239",
+              "title": "Robotic Systems Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "249",
+              "title": "CET Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "252",
+              "title": "Electronic Service Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "254",
+              "title": "Microcomputer Systems Basic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "255",
+              "title": "Microcomputer Systems Basic I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "256",
+              "title": "Microcomputer Systems Advanced I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "257",
+              "title": "Microcomputer Systems Advanced I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "262",
+              "title": "Industrial Automation Project",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Elements of Industrial Controls with PLCs II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Elements of Industrial Controls with PLCs II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "281",
+              "title": "Special Topics in Electronic Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "286C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "288",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "290",
+              "title": "Electronics Project",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "294",
+              "title": "Co-Op Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "231",
+              "title": "Introduction to Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "232",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechatronics Advanced Automation Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/electronic-engineering-technology/mechatronics-advanced-automation-shortterm-certificate",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "197",
+              "title": "Selected Topics in EET",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Elements of Industrial Controls with PLCs II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Elements of Industrial Controls with PLCs II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "Motor Controls II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "180",
+              "title": "Special Topics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "252",
+              "title": "Variable Speed Motor Drives",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics, Robotics & Automation A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/electronic-engineering-technology/mechatronics-robotics-automation-aas",
+      "total_credits": 150,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Introduction to Engineering Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "109",
+              "title": "Electrical Blueprint Reading I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "114",
+              "title": "Concepts of Solid State Electronics",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "115",
+              "title": "Concepts of Digital Electronics",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework:",
+          "credits_required": 93,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "197",
+              "title": "Selected Topics in EET",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "225",
+              "title": "Electronics Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Elements of Industrial Controls with PLCs II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Elements of Industrial Controls with PLCs II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "278",
+              "title": "Advanced Robotics",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Residential Wiring Methods II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "Motor Controls II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "232",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Conduit Bending and Installation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "119",
+              "title": "Principles of Mechanical Measurement and Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "126",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "128",
+              "title": "Principles of Industrial Environmental Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "129",
+              "title": "Industrial Safety and Maintenance Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "180",
+              "title": "Special Topics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "252",
+              "title": "Variable Speed Motor Drives",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "280",
+              "title": "Special Topics in Industrial Maintenance Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "291",
+              "title": "Cooperative Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "292",
+              "title": "Cooperative Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "297A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "297B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "297C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "297D",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "298",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "123",
+              "title": "Engine Lathe Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "134",
+              "title": "Lathe Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "137",
+              "title": "Milling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "148",
+              "title": "Introduction to Machine Shop I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Civil Engineering Technology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/civil-engineering/civil-engineering-technology-certificate",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "100",
+              "title": "Engineering Blueprints",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "101",
+              "title": "Introduction to Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "111",
+              "title": "Fundamentals of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "112",
+              "title": "Intermediate Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Additional Coursework",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "105",
+              "title": "Introduction to Microstation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "121",
+              "title": "Engineering Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "131",
+              "title": "Highway Design and Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "214",
+              "title": "Hydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "216",
+              "title": "Advanced Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "222",
+              "title": "Residential Land Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "223",
+              "title": "Site Planning and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "240",
+              "title": "Geographic Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "281A",
+              "title": "Special Topics in Civil Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "122",
+              "title": "Architectural Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Emergency Medical Services Short-Term Certificates",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/emergency-medical-services/emergency-medical-services-shortterm-certificates",
+      "total_credits": 50,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "EMS - 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "Cardiopulmonary Resuscitation I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "107",
+              "title": "Emergency Vehicle Operator Ambulance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Advanced EMT: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "Advanced Emergency Medical Technician Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Paramedic: 29 credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Cardiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic Patient Assessment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic Clinical I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "Paramedic Medical Emergencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Trauma Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "Paramedic Special Populations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "Paramedic Transition to the Workforce",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Advanced Competencies for Paramedics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "Paramedic Field Preceptorship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "Paramedic Team Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "Paramedic Applied Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/general-studies/general-studies-as",
+      "total_credits": 39,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V — Pre-Professional, Pre-Major and Electives",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Human Services A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/human-services/human-services-aas",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV — History, Social and Behavioral Sciences",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major and Electives",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "224",
+              "title": "Personal and Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "101",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "102",
+              "title": "Introduction to Casework",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "112",
+              "title": "Activity Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "211",
+              "title": "Introduction: Alcohol and Drug Prevention and Abuse",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "222",
+              "title": "Group Counseling Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "223",
+              "title": "Guidance and Counseling Technique",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "224",
+              "title": "Clinical Internship I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "225",
+              "title": "Clinical Internship II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "226",
+              "title": "Clinical Internship III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "133",
+              "title": "Geriatrics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "138",
+              "title": "Counseling from a Cultural Perspective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "216",
+              "title": "Relapse Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "217",
+              "title": "Alcoholism and Drug Abuse Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "230",
+              "title": "Special Topics in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Automation Technology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/industrial-automation-technology/industrial-automation-technology-certificate",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Introduction to Engineering Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "126",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "180",
+              "title": "Special Topics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "291",
+              "title": "Cooperative Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "296",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "297A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "297B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "297C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "298",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Automation Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/industrial-automation-technology/industrial-automation-technology-shortterm-certificate",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V - Required Courses",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V — Additional Coursework",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Introduction to Engineering Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "109",
+              "title": "Electrical Blueprint Reading I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "126",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts A.A.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/liberal-arts/liberal-arts-aa",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V — Pre-Professional, Pre-Major and Electives",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Marketing Management A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/marketing-management/marketing-management-aas",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV — History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V — Pre-Professional, Pre-Major and Electives: 49 credits",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "146",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "186",
+              "title": "Elements of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "122",
+              "title": "Visual Merchandising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "123",
+              "title": "Fundamentals of Selling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "220",
+              "title": "Advertising and Sales Promotion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "221",
+              "title": "Consumer Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MST",
+              "number": "209",
+              "title": "Physical Supply and Distribution Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Electrical Technology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/electrical-technology/electrical-technology-certificate",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Introduction to Engineering Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "109",
+              "title": "Electrical Blueprint Reading I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Residential Wiring Methods II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework:",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "192",
+              "title": "Practicum/Intern/Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "194",
+              "title": "Practicum/Intern/Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "286A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "286B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "286C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "288",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechanical Design Technology A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/mechanical-design-technology/mechanical-design-technology-aas",
+      "total_credits": 97,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "215",
+              "title": "Statics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "217",
+              "title": "Strength of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "111",
+              "title": "Mechanical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "146",
+              "title": "AutoCAD CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "147",
+              "title": "Inventor CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "202",
+              "title": "SOLIDWORKS CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "211",
+              "title": "Advanced Mechanical Drawings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "221",
+              "title": "Machine Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework:",
+          "credits_required": 53,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "122",
+              "title": "Architectural Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "123",
+              "title": "Architectural Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "187",
+              "title": "Advanced Inventor Cadd",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "203",
+              "title": "CREO CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "215A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "215B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "215C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "216",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "217",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "252",
+              "title": "Advanced Solidworks CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "261",
+              "title": "HVAC and Pipe Systems Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "271",
+              "title": "Structural and Weld Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "272",
+              "title": "Electrical and Electronic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "280",
+              "title": "3-D Studio Max",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "293",
+              "title": "Advanced Pro-Engineer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "Metrology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "128",
+              "title": "Geometric Dimensioning and Tolerancing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "181",
+              "title": "Special Topics in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/emergency-medical-services/emergency-medical-services-aas",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major and Elective Courses",
+          "credits_required": 51,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "Cardiopulmonary Resuscitation I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "107",
+              "title": "Emergency Vehicle Operator Ambulance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "Advanced Emergency Medical Technician Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Cardiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic Patient Assessment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic Clinical I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "Paramedic Medical Emergencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Trauma Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "Paramedic Special Populations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "Paramedic Transition to the Workforce",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Advanced Competencies for Paramedics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "Paramedic Field Preceptorship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "Paramedic Team Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "Paramedic Applied Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechanical Design Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/mechanical-design-technology/mechanical-design-technology-shortterm-certificate",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Technical Courses",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDT",
+              "number": "100",
+              "title": "Engineering Blueprints",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "111",
+              "title": "Mechanical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "122",
+              "title": "Architectural Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "146",
+              "title": "AutoCAD CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "147",
+              "title": "Inventor CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "202",
+              "title": "SOLIDWORKS CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "211",
+              "title": "Advanced Mechanical Drawings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/electrical-technology/electrical-technology-aas",
+      "total_credits": 159,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Introduction to Engineering Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "109",
+              "title": "Electrical Blueprint Reading I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Residential Wiring Methods II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework:",
+          "credits_required": 106,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "114",
+              "title": "Concepts of Solid State Electronics",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "115",
+              "title": "Concepts of Digital Electronics",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "119",
+              "title": "Circuit Fabrication I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "207",
+              "title": "Intro to Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "212",
+              "title": "Intro to Robotics Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "213",
+              "title": "Process Control and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "224",
+              "title": "Elements of Industrial Controls with PLCs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "229",
+              "title": "Elements of Industrial Controls with PLCs Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "238",
+              "title": "Process Control and Instrumentation Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "276",
+              "title": "Elements of Industrial Controls with PLCs II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "277",
+              "title": "Elements of Industrial Controls with PLCs II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "181",
+              "title": "Special Topics in Electrical Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "182",
+              "title": "Special Topics in Electrical Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "192",
+              "title": "Practicum/Intern/Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "194",
+              "title": "Practicum/Intern/Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "206",
+              "title": "Osha Safety Standards",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "232",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "234",
+              "title": "PLC Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "241",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "242",
+              "title": "Journeyman Master Prep Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Conduit Bending and Installation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "286A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "286B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "286C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "288",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "126",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "253",
+              "title": "Industrial Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Assistant Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/medical-laboratory-technician/medical-laboratory-assistant-shortterm-certificate",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses:",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "131",
+              "title": "Laboratory Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "132",
+              "title": "Laboratory Techniques II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "286",
+              "title": "Clinical Laboratory Practicum for MLA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technician A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/medical-laboratory-technician/medical-laboratory-technician-aas",
+      "total_credits": 49,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major and Elective Courses",
+          "credits_required": 46,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "111",
+              "title": "Urinalysis and Body Fluids",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "121",
+              "title": "Hematology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "131",
+              "title": "Laboratory Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "141",
+              "title": "MLT Microbiology I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "142",
+              "title": "MLT Microbiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "151",
+              "title": "MLT Clinical Chemistry",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "161",
+              "title": "Integrated Laboratory Simulation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "181",
+              "title": "Clinical Immunology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "191",
+              "title": "MLT Immunohematology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "293",
+              "title": "MLT Clinical Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "294",
+              "title": "Medical Laboratory Practicum Hematology and Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "295",
+              "title": "Medical Laboratory Practicum Microbiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "296",
+              "title": "Medical Laboratory Practicum Immunohematology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "297",
+              "title": "Medical Laboratory Practicum Chemistry and Immunology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/nursing/practical-nursing-certificate",
+      "total_credits": 46,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV — History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major, & Elective Courses",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Fundamental Concepts of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Nursing Concepts I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Nursing Concepts II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "Evidence Based Clinical Reasoning",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Health Information Technology Management Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/health-information-technology-management/health-information-technology-management-shortterm",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V - Professional, Major and Elective Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "134",
+              "title": "HIT Legal and Ethical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "151",
+              "title": "Health Data Content and Structure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "153",
+              "title": "Health Care Delivery Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "230",
+              "title": "Medical Coding Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "231",
+              "title": "Medical Coding Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "254",
+              "title": "Organizational Improvement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "295",
+              "title": "Special Topics in HIT III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "217",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Registered Nursing A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/nursing/registered-nursing-aas",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV — History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major, & Elective Courses",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Fundamental Concepts of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Nursing Concepts I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Nursing Concepts II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "Evidence Based Clinical Reasoning",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence Based Clinical Reasoning",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Medical Coding/Billing Specialist Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/office-administration/medical-codingbilling-specialist-shortterm-certificate",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V - Professional, Major and Elective Courses",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "206",
+              "title": "Human Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "134",
+              "title": "HIT Legal and Ethical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "230",
+              "title": "Medical Coding Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "231",
+              "title": "Medical Coding Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "232",
+              "title": "Medical Coding Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "233",
+              "title": "Medical Coding Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "Beginning Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "215",
+              "title": "Health Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "216",
+              "title": "Advanced Health Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Registered Nursing A.A.S. Mobility Option LPN to RN/Paramedic to RN",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/nursing/registered-nursing-aas-mobility-option-lpn-to-rnparamedic-to-rn",
+      "total_credits": 49,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV — History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major, & Elective Courses",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "209",
+              "title": "Concepts for Healthcare Transition Students*",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence Based Clinical Reasoning",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Office Administration A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/office-administration/office-administration-aas",
+      "total_credits": 163,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV — History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Administrative Assistant: General",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "Advanced Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "104",
+              "title": "Advanced Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "134",
+              "title": "Career and Professional Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "243",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Health Information Technology Management",
+          "credits_required": 50,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "134",
+              "title": "HIT Legal and Ethical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "151",
+              "title": "Health Data Content and Structure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "153",
+              "title": "Health Care Delivery Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "230",
+              "title": "Medical Coding Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "231",
+              "title": "Medical Coding Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "232",
+              "title": "Medical Coding Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "233",
+              "title": "Medical Coding Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "254",
+              "title": "Organizational Improvement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "295",
+              "title": "Special Topics in HIT III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "215",
+              "title": "Health Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "217",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Medical Coding and Scribing",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "230",
+              "title": "Medical Coding Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "231",
+              "title": "Medical Coding Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "232",
+              "title": "Medical Coding Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "233",
+              "title": "Medical Coding Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "104",
+              "title": "Advanced Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "134",
+              "title": "Career and Professional Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "215",
+              "title": "Health Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "216",
+              "title": "Advanced Health Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "243",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechanical Design Technology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/mechanical-design-technology/mechanical-design-technology-certificate",
+      "total_credits": 58,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDT",
+              "number": "100",
+              "title": "Engineering Blueprints",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "111",
+              "title": "Mechanical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "146",
+              "title": "AutoCAD CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "147",
+              "title": "Inventor CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "211",
+              "title": "Advanced Mechanical Drawings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework:",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "122",
+              "title": "Architectural Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "202",
+              "title": "SOLIDWORKS CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "215A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "215B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "215C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "216",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "217",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "221",
+              "title": "Machine Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "261",
+              "title": "HVAC and Pipe Systems Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "271",
+              "title": "Structural and Weld Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "272",
+              "title": "Electrical and Electronic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/paralegal/paralegal-aas",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV — History, Social and Behavioral Sciences",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V — Pre-Professional, Pre-Major and Electives",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "Beginning Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "101",
+              "title": "Introduction to Paralegal Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "102",
+              "title": "Basic Research and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "103",
+              "title": "Advanced Legal Research and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "160",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "210",
+              "title": "Real Property Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "230",
+              "title": "Domestic Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "240",
+              "title": "Wills, Trusts, and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "262",
+              "title": "Civil Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "291",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Manufacturing Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/precision-machining/additive-manufacturing-shortterm-certificate",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses:",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "147",
+              "title": "Inventor CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "202",
+              "title": "SOLIDWORKS CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "252",
+              "title": "Advanced Solidworks CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "Metrology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "128",
+              "title": "Geometric Dimensioning and Tolerancing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "181",
+              "title": "Special Topics in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Precision Machining A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/precision-machining/precision-machining-aas",
+      "total_credits": 133,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "Metrology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "128",
+              "title": "Geometric Dimensioning and Tolerancing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "139",
+              "title": "Basic Computer Numerical Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "147",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "148",
+              "title": "Introduction to Machine Shop I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "149",
+              "title": "Introduction to Machine Shop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "150",
+              "title": "Introduction to Machine Shop II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework:",
+          "credits_required": 95,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "147",
+              "title": "Inventor CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "202",
+              "title": "SOLIDWORKS CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "252",
+              "title": "Advanced Solidworks CADD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "108",
+              "title": "Machine Handbook Functions I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "109",
+              "title": "Orientation to Computer Assisted Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "123",
+              "title": "Engine Lathe Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "124",
+              "title": "Engine Lathe Lab II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "134",
+              "title": "Lathe Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "137",
+              "title": "Milling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "138",
+              "title": "Milling I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "140",
+              "title": "Basic Computer Numerical Control Turning Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "141",
+              "title": "Basic Computer Numeric Control Milling Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "154",
+              "title": "Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "162",
+              "title": "Precision Grinding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "181",
+              "title": "Special Topics in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "202",
+              "title": "Machine Maintenance and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "219",
+              "title": "Computer Numerical Control Graphics: Turning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "220",
+              "title": "Computer Numerical Control Graphics: Milling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "221",
+              "title": "Advanced Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "241",
+              "title": "CNC Milling Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "242",
+              "title": "CNC Milling Lab II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "243",
+              "title": "CNC Turning Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "244",
+              "title": "CNC Turning Lab II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "270",
+              "title": "Machining Skills Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "281",
+              "title": "Special Topics in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "286A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "286B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "286C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "288",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "291",
+              "title": "Cooperative Education in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "292",
+              "title": "Cooperative Education in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Automation Technology A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/industrial-automation-technology/industrial-automation-technology-aas",
+      "total_credits": 144,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "100",
+              "title": "Introduction to Engineering Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "109",
+              "title": "Electrical Blueprint Reading I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "126",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework:",
+          "credits_required": 94,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "278",
+              "title": "Advanced Robotics",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "119",
+              "title": "Principles of Mechanical Measurement and Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "128",
+              "title": "Principles of Industrial Environmental Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "140",
+              "title": "F.A.M.E. Manufacturing Core Exercise 1, Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "142",
+              "title": "F.A.M.E. Manufacturing Core Exercise 2, Workplace Visual Organization (5S)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "144",
+              "title": "F.A.M.E. Manufacturing Core Exercise 3, Lean Manufacturing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "146",
+              "title": "F.A.M.E. Manufacturing Core Exercise 4, Problem Solving",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "148",
+              "title": "F.A.M.E. Manufacturing Core Exercise 5, Machine Reliability",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "153",
+              "title": "Precision Machining Fundamentals I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "180",
+              "title": "Special Topics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "206",
+              "title": "Industrial Motors I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "211",
+              "title": "Industrial Motors II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "252",
+              "title": "Variable Speed Motor Drives",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "253",
+              "title": "Industrial Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "280",
+              "title": "Special Topics in Industrial Maintenance Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "291",
+              "title": "Cooperative Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "292",
+              "title": "Cooperative Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "293",
+              "title": "Cooperative Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "296",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "297A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "297B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "297C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "297D",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "298",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Residential Wiring Methods II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "122",
+              "title": "Advanced AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "Motor Controls II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "232",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Conduit Bending and Installation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Precision Machining - Basic CNC Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/precision-machining/precision-machining-basic-cnc-technology-shortterm-certificate",
+      "total_credits": 38,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Required Courses",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional Coursework",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "139",
+              "title": "Basic Computer Numerical Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "140",
+              "title": "Basic Computer Numerical Control Turning Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "141",
+              "title": "Basic Computer Numeric Control Milling Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "219",
+              "title": "Computer Numerical Control Graphics: Turning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "220",
+              "title": "Computer Numerical Control Graphics: Milling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "241",
+              "title": "CNC Milling Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "242",
+              "title": "CNC Milling Lab II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "243",
+              "title": "CNC Turning Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "244",
+              "title": "CNC Turning Lab II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "281",
+              "title": "Special Topics in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "292",
+              "title": "Cooperative Education in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant Technology A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/medical-assistant/medical-assistant-technology-aas",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area 1 - Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area II - Humanities and Fine Arts",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III - Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV - History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional Courses",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "Clinical Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Medical Administrative Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Medical Administrative Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Medical Laboratory Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "128",
+              "title": "Medical Law and Ethics for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "200",
+              "title": "Management of Office Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "211",
+              "title": "Clinical Procedures II for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "214",
+              "title": "Medical Assisting Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "217",
+              "title": "Microscopy for the Medical Office",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "219",
+              "title": "Radiology for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "228",
+              "title": "Medical Assistant Review Course",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "229",
+              "title": "Medical Assisting Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "239",
+              "title": "Phlebotomy Preceptorship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Precision Machining - Basic Precision Machining Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/precision-machining/precision-machining-basic-precision-machining-shortterm-certificate",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Required Courses",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Print Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "147",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "148",
+              "title": "Introduction to Machine Shop I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional Coursework",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "123",
+              "title": "Engine Lathe Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "Metrology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "128",
+              "title": "Geometric Dimensioning and Tolerancing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "134",
+              "title": "Lathe Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "137",
+              "title": "Milling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "138",
+              "title": "Milling I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "139",
+              "title": "Basic Computer Numerical Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "140",
+              "title": "Basic Computer Numerical Control Turning Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "141",
+              "title": "Basic Computer Numeric Control Milling Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "154",
+              "title": "Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "162",
+              "title": "Precision Grinding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "181",
+              "title": "Special Topics in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "221",
+              "title": "Advanced Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "270",
+              "title": "Machining Skills Application",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/surgical-technology/surgical-technology-aas",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area 1 - Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III - Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV - History, Social and Behavorial Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major and Electives",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "101",
+              "title": "Introduction to Surgical Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "102",
+              "title": "Applied Surgical Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "103",
+              "title": "Surgical Procedures",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "104",
+              "title": "Surgical Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "105",
+              "title": "Surgical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "106",
+              "title": "Role Transition in Surgical Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "107",
+              "title": "Surgical Anatomy and Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "108",
+              "title": "Pharmacology for the Surgical Technoligist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "109",
+              "title": "Introduction to Surgical Equipment, Instrumentation and Supplies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "111",
+              "title": "Clinical Procedures",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "204",
+              "title": "Surgical Practicum III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/radiography/radiography-aas",
+      "total_credits": 73,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III — Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV — History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional, Major and Elective Courses",
+          "credits_required": 56,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "111",
+              "title": "Introduction to Radiography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "112",
+              "title": "Radiographic Procedures I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "113",
+              "title": "Patient Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "114",
+              "title": "Clinical Education I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "122",
+              "title": "Radiographic Procedures II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "124",
+              "title": "Clinical Education II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "125",
+              "title": "Imaging Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "134",
+              "title": "Clinical Education III",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "135",
+              "title": "Exposure Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "136",
+              "title": "Radiation Protection and Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "212",
+              "title": "Image Evaluation and Pathology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "214",
+              "title": "Clinical Education IV",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "224",
+              "title": "Clinical Education V",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "227",
+              "title": "Review Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/welding-technology/welding-technology-certificate",
+      "total_credits": 145,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V - Technical Courses",
+          "credits_required": 145,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW Fillet/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW Fillet/Pac/Cac",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "115",
+              "title": "GTAW Carbon Pipe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "116",
+              "title": "GTAW Stainless Pipe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding Groove",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW Fillet/OFC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW Fillet/Pac/CAC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "Shielded Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "155",
+              "title": "GTAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "156",
+              "title": "GTAW Stainless Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "157",
+              "title": "Consumable Welding Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "158",
+              "title": "Consumable Welding Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "160",
+              "title": "Robotics Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "162",
+              "title": "Consumable Welding Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "163",
+              "title": "Consumable Welding Applications Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "166",
+              "title": "Flux Core Arc Welding (FCAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "167",
+              "title": "Flux Core Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "180",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "181",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "182",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "183",
+              "title": "Special Topics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "183M",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "184",
+              "title": "Special Topics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "193",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "217",
+              "title": "SMAW Carbon Pipe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "218",
+              "title": "Certification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection & Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "221",
+              "title": "Pipefitting and Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "223",
+              "title": "Blueprint Reading for Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "228",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "229",
+              "title": "Boiler Tube",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "230",
+              "title": "Orbital Gas Tungsten Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "240",
+              "title": "Orbital Gas Tungsten Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "250",
+              "title": "Pipe Preparation for Orbital Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "259",
+              "title": "GTAW Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "268",
+              "title": "Gas Tungsten Arc Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "269",
+              "title": "Boiler Tube Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "281",
+              "title": "Special Topics in Welding Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "286A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "286B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "286C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "288",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "291",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "292",
+              "title": "Welding Work Based Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Medical Assistant Technology Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/medical-assistant/medical-assistant-technology-certificate",
+      "total_credits": 50,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area 1 - Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III - Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Professional Courses",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "100",
+              "title": "Introduction to Medical Document Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "Clinical Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Medical Business Practices I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "124",
+              "title": "Medical Business Practices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Medical Laboratory Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "128",
+              "title": "Medical Law and Ethics for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "200",
+              "title": "Management of Office Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "214",
+              "title": "Medical Assisting Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "219",
+              "title": "Radiology for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "211",
+              "title": "Clinical Procedures II for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "222",
+              "title": "Medical Transcription I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "228",
+              "title": "Medical Assistant Review Course",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "229",
+              "title": "Medical Assisting Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Precision Machining Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/precision-machining/precision-machining-certificate",
+      "total_credits": 91,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I — Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V - Required Technical Courses",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Print Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "139",
+              "title": "Basic Computer Numerical Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "147",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "148",
+              "title": "Introduction to Machine Shop I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Coursework:",
+          "credits_required": 74,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "105",
+              "title": "Introduction to Computer-Aided Design (CAD)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "123",
+              "title": "Engine Lathe Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "Metrology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "128",
+              "title": "Geometric Dimensioning and Tolerancing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "134",
+              "title": "Lathe Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "137",
+              "title": "Milling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "140",
+              "title": "Basic Computer Numerical Control Turning Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "141",
+              "title": "Basic Computer Numeric Control Milling Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "149",
+              "title": "Introduction to Machine Shop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "150",
+              "title": "Introduction to Machine Shop II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "154",
+              "title": "Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "162",
+              "title": "Precision Grinding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "181",
+              "title": "Special Topics in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "221",
+              "title": "Advanced Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "241",
+              "title": "CNC Milling Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "242",
+              "title": "CNC Milling Lab II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "243",
+              "title": "CNC Turning Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "244",
+              "title": "CNC Turning Lab II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "270",
+              "title": "Machining Skills Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "286A",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "286B",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "286C",
+              "title": "Co-Op",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "288",
+              "title": "Co-Op",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "291",
+              "title": "Cooperative Education in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/welding-technology/welding-technology-shortterm-certificate",
+      "total_credits": 44,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V - Technical Courses",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW Fillet/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW Fillet/Pac/Cac",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW Fillet/OFC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW Fillet/Pac/CAC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "157",
+              "title": "Consumable Welding Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "158",
+              "title": "Consumable Welding Processes Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "160",
+              "title": "Robotics Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "162",
+              "title": "Consumable Welding Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "163",
+              "title": "Consumable Welding Applications Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "166",
+              "title": "Flux Core Arc Welding (FCAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "167",
+              "title": "Flux Core Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology Pipe Tube Welding Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/welding-technology/welding-technology-pipe-tube-welding-shortterm-certificate",
+      "total_credits": 44,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V - Technical Courses",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "115",
+              "title": "GTAW Carbon Pipe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "116",
+              "title": "GTAW Stainless Pipe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding Groove",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "Shielded Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "155",
+              "title": "GTAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "156",
+              "title": "GTAW Stainless Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "217",
+              "title": "SMAW Carbon Pipe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "221",
+              "title": "Pipefitting and Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "228",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "229",
+              "title": "Boiler Tube",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "230",
+              "title": "Orbital Gas Tungsten Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "268",
+              "title": "Gas Tungsten Arc Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "269",
+              "title": "Boiler Tube Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Word Processing Specialist Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/office-administration/word-processing-specialist-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V - Professional, Major and Elective Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "Advanced Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "Beginning Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "104",
+              "title": "Advanced Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Certified Production Technician - Dual Enrollment Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.gadsdenstate.edu/workplace-skills-enhancement/certified-production-technician-dual-enrollment-shortterm-certificate",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Technical Courses",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WKO",
+              "number": "141",
+              "title": "MSSC Safety Course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "142",
+              "title": "MSSC Quality Practices and Measurement Course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "143",
+              "title": "MSSC Manufacturing Processes and Production Course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "144",
+              "title": "MSSC Maintenance Awareness Course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "101",
+              "title": "Workplace Skills Development I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/al/programs/george-c-wallace-community-college-dothan.json
+++ b/data/al/programs/george-c-wallace-community-college-dothan.json
@@ -1,0 +1,4703 @@
+{
+  "college_slug": "george-c-wallace-community-college-dothan",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.wallace.edu/degrees",
+  "scraped_at": "2026-06-03T21:27:22.088Z",
+  "programs": [
+    {
+      "title": "Air Conditioning/Refrigeration, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/air-conditioningrefrigeration/air-conditioningrefrigeration-aas",
+      "total_credits": 58,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses (Required Orientation Courses)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses (Required Field of Concentration Courses)",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVAC/R Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVAC/R",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVAC/R Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVAC/R Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "134",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigerant Transition and Recovery Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "149",
+              "title": "Heat Pump Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "203",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Commercial Air Conditioning Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Troubleshooting HVAC/R Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic HVAC Technician, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/air-conditioningrefrigeration/basic-hvac-technician-stc",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Required Field of Concentration Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVAC/R Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVAC/R",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVAC/R Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigerant Transition and Recovery Theory",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning/Refrigeration, Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/air-conditioningrefrigeration/air-conditioningrefrigeration-certificate",
+      "total_credits": 52,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Required Orientation Courses",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVAC/R Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVAC/R",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVAC/R Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVAC/R Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "134",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigerant Transition and Recovery Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "149",
+              "title": "Heat Pump Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "203",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Commercial Air Conditioning Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Troubleshooting HVAC/R Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology, Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/automotive-technology/automotive-technology-certificate",
+      "total_credits": 52,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 46,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "101",
+              "title": "Fundamentals of Automotive Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "121",
+              "title": "Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "122",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "124",
+              "title": "Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "130",
+              "title": "Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "133",
+              "title": "Motor Vehicle Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "212",
+              "title": "Advanced Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "224",
+              "title": "Manual Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "230",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "239",
+              "title": "Engine Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "244",
+              "title": "Engine Performance and Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "246",
+              "title": "Automotive Emissions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "263",
+              "title": "Hybrid and Electric Vehicles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/automotive-technology/automotive-technology-aas",
+      "total_credits": 55,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 46,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "121",
+              "title": "Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "122",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "130",
+              "title": "Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "133",
+              "title": "Motor Vehicle Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "212",
+              "title": "Advanced Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "224",
+              "title": "Manual Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "230",
+              "title": "Automatic Transmission/Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "239",
+              "title": "Engine Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "246",
+              "title": "Automotive Emissions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "263",
+              "title": "Hybrid and Electric Vehicles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Diesel and Heavy Equipment Mechanics",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/automotive-technology/diesel-and-heavy-equipment-mechanics",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Required Field of Concentration Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "104",
+              "title": "Basic Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "105",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "111",
+              "title": "Equipment Safety / Mechanical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "156",
+              "title": "CDL License Test Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Technologies, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/business-technologies/business-technologies-aas",
+      "total_credits": 85,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "146",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "Accounting with QuickBooks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "113",
+              "title": "Spreadsheet Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ACCOUNTING TECHNOLOGY CONCENTRATION",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "129",
+              "title": "Individual Income Taxes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "248",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "BUSINESS MANAGEMENT & SUPERVISION CONCENTRATION",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "186",
+              "title": "Elements of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "248",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "279",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ENTREPRENEUSHIP CONCENTRATION",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "186",
+              "title": "Elements of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "279",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "OFFICE ADMINISTRATION CONCENTRATION",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records/Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Child Development, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/child-development/child-development-aas",
+      "total_credits": 49,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction to Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "Child Growth and Development Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "202",
+              "title": "Children’s Creative Experiences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children’s Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "Infant and Toddler Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Educating Exceptional Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "213",
+              "title": "Child Development Trends Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "214",
+              "title": "Families and Communities in Early Care and Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "215",
+              "title": "Supervised Practical Experience in Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "217",
+              "title": "Math and Science for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "222",
+              "title": "Social Studies for Children",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Child Development, Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/child-development/child-development-certificate",
+      "total_credits": 34,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction to Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "Child Growth and Development Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children’s Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "213",
+              "title": "Child Development Trends Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "214",
+              "title": "Families and Communities in Early Care and Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "217",
+              "title": "Math and Science for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Computer Information Science, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/computer-information-science/computer-information-science-aas",
+      "total_credits": 91,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "113",
+              "title": "Spreadsheet Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "117",
+              "title": "Database Management Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "150",
+              "title": "Introduction to Computer Logic and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "161",
+              "title": "Introduction to Networking Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "182",
+              "title": "Help Desk Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "Cyber Defense",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "268",
+              "title": "Software Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "269",
+              "title": "Hardware Support",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CYBER DEFENSE CONCENTRATION",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "246",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "282",
+              "title": "Computer Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GOOGLE IT SUPPORT PROFESSIONAL CONCENTRATION",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Google IT Professional Support I—Technical Support Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "121",
+              "title": "Google IT Professional Support II—Computer Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "122",
+              "title": "Google IT Professional Support III—Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "123",
+              "title": "Google IT Professional Support IV—System Administration and IT Infrastructure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "124",
+              "title": "Google IT Professional Support V—IT Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MOBILE APP DEVELOPMENT CONCENTRATION",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "219",
+              "title": "Android App Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "259",
+              "title": "Advanced Mobile App Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "285",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SOFTWARE DEVELOPMENT CONCENTRATION",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "285",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "212",
+              "title": "Visual Basic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice Forensic Concentration, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/criminal-justice/criminal-justice-forensic-concentration-aas",
+      "total_credits": 53,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area II: Humanities and Fine Arts",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "104",
+              "title": "Workkeys® Assessment and Advisement",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "140",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "147",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "178",
+              "title": "Narcotics and Dangerous Drugs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "208",
+              "title": "Introduction to Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "220",
+              "title": "Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "226",
+              "title": "Fingerprint Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "230",
+              "title": "Criminalistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "236",
+              "title": "Advanced Criminalistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "237",
+              "title": "Forensic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "238",
+              "title": "Crime Scene Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice Fundamentals, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/criminal-justice/criminal-justice-fundamentals-stc",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Required Field of Concentration Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "147",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "220",
+              "title": "Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "290",
+              "title": "Selected Topics - Seminar in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice Law Enforcement Concentration, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/criminal-justice/criminal-justice-law-enforcement-concentration-aas",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area II: Humanities and Fine Arts",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "104",
+              "title": "Workkeys® Assessment and Advisement",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "140",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "147",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "150",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "178",
+              "title": "Narcotics and Dangerous Drugs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "208",
+              "title": "Introduction to Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "209",
+              "title": "Juvenile Delinquency",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "220",
+              "title": "Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "230",
+              "title": "Criminalistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "238",
+              "title": "Crime Scene Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "239",
+              "title": "Issues in Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Electrical Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/electrical-technology/electrical-technology-aas",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHS",
+              "number": "112",
+              "title": "Physical Science II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER Core",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Residential Wiring Methods II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "Commercial/Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "132",
+              "title": "Commercial/Industrial Wiring II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "221",
+              "title": "Electronics for Electricians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "224",
+              "title": "Security and Alarm Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "225",
+              "title": "Smart House Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/electrical-technology/electrical-technology-stc",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "Commercial/Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic AAS Degree Curriculum",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/emergency-medical-services/emergency-medical-services-paramedic-aas-degree-curriculum",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "Advanced Emergency Medical Technician Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Cardiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic Patient Assessment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "243",
+              "title": "Paramedic Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic Clinical I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "Paramedic Medical Emergencies I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Trauma Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "Paramedic Special Populations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "Paramedic Transition to the Workforce",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Advanced Competencies for Paramedic",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "Paramedic Field Preceptorship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "Paramedic Team Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic Certificate Curriculum",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/emergency-medical-services/emergency-medical-services-paramedic-certificate-curriculum",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 46,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Cardiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic Patient Assessment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "243",
+              "title": "Paramedic Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic Clinical I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "Paramedic Medical Emergencies I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Trauma Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "Paramedic Special Populations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "Paramedic Transition to the Workforce",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Advanced Competencies for Paramedic",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "Paramedic Field Preceptorship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "Paramedic Team Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "3D Graphics Technician, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/engineering-graphics/3d-graphics-technician-stc",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Required Field of Concentration Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "144",
+              "title": "Basic 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "233",
+              "title": "Intermediate 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "244",
+              "title": "Advanced 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services-AEMT Short Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/emergency-medical-services/emergency-medical-servicesaemt-short-certificate",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "SHORT CERTIFICATE CURRICULUM ADVANCED EMERGENCY MEDICAL TECHNICIAN",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "Advanced Emergency Medical Technician Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Graphics Technician, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/engineering-graphics/architectural-graphics-technician-stc",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Required Field of Concentration Courses",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "150",
+              "title": "Theory of Residential Drawing and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "155",
+              "title": "Drawing for Residential Construction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "216",
+              "title": "Design of Structural Wood Members",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Graphics, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/engineering-graphics/engineering-graphics-aas",
+      "total_credits": 50,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 47,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "104",
+              "title": "Basic Computer-Aided Drafting and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "111",
+              "title": "Fundamentals of Drafting and Design Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "124",
+              "title": "Basic Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "127",
+              "title": "Intermediate Computer-Aided Drafting and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "128",
+              "title": "Intermediate Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "144",
+              "title": "Basic 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "106",
+              "title": "Workplace Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "150",
+              "title": "Theory of Residential Drawing and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "155",
+              "title": "Drawing for Residential Construction",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "213",
+              "title": "Civil Drafting, Plat Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "216",
+              "title": "Design of Structural Wood Members",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "225",
+              "title": "Structural Steel Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "233",
+              "title": "Intermediate 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "244",
+              "title": "Advanced 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Industrial Systems Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/industrial-systems-technology/industrial-systems-technology-aas",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHS",
+              "number": "112",
+              "title": "Physical Science II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "105",
+              "title": "Introduction to Process Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "119",
+              "title": "Principles of Mechanical Measurement and Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "123",
+              "title": "Concepts of Solid State Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "132",
+              "title": "Preventive and Predictive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "139",
+              "title": "Introduction to Robot Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "208",
+              "title": "Advanced Process Simulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "Advanced Programmable Logic Controllers (PLC's)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems Technology: FAME - Advanced Manufacturing, A.A.S",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/industrial-systems-technology/industrial-systems-technology-fame-advanced-manufacturing-aas",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area II: Humanities and Fine Arts",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "140",
+              "title": "F.A.M.E. MANUFACTURING CORE EXERCISE 1, SAFETY CULTURE",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "142",
+              "title": "F.A.M.E. MANUFACTURING CORE EXERCISE 2, WORKPLACE VISUAL ORGANIZATION (5S)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "144",
+              "title": "F.A.M.E. MANUFACTURING CORE EXERCISE 3, LEAN MANUFACTURING",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "146",
+              "title": "F.A.M.E. MANUFACTURING CORE EXERCISE 4, PROBLEM SOLVING",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "148",
+              "title": "F.A.M.E. MANUFACTURING CORE EXERCISE 5, MACHINE RELIABILITY",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHS",
+              "number": "112",
+              "title": "Physical Science II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Pre-Professional, Pre-Major, and Elective Courses",
+          "credits_required": 52,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORT",
+              "number": "100",
+              "title": "Orientation for Career Students",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "119",
+              "title": "Principles of Mechanical Measurement and Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "PRINCIPLES OF INDUSTRIAL PUMPS AND PIPING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "129",
+              "title": "INDUSTRIAL SAFETY AND MAINTENANCE TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "132",
+              "title": "Preventive and Predictive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "139",
+              "title": "Introduction to Robot Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "Introduction to Programmable Logic Controllers (PLC's)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "208",
+              "title": "Advanced Process Simulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "213",
+              "title": "Industrial Motor Control II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "253",
+              "title": "INDUSTRIAL ROBOTICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "Advanced Programmable Logic Controllers (PLC's)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "107",
+              "title": "Smaw Fillet/OFC/PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Millwright Technician, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/industrial-systems-technology/millwright-technician-stc",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Required Field of Concentration Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "119",
+              "title": "Principles of Mechanical Measurement and Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "132",
+              "title": "Preventive and Predictive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "107",
+              "title": "Smaw Fillet/OFC/PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Masonry, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/masonry/masonry-stc",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Required Field of Concentration Courses",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAS",
+              "number": "111",
+              "title": "Masonry Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "121",
+              "title": "Brick/Block Masonry Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "131",
+              "title": "Brick/Block Masonry Fundamentals II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "151",
+              "title": "Brick/Block Masonry Fundamentals III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "161",
+              "title": "Block Masonry Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "162",
+              "title": "Brick Masonry Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "211",
+              "title": "Stone Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "251",
+              "title": "Stone Masonry Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting (MAT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/medical-assisting/medical-assisting-mat",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 56,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "102",
+              "title": "Medical Assisting Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Medical Assisting Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "Clinical Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Medical Administrative Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Medical Administrative Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "122",
+              "title": "Basic Concepts of Interpersonal Relationships",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "125",
+              "title": "Laboratory Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "128",
+              "title": "Medical Law and Ethics for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "130",
+              "title": "Medical Office Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "200",
+              "title": "Management of Office Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "211",
+              "title": "Clinical Procedures II for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "215",
+              "title": "Laboratory Procedures II for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "216",
+              "title": "Medical Pharmacology for the Medical Office",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Medical Office Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "227",
+              "title": "Special Topics in Medical Assisting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "228",
+              "title": "Medical Assistant Review Course",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "229",
+              "title": "Medical Assistant Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "EKG Technician Short Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/medical-assisting/ekg-technician-short-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Required Field of Concentration Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "Cardiopulmonary Resuscitation I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "102",
+              "title": "Medical Assisting Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Medical Assisting Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "Clinical Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "122",
+              "title": "Basic Concepts of Interpersonal Relationships",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "128",
+              "title": "Medical Law and Ethics for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "211",
+              "title": "Clinical Procedures II for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nail Technology, STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/nail-technology/nail-technology-stc",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Required Field of Concentration Courses",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "148",
+              "title": "Nail Care Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "152",
+              "title": "Nail Care Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "149",
+              "title": "Nail Art Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "154",
+              "title": "Nail Art Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "119",
+              "title": "Business of Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "167",
+              "title": "State Board Review",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "181",
+              "title": "Special Topics Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "182",
+              "title": "Special Topics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "106",
+              "title": "Workplace Skills",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate Degree Nursing (ADN)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/nursing-associate-degree-in-nursing/associate-degree-nursing-adn",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "102",
+              "title": "Fundamentals of Nursing",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "103",
+              "title": "Health Assessment",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "104",
+              "title": "Introduction to Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "105",
+              "title": "Adult Nursing",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "106",
+              "title": "Maternal and Child Nursing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "201",
+              "title": "Nursing Through the Lifespan I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "202",
+              "title": "Nursing Through the Lifespan II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "203",
+              "title": "Nursing Through the Lifespan III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "204",
+              "title": "Role Transition for the Registered Nurse",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "LPN-to-RN Mobility Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/nursing-associate-degree-in-nursing/lpntorn-mobility-concentration",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "199",
+              "title": "LPN to Associate Degree Nursing (RN) Transition",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "202",
+              "title": "Nursing Through the Lifespan II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "203",
+              "title": "Nursing Through the Lifespan III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "204",
+              "title": "Role Transition for the Registered Nurse",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Physical Therapist Assistant (PTA)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/physical-therapist-assistant/physical-therapist-assistant-pta",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HPS",
+              "number": "112",
+              "title": "Medical Terminolgy for Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "200",
+              "title": "PT Issues and Trends",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "201",
+              "title": "PTA Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "202",
+              "title": "PTA Communication Skills",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "204",
+              "title": "PTA Forum I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "220",
+              "title": "Functional Anatomy and Kinesiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "222",
+              "title": "Functional Anatomy and Kinesiology Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "230",
+              "title": "Neuroscience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "231",
+              "title": "Rehabilitation Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "232",
+              "title": "Orthopedics for the PTA",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "240",
+              "title": "Physical Disabilities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "241",
+              "title": "Physical Disabilities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "250",
+              "title": "Therapeutic Procedures I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "251",
+              "title": "Therapeutic Procedures II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "253",
+              "title": "Therapeutic Procedures III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "260",
+              "title": "Clinical Education I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "261",
+              "title": "Clinical Education II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "266",
+              "title": "CLINICAL FIELD WORK I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "268",
+              "title": "Clinical Practicum",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "290",
+              "title": "Therapeutic Exercise",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/practical-nursing/practical-nursing",
+      "total_credits": 50,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "102",
+              "title": "Fundamentals of Nursing",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "103",
+              "title": "Health Assessment",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "104",
+              "title": "Introduction to Pharmacology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "105",
+              "title": "Adult Nursing",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "106",
+              "title": "Maternal and Child Nursing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "107",
+              "title": "Adult/Child Nursing I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "108",
+              "title": "Psychosocial Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "109",
+              "title": "Role Transition for the Practical Nurse",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Surgical Technology (SUR)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/surgical-technology/surgical-technology-sur",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AREA I: WRITTEN COMPOSITION",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AREA III: NATURAL SCIENCES AND MATHEMATICS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AREA IV HISTORY, SOCIAL AND BEHAVIORAL SCIENCE",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AREA V: CAREER AND TECHNICAL COURSES",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "101",
+              "title": "Introduction to Surgical Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "102",
+              "title": "Applied Surgical Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "103",
+              "title": "Surgical Procedures",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "104",
+              "title": "Surgical Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "105",
+              "title": "Surgical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "106",
+              "title": "Role Transition in Surgical Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "108",
+              "title": "Pharmacology for the Surgical Technologist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "203",
+              "title": "Surgical Procedures II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "204",
+              "title": "Surgical Practicum III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "205",
+              "title": "Surgical Practicum IV",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology (RAD)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/radiologic-technology/radiologic-technology-rad",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 54,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "111",
+              "title": "Introduction to Radiography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "112",
+              "title": "Radiography Procedures",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "113",
+              "title": "Patient Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "114",
+              "title": "Clinical Education I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "122",
+              "title": "Radiographic Procedures II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "124",
+              "title": "Clinical Education II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "125",
+              "title": "Imaging Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "134",
+              "title": "Clinical Education III",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "135",
+              "title": "Exposure Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "136",
+              "title": "Radiation Protection and Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "212",
+              "title": "Image Evaluation and Pathology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "214",
+              "title": "Clinical Education IV",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "224",
+              "title": "Clinical Education V",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "227",
+              "title": "Review Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapist (RPT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/respiratory-therapist/respiratory-therapist-rpt",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 52,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "266",
+              "title": "Advanced CV Life Support",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "210",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "211",
+              "title": "Introduction to Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "212",
+              "title": "Fundamentals of Respiratory Care I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "213",
+              "title": "Anatomy and Physiology for the RCP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "214",
+              "title": "Pharmacology for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "220",
+              "title": "Clinical Practice II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "221",
+              "title": "Pathology for the RCP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "222",
+              "title": "Fundamentals of Respiratory Care II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "223",
+              "title": "Acid/Base Regulation and ABG Analysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "230",
+              "title": "Clinical Practice III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "231",
+              "title": "Pathology for the RCP II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "232",
+              "title": "Diagnostic Procedures for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "233",
+              "title": "Special Procedures for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "234",
+              "title": "Mechanical Ventilation for the RCP",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "240",
+              "title": "Clinical Practice IV",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "241",
+              "title": "Rehabilitation and Home Care for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "242",
+              "title": "Perinatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "243",
+              "title": "Computer Applications for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "244",
+              "title": "Critical Care Considerations for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology, Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wallace.edu/welding-technology/welding-technology-certificate",
+      "total_credits": 49,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Career and Technical Courses",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "107",
+              "title": "Smaw Fillet/OFC/PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "115",
+              "title": "GTAW Carbon Pipe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding Groove",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "Smaw Fillet/OFC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "Smaw Fillet/PAC/CAC/Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "Shielded Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "155",
+              "title": "GTAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "157",
+              "title": "Consumable Welding Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "221",
+              "title": "Pipefitting and Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "228",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "268",
+              "title": "Gas Tungsten Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/al/programs/george-c-wallace-state-community-college-hanceville.json
+++ b/data/al/programs/george-c-wallace-state-community-college-hanceville.json
@@ -1,0 +1,26494 @@
+{
+  "college_slug": "george-c-wallace-state-community-college-hanceville",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://wallacestate.cleancatalog.net/degrees",
+  "scraped_at": "2026-06-03T21:27:30.873Z",
+  "programs": [
+    {
+      "title": "Advanced Automotive Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/advanced-automotive-technology/advanced-automotive-technology",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "101",
+              "title": "Fundamentals of Automotive Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "121",
+              "title": "Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "122",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "130",
+              "title": "Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "124",
+              "title": "Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "162",
+              "title": "Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "220",
+              "title": "Advanced Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "235",
+              "title": "Transmissions and Transaxles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "133",
+              "title": "Motor Vehicle Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "239",
+              "title": "Engine Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "244",
+              "title": "Engine Performance and Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "246",
+              "title": "Automotive Emissions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "212",
+              "title": "Advanced Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "250",
+              "title": "Hybrid & Electric Vehicle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "260",
+              "title": "Light Duty Diesel",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Advanced Automotive Technology - Under Hood/Drivability Specialist",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/advanced-automotive-technology/advanced-automotive-technology-under-hooddrivability-specialist",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "101",
+              "title": "Fundamentals of Automotive Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "124",
+              "title": "Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "162",
+              "title": "Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "220",
+              "title": "Advanced Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "133",
+              "title": "Motor Vehicle Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "239",
+              "title": "Engine Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "244",
+              "title": "Engine Performance and Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "246",
+              "title": "Automotive Emissions",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Advanced Automotive Technology - Automotive Service Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/advanced-automotive-technology/advanced-automotive-technology-automotive-service-technology",
+      "total_credits": 55,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "101",
+              "title": "Fundamentals of Automotive Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "121",
+              "title": "Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "122",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "130",
+              "title": "Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "124",
+              "title": "Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "162",
+              "title": "Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "220",
+              "title": "Advanced Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "235",
+              "title": "Transmissions and Transaxles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "133",
+              "title": "Motor Vehicle Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "239",
+              "title": "Engine Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "244",
+              "title": "Engine Performance and Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "246",
+              "title": "Automotive Emissions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "212",
+              "title": "Advanced Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "250",
+              "title": "Hybrid & Electric Vehicle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "260",
+              "title": "Light Duty Diesel",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Horticulture - Greenhouse Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/agriculturehorticulture/horticulture-greenhouse-technician",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GREENHOUSE TECHNICIAN SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOC",
+              "number": "211",
+              "title": "Greenhouse Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "120",
+              "title": "Plant Propagation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "210",
+              "title": "Greenhouse Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "140",
+              "title": "Pest Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "134",
+              "title": "Introduction to Floriculture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Horticulture - Landscape Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/agriculturehorticulture/horticulture-landscape-technician",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "LANDSCAPE TECHNICIAN SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOC",
+              "number": "212",
+              "title": "Landscape Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "136",
+              "title": "Residential Landscape Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "151",
+              "title": "Irrigation Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "218",
+              "title": "Landscape Construction",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Automotive Technology - Under Car/Chassis Specialist",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/advanced-automotive-technology/advanced-automotive-technology-under-carchassis-specialist",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "101",
+              "title": "Fundamentals of Automotive Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "121",
+              "title": "Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "122",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "130",
+              "title": "Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "162",
+              "title": "Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "235",
+              "title": "Transmissions and Transaxles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Advanced Automotive Technology - Electrical Vehicle Specialist in Automotive",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/advanced-automotive-technology/advanced-automotive-technology-electrical-vehicle-specialist-in",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ELECTRICAL VEHICLE SPECIALIST IN AUTOMOTIVE SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "162",
+              "title": "Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "212",
+              "title": "Advanced Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "250",
+              "title": "Hybrid & Electric Vehicle",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Horticulture Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/agriculturehorticulture/horticulture-technology-0",
+      "total_credits": 58,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "110",
+              "title": "Introduction to Horticulture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "115",
+              "title": "Soils & Fertilizers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "130",
+              "title": "Nursery Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "135",
+              "title": "Ornamental Plant Identification and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOC",
+              "number": "211",
+              "title": "Greenhouse Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "120",
+              "title": "Plant Propagation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "210",
+              "title": "Greenhouse Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "140",
+              "title": "Pest Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "134",
+              "title": "Introduction to Floriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOC",
+              "number": "125",
+              "title": "Turf Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "111",
+              "title": "Horticultural Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGP",
+              "number": "152",
+              "title": "Agricultural Equipment Repair and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "230",
+              "title": "Vegetable and Orchard Crops",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOC",
+              "number": "212",
+              "title": "Landscape Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "136",
+              "title": "Residential Landscape Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "151",
+              "title": "Irrigation Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "218",
+              "title": "Landscape Construction",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Horticulture Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/agriculturehorticulture/horticulture-technology",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "110",
+              "title": "Introduction to Horticulture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "115",
+              "title": "Soils & Fertilizers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "130",
+              "title": "Nursery Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "135",
+              "title": "Ornamental Plant Identification and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOC",
+              "number": "211",
+              "title": "Greenhouse Crop Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "120",
+              "title": "Plant Propagation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "210",
+              "title": "Greenhouse Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "140",
+              "title": "Pest Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "134",
+              "title": "Introduction to Floriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOC",
+              "number": "125",
+              "title": "Turf Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "111",
+              "title": "Horticultural Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGP",
+              "number": "152",
+              "title": "Agricultural Equipment Repair and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "230",
+              "title": "Vegetable and Orchard Crops",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOC",
+              "number": "212",
+              "title": "Landscape Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "136",
+              "title": "Residential Landscape Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "151",
+              "title": "Irrigation Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "218",
+              "title": "Landscape Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Horticulture - Nursery Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/agriculturehorticulture/horticulture-nursery-technician",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "NURSERY TECHNICIAN SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOC",
+              "number": "110",
+              "title": "Introduction to Horticulture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "115",
+              "title": "Soils & Fertilizers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "130",
+              "title": "Nursery Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "135",
+              "title": "Ornamental Plant Identification and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Flight Technology - Commercial Airplane",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/aviationflight-technology/flight-technology-commercial-airplane",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS COMMERCIAL AIRPLANE – Guided Pathway/Map",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "111",
+              "title": "Private Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "112",
+              "title": "Professional Pilot Airplane Lab 1 (pvt)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "241",
+              "title": "Instrument Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "122",
+              "title": "Professional Pilot Airplane Lab 2 (pvt)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "132",
+              "title": "Professional Pilot Airplane Lab 3 (inst)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "121",
+              "title": "Commercial Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "134",
+              "title": "Professional Pilot Airplane Lab 4 (inst)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "240",
+              "title": "Professional Pilot Airplane Lab 5 (cmml)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "111",
+              "title": "Physical Science",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "242",
+              "title": "Professional Pilot Airplane Lab 6 (cmml)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "112",
+              "title": "Physical Science II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "134",
+              "title": "UAS Operations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Flight Technology - CFI Airplane",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/aviationflight-technology/flight-technology-cfi-airplane",
+      "total_credits": 76,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "111",
+              "title": "Private Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "112",
+              "title": "Professional Pilot Airplane Lab 1 (pvt)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "241",
+              "title": "Instrument Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "122",
+              "title": "Professional Pilot Airplane Lab 2 (pvt)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "132",
+              "title": "Professional Pilot Airplane Lab 3 (inst)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "121",
+              "title": "Commercial Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "134",
+              "title": "Professional Pilot Airplane Lab 4 (inst)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "240",
+              "title": "Professional Pilot Airplane Lab 5 (cmml)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "111",
+              "title": "Physical Science",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "242",
+              "title": "Professional Pilot Airplane Lab 6 (cmml)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "112",
+              "title": "Physical Science II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "134",
+              "title": "UAS Operations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "264",
+              "title": "Flight Instructor Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "281",
+              "title": "Flight Instructor-Airplane, Initial Issuance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "283",
+              "title": "Flight Instructor-Instrument Airplane, Added Rating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "106",
+              "title": "Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Flight Technology - Commercial Helicopter",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/aviationflight-technology/flight-technology-commercial-helicopter",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "111",
+              "title": "Private Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "200",
+              "title": "Professional Pilot Helicopter Lab 1 (pvt)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "241",
+              "title": "Instrument Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "210",
+              "title": "Professional Pilot Helicopter Lab 2 (pvt)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "232",
+              "title": "Professional Pilot Helicopter Lab 3 (inst)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "121",
+              "title": "Commercial Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "234",
+              "title": "Professional Pilot Helicopter Lab 4 (inst)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "213",
+              "title": "Professional Pilot Helicopter Lab 5 (cmml)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "111",
+              "title": "Physical Science",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "214",
+              "title": "Professional Pilot Helicopter Lab 6 (cmml)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "134",
+              "title": "UAS Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "112",
+              "title": "Physical Science II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Flight Technology - CFI Helicopter",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/aviationflight-technology/flight-technology-cfi-helicopter-0",
+      "total_credits": 76,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "111",
+              "title": "Private Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "200",
+              "title": "Professional Pilot Helicopter Lab 1 (pvt)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "241",
+              "title": "Instrument Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "210",
+              "title": "Professional Pilot Helicopter Lab 2 (pvt)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "232",
+              "title": "Professional Pilot Helicopter Lab 3 (inst)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "121",
+              "title": "Commercial Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "234",
+              "title": "Professional Pilot Helicopter Lab 4 (inst)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "213",
+              "title": "Professional Pilot Helicopter Lab 5 (cmml)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "111",
+              "title": "Physical Science",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "214",
+              "title": "Professional Pilot Helicopter Lab 6 (cmml)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "134",
+              "title": "UAS Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "112",
+              "title": "Physical Science II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "264",
+              "title": "Flight Instructor Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "285",
+              "title": "Flight Instructor-Helicopter, Initial Issuance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "287",
+              "title": "Flight Instructor Instrument-Helicopter, Added Rating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "106",
+              "title": "Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Flight Technology - Commercial Pilot Airplane",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/aviationflight-technology/flight-technology-commercial-pilot-airplane",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "121",
+              "title": "Commercial Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "240",
+              "title": "Professional Pilot Airplane Lab 5 (cmml)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "242",
+              "title": "Professional Pilot Airplane Lab 6 (cmml)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Flight Technology - Instrument Pilot Airplane Rating",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/aviationflight-technology/flight-technology-instrument-pilot-airplane-rating",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "INSTRUMENT PILOT AIRPLANE RATING SHORT-TERM CERTIFICATE– Guided Pathway/Map",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "241",
+              "title": "Instrument Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "132",
+              "title": "Professional Pilot Airplane Lab 3 (inst)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "134",
+              "title": "Professional Pilot Airplane Lab 4 (inst)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Flight Technology - Private Pilot Airplane",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/aviationflight-technology/flight-technology-private-pilot-airplane",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PRIVATE PILOT AIRPLANE SHORT-TERM CERTIFICATE– Guided Pathway/Map",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "111",
+              "title": "Private Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "112",
+              "title": "Professional Pilot Airplane Lab 1 (pvt)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "122",
+              "title": "Professional Pilot Airplane Lab 2 (pvt)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Flight Technology - Private Pilot Helicopter",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/aviationflight-technology/flight-technology-private-pilot-helicopter",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PRIVATE PILOT HELICOPTER SHORT-TERM CERTIFICATE– Guided Pathway/Map",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "111",
+              "title": "Private Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "200",
+              "title": "Professional Pilot Helicopter Lab 1 (pvt)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "210",
+              "title": "Professional Pilot Helicopter Lab 2 (pvt)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Salon and Spa Management - Barbering",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/barbering/salon-and-spa-management-barbering",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "108",
+              "title": "Introduction to Barbering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "109",
+              "title": "Bacteriology and Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "111",
+              "title": "Introduction to Barbering Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "143",
+              "title": "Specialty Hair Preparation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAR",
+              "number": "112",
+              "title": "Science of Barbering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "113",
+              "title": "Fundamentals of Barbering Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "121",
+              "title": "Chemical Hair Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "144",
+              "title": "Hair Shaping and Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAR",
+              "number": "122",
+              "title": "Hair Coloring Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "124",
+              "title": "Hair Coloring Methodology Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "143",
+              "title": "State Board Review",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "115",
+              "title": "Cutting and Styling Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "Salon Management Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "201",
+              "title": "Entrepreneurship for Salon/Spa",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "190",
+              "title": "Internship in Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Education & Office Administration - Accounting Applications",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-education-office-administration/business-education-office-administration-accounting",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records/Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "243",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "137",
+              "title": "Computerized Financial Record Keeping",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "136",
+              "title": "Advanced Financial Record Keeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "248",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Education & Office Administration - Accounting",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-education-office-administration/business-education-office-administration-accounting-0",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records/Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "136",
+              "title": "Advanced Financial Record Keeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "244",
+              "title": "Database Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "243",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "248",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "197",
+              "title": "Advanced Commercial Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "137",
+              "title": "Computerized Financial Record Keeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "211",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Education & Office Administration - Administrative Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-education-office-administration/business-education-office-administration-administrative",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records/Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "110",
+              "title": "Computer Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "247",
+              "title": "Special Projects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "217",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "243",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "134",
+              "title": "Career & Professional Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "242",
+              "title": "Office Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "246",
+              "title": "Office Graphics and Presentations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "211",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Math",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Flight Technology - Commercial Pilot Helicopter",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/aviationflight-technology/flight-technology-commercial-pilot-helicopter",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "COMMERCIAL PILOT HELICOPTER SHORT-TERM CERTIFICATE– Guided Pathway/Map",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "121",
+              "title": "Commercial Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "213",
+              "title": "Professional Pilot Helicopter Lab 5 (cmml)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "214",
+              "title": "Professional Pilot Helicopter Lab 6 (cmml)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Flight Technology - Instrument Pilot Helicopter Rating",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/aviationflight-technology/flight-technology-instrument-pilot-helicopter-rating",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "INSTRUMENT PILOT HELICOPTER RATING SHORT-TERM CERTIFICATE– Guided Pathway/Map",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "241",
+              "title": "Instrument Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "232",
+              "title": "Professional Pilot Helicopter Lab 3 (inst)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "234",
+              "title": "Professional Pilot Helicopter Lab 4 (inst)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Education & Office Administration - General Office Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-education-office-administration/business-education-office-administration-general-office",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records/Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "243",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "246",
+              "title": "Office Graphics and Presentations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Math",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Education & Office Administration - Human Resource Applications",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-education-office-administration/business-education-office-administration-human-resource",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records/Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Education & Office Administration - Medical Administrative Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-education-office-administration/business-education-office-administration-medical",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records/Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POL",
+              "number": "211",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "214",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "233",
+              "title": "Trends in Office Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "243",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "160",
+              "title": "HIT Professional Practices Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "244",
+              "title": "Database Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Flight Technology - Certified Flight Instructor",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/aviationflight-technology/flight-technology-certified-flight-instructor",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "CERTIFIED FLIGHT INSTRUCTOR SHORT-TERM CERTIFICATE– Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FLT",
+              "number": "264",
+              "title": "Flight Instructor Ground",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "281",
+              "title": "Flight Instructor-Airplane, Initial Issuance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FLT",
+              "number": "283",
+              "title": "Flight Instructor-Instrument Airplane, Added Rating",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management & Supervision - Banking and Finance",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-banking-and-finance",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS BANKING AND FINANCE - Guided Pathway/Map",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BFN",
+              "number": "100",
+              "title": "Principles of Banking",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BFN",
+              "number": "101",
+              "title": "Law and Banking: Principles",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "113",
+              "title": "Spreadsheet Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BFN",
+              "number": "102",
+              "title": "Law and Banking: Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "266",
+              "title": "Entrepreneurial Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BFN",
+              "number": "280",
+              "title": "Real Estate Finance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BFN",
+              "number": "205",
+              "title": "Money and Banking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Education & Office Administration - Medical Office Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-education-office-administration/business-education-office-administration-medical-office",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records/Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "214",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "233",
+              "title": "Trends in Office Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "243",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "160",
+              "title": "HIT Professional Practices Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "215",
+              "title": "Health Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Horticulture - Turf Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/agriculturehorticulture/horticulture-turf-technician",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "TURF TECHNICIAN SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOC",
+              "number": "125",
+              "title": "Turf Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "111",
+              "title": "Horticultural Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGP",
+              "number": "152",
+              "title": "Agricultural Equipment Repair and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOC",
+              "number": "230",
+              "title": "Vegetable and Orchard Crops",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management & Supervision - Banking and Finance",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-banking-and-finance-0",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "BANKING AND FINANCE SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BFN",
+              "number": "100",
+              "title": "Principles of Banking",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BFN",
+              "number": "101",
+              "title": "Law and Banking: Principles",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BFN",
+              "number": "102",
+              "title": "Law and Banking: Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "266",
+              "title": "Entrepreneurial Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BFN",
+              "number": "280",
+              "title": "Real Estate Finance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BFN",
+              "number": "205",
+              "title": "Money and Banking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Education & Office Administration - Software Applications",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-education-office-administration/business-education-office-administration-software",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "243",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "244",
+              "title": "Database Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "246",
+              "title": "Office Graphics and Presentations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "247",
+              "title": "Special Projects",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management & Supervision - Business Supervision",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-business-supervision",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "248",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "266",
+              "title": "Entrepreneurial Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management & Supervision - Entrepreneurship Applications",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-entrepreneurship-applications",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "265",
+              "title": "Entrepreneurial Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "279",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETP",
+              "number": "266",
+              "title": "Entrepreneurial Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "267",
+              "title": "Innovation And Creativity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "268",
+              "title": "Business Planning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management & Supervision - Financial Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-financial-management",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "137",
+              "title": "Computerized Financial Record Keeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "266",
+              "title": "Entrepreneurial Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "248",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "272",
+              "title": "Business Statistics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "113",
+              "title": "Spreadsheet Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "247",
+              "title": "Special Projects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "211",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management & Supervision - Business Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-business-management",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "211",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "248",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "267",
+              "title": "Innovation And Creativity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "266",
+              "title": "Entrepreneurial Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "298",
+              "title": "Directed Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management & Supervision - Entrepreneurship",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-entrepreneurship",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "211",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "248",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "265",
+              "title": "Entrepreneurial Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "279",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "266",
+              "title": "Entrepreneurial Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "267",
+              "title": "Innovation And Creativity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "268",
+              "title": "Business Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "113",
+              "title": "Spreadsheet Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management & Supervision - Financial Applications",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-financial-applications",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETP",
+              "number": "266",
+              "title": "Entrepreneurial Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "248",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "272",
+              "title": "Business Statistics II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management & Supervision - Logistics Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-logistics-management-0",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "211",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "101",
+              "title": "Transportation & Distribution Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "127",
+              "title": "Logistics and Regulatory Compliance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "108",
+              "title": "Introduction to Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "110",
+              "title": "Warehouse Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "113",
+              "title": "Spreadsheet Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "132",
+              "title": "Physical Distribution Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "290",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "112",
+              "title": "Warehouse Operations Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "125",
+              "title": "Foundational Knowledge of Supply Chain Logistics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management & Supervision - Human Resource Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-human-resource-management",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management & Supervision - Office Supervision",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-office-supervision",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Child Development",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/child-development/child-development",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "CHILD DEVELOPMENT SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "Child Growth and Development Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Program Planning for Educating Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Educating Children with Exceptional Needs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Child Development - Early Childhood Education I",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/child-development/child-development-early-childhood-education-i",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall or Summer Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Child Development",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/child-development/child-development-0",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "Infant and Toddler Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "English Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "202",
+              "title": "Children’s Creative Experiences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children’s Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "Child Growth and Development Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Program Planning for Educating Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "Administration of Child Development Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Educating Children with Exceptional Needs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "214",
+              "title": "Families and Communities in Early Care and Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "215",
+              "title": "Supervised Practical Experience in Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Child Development",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/child-development/child-development-1",
+      "total_credits": 38,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Spring Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "Child Growth and Development Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Program Planning for Educating Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Educating Children with Exceptional Needs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "Infant and Toddler Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children’s Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Child Development - Infant/Toddler",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/child-development/child-development-infanttoddler",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall or Summer Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "Infant and Toddler Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Child Development - Early Childhood Education II",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/child-development/child-development-early-childhood-education-ii",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall, Spring or Summer Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children’s Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Child Development - Preschool/Family Child Care I",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/child-development/child-development-preschoolfamily-child-care-i",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall or Summer Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Business Management & Supervision - Logistics Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-logistics-management",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "LOGISTICS MANAGEMENT SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LGT",
+              "number": "101",
+              "title": "Transportation & Distribution Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "112",
+              "title": "Warehouse Operations Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "125",
+              "title": "Foundational Knowledge of Supply Chain Logistics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LGT",
+              "number": "127",
+              "title": "Logistics and Regulatory Compliance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "108",
+              "title": "Introduction to Logistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "110",
+              "title": "Warehouse Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LGT",
+              "number": "132",
+              "title": "Physical Distribution Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "290",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Child Development - Preschool/Family Child Care II",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/child-development/child-development-preschoolfamily-child-care-ii",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall or Summer Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children’s Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "Administration of Child Development Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "214",
+              "title": "Families and Communities in Early Care and Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Computer Science - Artificial Intelligence Programming",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/computer-science/computer-science-artificial-intelligence-programming",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ARTIFICAL INTELLIGENCE PROGRAMMING SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "150",
+              "title": "Introduction to Computer Logic and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "235",
+              "title": "Data Analytics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Science – Cyber Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/computer-science/computer-science-cyber-technician",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "CYBER TECHNICIAN SHORT-TERM CERTIFICATE − Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "214",
+              "title": "Pen Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "Cyber Defense",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "211",
+              "title": "Principles of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Science - Data Analytics",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/computer-science/computer-science-data-analytics",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "DATA ANALYTICS SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "272",
+              "title": "Business Statistics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "235",
+              "title": "Data Analytics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Science - Cybersecurity and Networking Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/computer-science/computer-science-cybersecurity-and-networking-technology",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "270",
+              "title": "Cisco CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "Cyber Defense",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "214",
+              "title": "Pen Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "271",
+              "title": "Cisco CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "211",
+              "title": "Principles of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "267",
+              "title": "Enterprise Virtualization",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "281",
+              "title": "System Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "294",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Science - Electric Vehicle in Cybersecurity",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/computer-science/computer-science-electric-vehicle-in-cybersecurity",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "Cyber Defense",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Science - Programming",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/computer-science/computer-science-programming",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAMMING SHORT-TERM CERTIFICATE − Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "150",
+              "title": "Introduction to Computer Logic and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "255",
+              "title": "JAVA Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Business Management & Supervision - Office Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/business-management-supervision/business-management-supervision-office-management",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "137",
+              "title": "Computerized Financial Record Keeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "113",
+              "title": "Spreadsheet Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "211",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "247",
+              "title": "Special Projects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "217",
+              "title": "Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Computer Science - Programming",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/computer-science/computer-science-programming-0",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "150",
+              "title": "Introduction to Computer Logic and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "211",
+              "title": "Principles of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "212",
+              "title": "Visual Basic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "255",
+              "title": "JAVA Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "222",
+              "title": "Database Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "294",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "281",
+              "title": "System Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "235",
+              "title": "Data Analytics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Science – Information Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/computer-science/computer-science-information-technology",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "INFORMATION TECHNOLOGY SHORT-TERM CERTIFICATE − Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "211",
+              "title": "Principles of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Science – Systems Engineering Technology (SET)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/computer-science/computer-science-systems-engineering-technology-set",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1 (Fall)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "150",
+              "title": "Introduction to Computer Logic and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "222",
+              "title": "Database Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "101",
+              "title": "Introduction to Systems Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2 (Spring)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "231",
+              "title": "Systems Modeling I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3 (Fall)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "255",
+              "title": "JAVA Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "211",
+              "title": "Principles of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "221",
+              "title": "MBSE in Digital Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "232",
+              "title": "Systems Modeling II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 (Spring)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "233",
+              "title": "Systems Modeling III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "241",
+              "title": "Systems Engineering Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Criminal Justice - Corrections",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/criminal-justice/criminal-justice-corrections",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "150",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "156",
+              "title": "Correctional Institutions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "157",
+              "title": "Community Based Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "259",
+              "title": "Issues in Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "256",
+              "title": "Correctional Rehabilitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "212",
+              "title": "Correctional Counseling Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Computer Science - Systems Engineering Technology (SET) -- Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/computer-science/computer-science-systems-engineering-technology-set-shortterm-certificate",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SYS",
+              "number": "101",
+              "title": "Introduction to Systems Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "231",
+              "title": "Systems Modeling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "221",
+              "title": "MBSE in Digital Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "232",
+              "title": "Systems Modeling II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "233",
+              "title": "Systems Modeling III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "241",
+              "title": "Systems Engineering Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Criminal Justice - Forensic Investigation",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/criminal-justice/criminal-justice-forensic-investigation",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "230",
+              "title": "Criminalistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "237",
+              "title": "Forensic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "178",
+              "title": "Narcotics/Dangerous Drugs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "236",
+              "title": "Advanced Criminalistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "147",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "238",
+              "title": "Crime Scene Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "226",
+              "title": "Fingerprint Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "222",
+              "title": "Introduction to Forensic Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "227",
+              "title": "Homicide Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "220",
+              "title": "Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "280",
+              "title": "Internship in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "146",
+              "title": "Criminal Evidence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "177",
+              "title": "Criminal and Deviant Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice - Crime Scene Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/criminal-justice/criminal-justice-crime-scene-technician",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "CRIME SCENE TECHNICIAN SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "237",
+              "title": "Forensic Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "238",
+              "title": "Crime Scene Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "226",
+              "title": "Fingerprint Science",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice - Law Enforcement",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/criminal-justice/criminal-justice-law-enforcement",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "220",
+              "title": "Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "140",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "177",
+              "title": "Criminal and Deviant Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "116",
+              "title": "Police Patrol",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "147",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "238",
+              "title": "Crime Scene Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "227",
+              "title": "Homicide Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "290",
+              "title": "Selected Topics - Seminar in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "230",
+              "title": "Criminalistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "280",
+              "title": "Internship in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "178",
+              "title": "Narcotics/Dangerous Drugs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "239",
+              "title": "Issues in Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "209",
+              "title": "Juvenile Delinquency",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice - Law Enforcement",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/criminal-justice/criminal-justice-law-enforcement-0",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "220",
+              "title": "Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "178",
+              "title": "Narcotics/Dangerous Drugs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "177",
+              "title": "Criminal and Deviant Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "116",
+              "title": "Police Patrol",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "147",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "227",
+              "title": "Homicide Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice - Private Security",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/criminal-justice/criminal-justice-private-security",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "160",
+              "title": "Introduction to Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "166",
+              "title": "Private and Retail Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "167",
+              "title": "Industrial Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Computer Science – Network Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/computer-science/computer-science-network-technician",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "NETWORK TECHNICIAN SHORT-TERM CERTIFICATE − Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "270",
+              "title": "Cisco CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "271",
+              "title": "Cisco CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "267",
+              "title": "Enterprise Virtualization",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Science - Data Analytics",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/computer-science/computer-science-data-analytics-1",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "211",
+              "title": "Principles of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "235",
+              "title": "Data Analytics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "150",
+              "title": "Introduction to Computer Logic and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "248",
+              "title": "Introduction to IOT (Internet of Things)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "222",
+              "title": "Database Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "294",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "272",
+              "title": "Business Statistics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "281",
+              "title": "System Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Culinary Arts",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/culinary-arts/culinary-arts-0",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "271",
+              "title": "Management of Food and Beverage Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "112",
+              "title": "Sanitation, Safety, and Food Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "125",
+              "title": "Food Preparation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "115",
+              "title": "Advanced Food Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "213",
+              "title": "Food Purchasing and Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "262",
+              "title": "Restaurant Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "101",
+              "title": "Orientation to the Hospitality Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "111",
+              "title": "Foundations in Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "201",
+              "title": "Meat Preparation and Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "203",
+              "title": "Stocks and Sauces",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "122",
+              "title": "Fundamentals of Quantity Cooking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "204",
+              "title": "Foundations of Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "102",
+              "title": "Catering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "208",
+              "title": "Advanced Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "205",
+              "title": "Intro to Garde Manger",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "215",
+              "title": "Regional Cuisines of the Americas",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts - Advanced Culinary Arts",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/culinary-arts/culinary-arts-advanced-culinary-arts",
+      "total_credits": 38,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "112",
+              "title": "Sanitation, Safety, and Food Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "125",
+              "title": "Food Preparation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "115",
+              "title": "Advanced Food Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "262",
+              "title": "Restaurant Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "101",
+              "title": "Orientation to the Hospitality Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "203",
+              "title": "Stocks and Sauces",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "122",
+              "title": "Fundamentals of Quantity Cooking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "204",
+              "title": "Foundations of Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "205",
+              "title": "Intro to Garde Manger",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "215",
+              "title": "Regional Cuisines of the Americas",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/dental-assisting/dental-assisting",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "100",
+              "title": "Introduction to Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "101",
+              "title": "Pre-Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "102",
+              "title": "Dental Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "103",
+              "title": "Dental Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "104",
+              "title": "Basic Sciences for Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAT",
+              "number": "111",
+              "title": "Clinical Practice I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "112",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "113",
+              "title": "Dental Health Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "116",
+              "title": "Pre-Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAT",
+              "number": "114",
+              "title": "Dental Office Administration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "122",
+              "title": "Clinical Practice II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "141",
+              "title": "Directed Studies in Dental Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "124",
+              "title": "Clinically Applied Infection Control & OSHA Standards",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/dental-assisting/dental-assisting-0",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "100",
+              "title": "Introduction to Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "101",
+              "title": "Pre-Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "102",
+              "title": "Dental Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "103",
+              "title": "Dental Anatomy and Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "104",
+              "title": "Basic Sciences for Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAT",
+              "number": "111",
+              "title": "Clinical Practice I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "112",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "113",
+              "title": "Dental Health Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "116",
+              "title": "Pre-Clinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAT",
+              "number": "114",
+              "title": "Dental Office Administration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "122",
+              "title": "Clinical Practice II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "141",
+              "title": "Directed Studies in Dental Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "124",
+              "title": "Clinically Applied Infection Control & OSHA Standards",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Imaging",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/diagnostic-imaging/diagnostic-imaging",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "111",
+              "title": "Introduction to Radiography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "112",
+              "title": "Radiography Procedures I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "113",
+              "title": "Patient Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "114",
+              "title": "Clinical Education I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "125",
+              "title": "Imaging Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "122",
+              "title": "Radiographic Procedures II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "124",
+              "title": "Clinical Education II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "135",
+              "title": "Exposure Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "136",
+              "title": "Radiation Protection and Biology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "204",
+              "title": "Clinical Education III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "212",
+              "title": "Image Evaluation and Pathology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "214",
+              "title": "Clinical Education IV",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "227",
+              "title": "Review Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/dental-hygiene/dental-hygiene",
+      "total_credits": 76,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS DENTAL HYGIENE – Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHY",
+              "number": "110",
+              "title": "Dental Hygiene Theory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "112",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "114",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "116",
+              "title": "Dental Anatomy, Histology & Embryology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "118",
+              "title": "Anatomy, Embryology & Histology of the Head and Neck",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHY",
+              "number": "120",
+              "title": "Dental Materials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "122",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "124",
+              "title": "Dental Hygiene Theory II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "126",
+              "title": "Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "128",
+              "title": "Pharmacology / Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHY",
+              "number": "130",
+              "title": "Biological Chemistry and Applied Nutrition",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "132",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "134",
+              "title": "Dental Hygiene Theory III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "216",
+              "title": "Dental Research",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "104",
+              "title": "Introduction to Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHY",
+              "number": "210",
+              "title": "General and Oral Pathology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "212",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "214",
+              "title": "Dental Hygiene Theory IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "217",
+              "title": "Community Dental Health",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHY",
+              "number": "218",
+              "title": "Clinical Dental Hygiene IV",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "220",
+              "title": "Dental Hygiene Theory V",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiation Therapy",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/diagnostic-imaging/radiation-therapy",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "113",
+              "title": "Patient Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "114",
+              "title": "Clinical Education I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "120",
+              "title": "Introduction to Radiation Therapy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "125",
+              "title": "Imaging Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "141",
+              "title": "Radiobiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "234",
+              "title": "Pathophysiology and Sectional Anatomy",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "124",
+              "title": "Clinical Education II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "230",
+              "title": "Radiation Therapy Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "232",
+              "title": "Principles and Practice I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "236",
+              "title": "Treatment Planning",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "204",
+              "title": "Clinical Education III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "242",
+              "title": "Principles and Practice II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "214",
+              "title": "Clinical Education IV",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "245",
+              "title": "Radiation Therapy Review Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - Abdominal/Vascular",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/diagnostic-medical-sonography/diagnostic-medical-sonography-abdominalvascular",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Technical Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "202",
+              "title": "Foundations of Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "205",
+              "title": "Abdominal Sonography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "216",
+              "title": "Sonographic Principles & Instrumentation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "229",
+              "title": "Sonography Preceptorship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "261",
+              "title": "Vascular Sonography Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "207",
+              "title": "Abdominal Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "217",
+              "title": "Sonographic Principles & Instrumentation II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "230",
+              "title": "Sonography Preceptorship II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "234",
+              "title": "Sonography Lab II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "263",
+              "title": "Pathology of Vascular Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "225",
+              "title": "Superficial Sonography",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "231",
+              "title": "Sonography Preceptorship III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "235",
+              "title": "Sonography Lab III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "240",
+              "title": "Sonography Seminar I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "232",
+              "title": "Sonography Preceptorship IV",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "241",
+              "title": "Sonography Seminar II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "245",
+              "title": "Sonography Case Presentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "250",
+              "title": "Introduction to Advanced Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - Corrections",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/criminal-justice/criminal-justice-corrections-0",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "150",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "156",
+              "title": "Correctional Institutions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "178",
+              "title": "Narcotics/Dangerous Drugs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "157",
+              "title": "Community Based Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "177",
+              "title": "Criminal and Deviant Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "259",
+              "title": "Issues in Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "238",
+              "title": "Crime Scene Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "147",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "227",
+              "title": "Homicide Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "280",
+              "title": "Internship in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "256",
+              "title": "Correctional Rehabilitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "212",
+              "title": "Correctional Counseling Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Introduction to Geology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Diagnostic Medical Sonography - Cardiovascular",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/diagnostic-medical-sonography/diagnostic-medical-sonography-cardiovascular",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Technical Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "202",
+              "title": "Foundations of Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "216",
+              "title": "Sonographic Principles & Instrumentation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "229",
+              "title": "Sonography Preceptorship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "233",
+              "title": "Sonography Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "271",
+              "title": "Echocardiographic Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "217",
+              "title": "Sonographic Principles & Instrumentation II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "230",
+              "title": "Sonography Preceptorship II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "234",
+              "title": "Sonography Lab II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "261",
+              "title": "Vascular Sonography Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "273",
+              "title": "Pathology of the Cardiovascular System",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "231",
+              "title": "Sonography Preceptorship III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "235",
+              "title": "Sonography Lab III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "240",
+              "title": "Sonography Seminar I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "263",
+              "title": "Pathology of Vascular Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "232",
+              "title": "Sonography Preceptorship IV",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "241",
+              "title": "Sonography Seminar II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "245",
+              "title": "Sonography Case Presentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "275",
+              "title": "Advanced Echocardiographic Modalities",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - Obstetrics & Gynecology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/diagnostic-medical-sonography/diagnostic-medical-sonography-obstetrics-gynecology",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Technical Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "202",
+              "title": "Foundations of Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "206",
+              "title": "Gynecologic Sonography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "216",
+              "title": "Sonographic Principles & Instrumentation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "220",
+              "title": "Obstetrical Sonography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "229",
+              "title": "Sonography Preceptorship I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "205",
+              "title": "Abdominal Sonography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "217",
+              "title": "Sonographic Principles & Instrumentation II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "221",
+              "title": "Obstetrical Sonography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "223",
+              "title": "Breast Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "230",
+              "title": "Sonography Preceptorship II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "240",
+              "title": "Sonography Seminar I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "222",
+              "title": "Advanced Maternal Fetal Sonography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "231",
+              "title": "Sonography Preceptorship III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "241",
+              "title": "Sonography Seminar II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "245",
+              "title": "Sonography Case Presentation",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - Forensic Psychology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/criminal-justice/criminal-justice-forensic-psychology",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "222",
+              "title": "Introduction to Forensic Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "280",
+              "title": "Brain, Mind, and Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "207",
+              "title": "Psychology of Adjustment",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "208",
+              "title": "Contemporary Issues in Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Diesel Technology - Commercial Transportation Specialist",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/diesel-technology/diesel-technology-commercial-transportation-specialist",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "COMMERCIAL TRANSPORTATION SPECIALIST SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "105",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "154",
+              "title": "Vehicle Maintenance & Safe Operating Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "156",
+              "title": "CDL License Test Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - Diesel Engine Specialist",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/diesel-technology/diesel-technology-diesel-engine-specialist",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "DIESEL ENGINE SPECIALIST SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "104",
+              "title": "Basic Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "124",
+              "title": "Electronic Engine Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "126",
+              "title": "Advanced Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "127",
+              "title": "Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - Heavy Duty Electrical Vehicle Specialist",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/diesel-technology/diesel-technology-heavy-duty-electrical-vehicle-specialist",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "HEAVY DUTY ELECTRICAL VEHICLE SPECIALIST IN DIESEL SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "105",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "125",
+              "title": "Heavy Vehicle Drive Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "130",
+              "title": "Electrical/Electronic Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "234",
+              "title": "Diesel Electronic Systems (Cab/Chassis)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/diesel-technology/diesel-technology-0",
+      "total_credits": 55,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "105",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "122",
+              "title": "Heavy Vehicle Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "123",
+              "title": "Pneumatics and Hydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "130",
+              "title": "Electrical/Electronic Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "135",
+              "title": "Heavy Vehicle Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "104",
+              "title": "Basic Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "124",
+              "title": "Electronic Engine Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "126",
+              "title": "Advanced Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "127",
+              "title": "Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "139",
+              "title": "Diesel Emissions and After-treatment Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "154",
+              "title": "Vehicle Maintenance & Safe Operating Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "156",
+              "title": "CDL License Test Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "137",
+              "title": "Heating, Air Conditioning/Refrigeration Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "234",
+              "title": "Diesel Electronic Systems (Cab/Chassis)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "118",
+              "title": "Industrial and Agricultural Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "125",
+              "title": "Heavy Vehicle Drive Trains",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology - Preventive Maintenance Specialist",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/diesel-technology/diesel-technology-preventive-maintenance-specialist",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PREVENTIVE MAINTENANCE SPECIALIST SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "105",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "122",
+              "title": "Heavy Vehicle Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "135",
+              "title": "Heavy Vehicle Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "130",
+              "title": "Electrical/Electronic Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/culinary-arts/culinary-arts",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "112",
+              "title": "Sanitation, Safety, and Food Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "125",
+              "title": "Food Preparation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "115",
+              "title": "Advanced Food Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "204",
+              "title": "Foundations of Baking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "101",
+              "title": "Orientation to the Hospitality Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "203",
+              "title": "Stocks and Sauces",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "122",
+              "title": "Fundamentals of Quantity Cooking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "205",
+              "title": "Intro to Garde Manger",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - Electric Vehicle Charging Infrastructure",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electrical-technology/electrical-technology-electric-vehicle-charging-infrastructure",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ELECTRIC VEHICLE CHARGING INFRASTRUCTURE SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "231",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "181",
+              "title": "Special Topics in ILT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "132",
+              "title": "Commercial/Industrial Wiring II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "225",
+              "title": "Smart House Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electrical-technology/electrical-technology-0",
+      "total_credits": 58,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "160",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "161",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "138",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "197",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "231",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "166",
+              "title": "Motors and Transformers I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "194",
+              "title": "Intro. to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "104",
+              "title": "Distribution System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "117",
+              "title": "Principles of Construction Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "167",
+              "title": "AC/DC Machinery and Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "169",
+              "title": "Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "181",
+              "title": "Special Topics in ILT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "132",
+              "title": "Commercial/Industrial Wiring II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "225",
+              "title": "Smart House Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electrical-technology/electrical-technology",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "160",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "161",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "138",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "197",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "231",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "166",
+              "title": "Motors and Transformers I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "194",
+              "title": "Intro. to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "104",
+              "title": "Distribution System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "117",
+              "title": "Principles of Construction Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "167",
+              "title": "AC/DC Machinery and Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "169",
+              "title": "Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "181",
+              "title": "Special Topics in ILT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "132",
+              "title": "Commercial/Industrial Wiring II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "225",
+              "title": "Smart House Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - Electricity and Controls Level 1",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electrical-technology/electrical-technology-electricity-and-controls-level-1",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ELECTRICITY AND CONTROLS LEVEL 1 SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "138",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "160",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "161",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - Electricity and Controls Level 2",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electrical-technology/electrical-technology-electricity-and-controls-level-2",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ELECTRICITY AND CONTROLS LEVEL 2 SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "197",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - Wiring Applications Level 1",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electrical-technology/electrical-technology-wiring-applications-level-1",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "WIRING APPLICATIONS LEVEL 1 SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "166",
+              "title": "Motors and Transformers I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "194",
+              "title": "Intro. to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "231",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - Wiring Applications Level 2",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electrical-technology/electrical-technology-wiring-applications-level-2",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "WIRING APPLICATIONS LEVEL 2 SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "104",
+              "title": "Distribution System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "117",
+              "title": "Principles of Construction Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "167",
+              "title": "AC/DC Machinery and Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "169",
+              "title": "Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electro Automation - Advanced Automation, Robotics & Control with Integration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electro-automation-mechatronics/electro-automation-advanced-automation-robotics-control-with",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ADVANCED AUTOMATION, ROBOTICS & CONTROLS WITH INTERGRATION SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "210",
+              "title": "Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "102",
+              "title": "Industrial Automation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electro Automation - ElectroAutomation Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electro-automation-mechatronics/electro-automation-electroautomation-technology",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "160",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "161",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "162",
+              "title": "Solid State Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "163",
+              "title": "Digital Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "197",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "164",
+              "title": "Circuit Fabrication I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "194",
+              "title": "Intro. to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "175",
+              "title": "Computer Fundamentals for Technology Students",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "218",
+              "title": "Industrial Robotics Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "169",
+              "title": "Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "195",
+              "title": "Troubleshooting Techniques I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "196",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "210",
+              "title": "Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "102",
+              "title": "Industrial Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electro Automation - Basic Automation, Robotics and Controls",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electro-automation-mechatronics/electro-automation-basic-automation-robotics-and-controls",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "BASIC AUTOMATION, ROBOTICS AND CONTROLS SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "194",
+              "title": "Intro. to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "175",
+              "title": "Computer Fundamentals for Technology Students",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "218",
+              "title": "Industrial Robotics Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electro Automation - Basic Electronics",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electro-automation-mechatronics/electro-automation-basic-electronics",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "BASIC ELECTRONICS SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "160",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "161",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electro Automation - ElectroAutomation Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electro-automation-mechatronics/electro-automation-electroautomation-technology-0",
+      "total_credits": 53,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "160",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "161",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "162",
+              "title": "Solid State Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "163",
+              "title": "Digital Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "197",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "164",
+              "title": "Circuit Fabrication I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "194",
+              "title": "Intro. to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "175",
+              "title": "Computer Fundamentals for Technology Students",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "218",
+              "title": "Industrial Robotics Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "169",
+              "title": "Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "195",
+              "title": "Troubleshooting Techniques I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "196",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "210",
+              "title": "Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "102",
+              "title": "Industrial Automation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electro Automation - Intermediate Automation, Robotics and Controls",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electro-automation-mechatronics/electro-automation-intermediate-automation-robotics-and-controls",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "INTERMEDIATE AUTOMATION, ROBOTICS AND CONTROLS SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "169",
+              "title": "Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "195",
+              "title": "Troubleshooting Techniques I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "196",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - AAS Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/emergency-medical-services/emergency-medical-services-aas-degree",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "107",
+              "title": "Emergency Vehicle Operator Ambulance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Paramedic Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Cardiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic Patient Assessment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic Clinical I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "Paramedic Applied Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "Paramedic Medical Emergencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Trauma Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "Paramedic Special Populations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "Paramedic Transition to the Workforce",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Advanced Competencies for the Paramedic",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "Paramedic Field Preceptorship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "Paramedic Team Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electro Automation - FAME",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electro-automation-mechatronics/electro-automation-fame",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FAME SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "186",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "147",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "150",
+              "title": "FAME Manufacturing Core Exercise 1, Safety Culture",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "152",
+              "title": "FAME Manufacturing Core Exercise 2",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "154",
+              "title": "FAME Manufacturing Core Exercise 3",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "156",
+              "title": "FAME Manufacturing Core Exercise 4",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "158",
+              "title": "FAME Manufacturing Core Exercise 5",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/diesel-technology/diesel-technology",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "105",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "122",
+              "title": "Heavy Vehicle Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "123",
+              "title": "Pneumatics and Hydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "130",
+              "title": "Electrical/Electronic Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "135",
+              "title": "Heavy Vehicle Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "104",
+              "title": "Basic Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "124",
+              "title": "Electronic Engine Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "126",
+              "title": "Advanced Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "127",
+              "title": "Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "139",
+              "title": "Diesel Emissions and After-treatment Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "137",
+              "title": "Heating, Air Conditioning/Refrigeration Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "154",
+              "title": "Vehicle Maintenance & Safe Operating Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "156",
+              "title": "CDL License Test Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "234",
+              "title": "Diesel Electronic Systems (Cab/Chassis)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "118",
+              "title": "Industrial and Agricultural Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "125",
+              "title": "Heavy Vehicle Drive Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - EMT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/emergency-medical-services/emergency-medical-services-emt",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "EMT SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "107",
+              "title": "Emergency Vehicle Operator Ambulance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Advanced EMT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/emergency-medical-services/emergency-medical-services-advanced-emt",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Advanced EMT SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "Advanced Emergency Medical Technician Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/emergency-medical-services/emergency-medical-services-paramedic",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "107",
+              "title": "Emergency Vehicle Operator Ambulance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Paramedic Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Cardiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic Patient Assessment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic Clinical I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "Paramedic Applied Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "Paramedic Medical Emergencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Trauma Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "Paramedic Special Populations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "Paramedic Transition to the Workforce",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Advanced Competencies for the Paramedic",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "Paramedic Field Preceptorship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "Paramedic Team Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services w/Advanced - AAS Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/emergency-medical-services/emergency-medical-services-wadvanced-aas-degree",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "107",
+              "title": "Emergency Vehicle Operator Ambulance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "Advanced Emergency Medical Technician Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Paramedic Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Cardiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic Patient Assessment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic Clinical I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "Paramedic Applied Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "Paramedic Medical Emergencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Trauma Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "Paramedic Special Populations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "Paramedic Transition to the Workforce",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Advanced Competencies for the Paramedic",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "Paramedic Field Preceptorship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "Paramedic Team Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/engineering-technology/engineering-technology",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "102",
+              "title": "Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "100",
+              "title": "Engineering Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "125",
+              "title": "Modern Graphics for Engineers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "212",
+              "title": "CAD for Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDT",
+              "number": "205",
+              "title": "Fundamentals of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "114",
+              "title": "10 Hour OSHA Construction Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "128",
+              "title": "Advanced Computer Aided Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "108",
+              "title": "Intro to 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "127",
+              "title": "Mechanical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "215",
+              "title": "Architectural Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "100",
+              "title": "Engineering Blueprints",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "208",
+              "title": "Intermediate 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "261",
+              "title": "Reverse Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDT",
+              "number": "221",
+              "title": "Structural Drafting for Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AET",
+              "number": "245",
+              "title": "Advanced Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "217",
+              "title": "Machine Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "261",
+              "title": "HVAC and Pipe Systems Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Advanced Engineering Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/engineering-technology/advanced-engineering-technology",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "102",
+              "title": "Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "125",
+              "title": "Modern Graphics for Engineers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "100",
+              "title": "Engineering Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "212",
+              "title": "CAD for Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "113",
+              "title": "Precalculus Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "108",
+              "title": "Intro to 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "114",
+              "title": "10 Hour OSHA Construction Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "160",
+              "title": "Additive Mfg. Production Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENT",
+              "number": "127",
+              "title": "Mechanical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "125",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "100",
+              "title": "Engineering Blueprints",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "208",
+              "title": "Intermediate 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "261",
+              "title": "Reverse Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "217",
+              "title": "Machine Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering Technology - Construction Basics",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/engineering-technology/engineering-technology-construction-basics",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMT",
+              "number": "101",
+              "title": "Construction Materials and Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "290",
+              "title": "Building Information Modeling (BIM)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDT",
+              "number": "205",
+              "title": "Fundamentals of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "156",
+              "title": "Contracting and Construction Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMT",
+              "number": "102",
+              "title": "Construction Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "205",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "220",
+              "title": "Sustainable Project Delivery",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering Technology - Advanced Design",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/engineering-technology/engineering-technology-advanced-design",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "102",
+              "title": "Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "108",
+              "title": "Intro to 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "208",
+              "title": "Intermediate 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "261",
+              "title": "Reverse Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "245",
+              "title": "Advanced Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering Technology - Basic AutoCAD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/engineering-technology/engineering-technology-basic-autocad",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "BASIC AUTOCAD SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "102",
+              "title": "Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "125",
+              "title": "Modern Graphics for Engineers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "212",
+              "title": "CAD for Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering Technology - Construction Management Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/engineering-technology/engineering-technology-construction-management-technology",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "102",
+              "title": "Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "175",
+              "title": "Electrical and Plumbing Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "101",
+              "title": "Construction Materials and Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "290",
+              "title": "Building Information Modeling (BIM)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDT",
+              "number": "205",
+              "title": "Fundamentals of Surveying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUC",
+              "number": "133",
+              "title": "Building Codes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "125",
+              "title": "Modern Graphics for Engineers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "156",
+              "title": "Contracting and Construction Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "114",
+              "title": "Design Innovation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "114",
+              "title": "10 Hour OSHA Construction Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "102",
+              "title": "Construction Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "221",
+              "title": "Energy Design of Buildings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUC",
+              "number": "142",
+              "title": "Construction Estimating",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUC",
+              "number": "150",
+              "title": "Homebuilders License Exam Review",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "205",
+              "title": "Construction Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "220",
+              "title": "Sustainable Project Delivery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Engineering Technology - Digital Fabrication",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/engineering-technology/engineering-technology-digital-fabrication",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "102",
+              "title": "Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "130",
+              "title": "Introduction to Materials and Finishes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "100",
+              "title": "Engineering Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "108",
+              "title": "Intro to 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "160",
+              "title": "Additive Mfg. Production Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "210",
+              "title": "Design for Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "114",
+              "title": "10 Hour OSHA Construction Safety",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENT",
+              "number": "127",
+              "title": "Mechanical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "155",
+              "title": "Manufacturing Projects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDT",
+              "number": "100",
+              "title": "Engineering Blueprints",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "277",
+              "title": "Industrial Energy Sources & Sustainability",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "261",
+              "title": "Reverse Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "216",
+              "title": "Industrial Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AET",
+              "number": "245",
+              "title": "Advanced Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "217",
+              "title": "Machine Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "157",
+              "title": "Material Properties",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering Technology - Construction Science",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/engineering-technology/engineering-technology-construction-science",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "CONSTRUCTION SCIENCE SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMT",
+              "number": "175",
+              "title": "Electrical and Plumbing Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "101",
+              "title": "Construction Materials and Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "290",
+              "title": "Building Information Modeling (BIM)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Business Administration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/business-administration",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "English Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "111",
+              "title": "Physical Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "262",
+              "title": "English Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "120",
+              "title": "Calculus and Its Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "272",
+              "title": "Business Statistics II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Agriculture/Horticulture - Poultry Science 2+2",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/agriculturehorticulture-poultry-science-22",
+      "total_credits": 129,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "113",
+              "title": "Precalculus Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGP",
+              "number": "130",
+              "title": "Poultry Production",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "221",
+              "title": "Organic Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "125",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGP",
+              "number": "130",
+              "title": "Poultry Production",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "221",
+              "title": "Organic Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "222",
+              "title": "Organic Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Technology - Mechanical Engineering",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/engineering-technology/engineering-technology-mechanical-engineering",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "102",
+              "title": "Computer Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "108",
+              "title": "Intro to 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "208",
+              "title": "Intermediate 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "261",
+              "title": "Reverse Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AET",
+              "number": "245",
+              "title": "Advanced Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "127",
+              "title": "Mechanical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "128",
+              "title": "Advanced Computer Aided Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "217",
+              "title": "Machine Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Child Development Apprenticeship",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/child-development-apprenticeship",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "110",
+              "title": "Finite Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "Administration of Child Development Programs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "Infant and Toddler Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children’s Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Electro Automation - Intermediate Electronics",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/electro-automation-mechatronics/electro-automation-intermediate-electronics",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "INTERMEDIATE ELECTRONICS SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "162",
+              "title": "Solid State Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "163",
+              "title": "Digital Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "197",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "164",
+              "title": "Circuit Fabrication I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/criminal-justice",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "147",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "238",
+              "title": "Crime Scene Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "220",
+              "title": "Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "140",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Cybersecurity",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/cybersecurity",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "113",
+              "title": "Precalculus Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "211",
+              "title": "Principles of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "125",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "Cyber Defense",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "126",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dance - Choreography",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/dance-choreography",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNC",
+              "number": "143",
+              "title": "Ballet Technique I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "151",
+              "title": "Elementary Jazz I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "111",
+              "title": "Elementary Modern Dance I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "234",
+              "title": "Choreography I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "161",
+              "title": "Dance Workshop II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNC",
+              "number": "144",
+              "title": "Ballet Technique II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "243",
+              "title": "Ballet Technique III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "235",
+              "title": "Choreography II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "260",
+              "title": "Dance Workshop IV",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dance - Ballet Pedagogy",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/dance-ballet-pedagogy",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNC",
+              "number": "143",
+              "title": "Ballet Technique I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "191",
+              "title": "Pointe Technique I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "281",
+              "title": "Dance Pedagogy I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "234",
+              "title": "Choreography I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNC",
+              "number": "282",
+              "title": "Pedagogy II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "192",
+              "title": "Pointe Technique II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "144",
+              "title": "Ballet Technique II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "283",
+              "title": "Dance Pedagogy Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "260",
+              "title": "Dance Workshop IV",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dance Education",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/dance-education",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "143",
+              "title": "Ballet Technique I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "191",
+              "title": "Pointe Technique I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "281",
+              "title": "Dance Pedagogy I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "101",
+              "title": "Dance Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "234",
+              "title": "Choreography I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "282",
+              "title": "Pedagogy II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "161",
+              "title": "Dance Workshop II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "192",
+              "title": "Pointe Technique II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "151",
+              "title": "Elementary Jazz I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "162",
+              "title": "Dance Workshop III",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "102",
+              "title": "Introduction to Humanities II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "144",
+              "title": "Ballet Technique II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "283",
+              "title": "Dance Pedagogy Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "260",
+              "title": "Dance Workshop IV",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dance Performance",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/dance-performance",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "143",
+              "title": "Ballet Technique I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "151",
+              "title": "Elementary Jazz I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "160",
+              "title": "Dance Workshop I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "101",
+              "title": "Dance Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "111",
+              "title": "Elementary Modern Dance I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "234",
+              "title": "Choreography I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "161",
+              "title": "Dance Workshop II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "144",
+              "title": "Ballet Technique II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "191",
+              "title": "Pointe Technique I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "162",
+              "title": "Dance Workshop III",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "102",
+              "title": "Introduction to Humanities II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "243",
+              "title": "Ballet Technique III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "235",
+              "title": "Choreography II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "260",
+              "title": "Dance Workshop IV",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Education",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/general-education",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Introduction to Geology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Forensic Psychology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/forensic-psychology",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "222",
+              "title": "Introduction to Forensic Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "280",
+              "title": "Brain, Mind, and Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "207",
+              "title": "Psychology of Adjustment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "208",
+              "title": "Contemporary Issues in Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "177",
+              "title": "Criminal and Deviant Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "238",
+              "title": "Crime Scene Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Early Childhood Education",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/early-childhood-education",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "Infant and Toddler Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "110",
+              "title": "Finite Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Introduction to Geology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Forensic Psychology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/forensic-psychology-0",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "222",
+              "title": "Introduction to Forensic Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "280",
+              "title": "Brain, Mind, and Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "207",
+              "title": "Psychology of Adjustment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "208",
+              "title": "Contemporary Issues in Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Global Studies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/global-studies",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Introductory Spanish I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Introduction to Geology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "100",
+              "title": "World Regional Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "106",
+              "title": "Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "102",
+              "title": "Introductory Spanish II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEO",
+              "number": "101",
+              "title": "Principles of Physical Geography I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "271",
+              "title": "World Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "History of World Religions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "230",
+              "title": "Comparative Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies/Liberal Arts",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/general-studiesliberal-arts",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "224",
+              "title": "Personal and Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Introduction to Geology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Health and Wellness Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/health-and-wellness-management",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "224",
+              "title": "Personal and Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "First Aid",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "232",
+              "title": "Care and Prevention of Athletic Injuries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Liberal Arts/General Studies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/liberal-artsgeneral-studies",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "120",
+              "title": "Theater Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "224",
+              "title": "Personal and Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Introduction to Geology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Logistics and Supply Chain Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/logistics-and-supply-chain-management",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AS LOGISTICS AND SUPPLY CHAIN MANAGEMENT - Guided Pathway/Map",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "English Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "272",
+              "title": "Business Statistics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Manufacturing Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/manufacturing-management",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Studies with Concentration in Manufacturing Management - Guided Pathway/Map",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "111",
+              "title": "Physical Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "101",
+              "title": "Principles of Physical Geography I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "272",
+              "title": "Business Statistics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Corrections",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/corrections",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "150",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Introduction to Geology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "156",
+              "title": "Correctional Institutions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "157",
+              "title": "Community Based Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "280",
+              "title": "Internship in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "212",
+              "title": "Correctional Counseling Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "259",
+              "title": "Issues in Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "102",
+              "title": "Introduction to Geology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "256",
+              "title": "Correctional Rehabilitation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Pre-Engineering",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/preengineering",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "125",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "126",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "213",
+              "title": "General Physics with CAL I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "227",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "214",
+              "title": "General Physics with CAL II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Pre-Education",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/preeducation",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "First Aid",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POL",
+              "number": "211",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "111",
+              "title": "Physical Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Nursing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/prenursing",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "104",
+              "title": "Introduction to Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Information Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/information-technology",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "120",
+              "title": "Calculus and Its Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "272",
+              "title": "Business Statistics II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Religious Studies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/religious-studies-0",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "RELIGIOUS STUDIES SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "History of World Religions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "119",
+              "title": "Interpreting the Bible",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "151",
+              "title": "Survey of the Old Testament",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "152",
+              "title": "Survey of the New Testament",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "206",
+              "title": "History of American Christianity",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Work Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/social-work-technician",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWT",
+              "number": "130",
+              "title": "The Community and the Social Worker",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SWT",
+              "number": "131",
+              "title": "Problems of Children and Youth",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWT",
+              "number": "299",
+              "title": "Special Topics in Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sports Administration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/sports-administration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "205",
+              "title": "Introduction to Sports Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "224",
+              "title": "Personal and Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Introduction to Geology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "206",
+              "title": "Current Issues in Sports Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "Cardiopulmonary Resuscitation I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "100",
+              "title": "Fundamentals of Fitness",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "First Aid",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sports Medicine",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/sports-medicine",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "224",
+              "title": "Personal and Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "First Aid",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "232",
+              "title": "Care and Prevention of Athletic Injuries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "100",
+              "title": "Fundamentals of Fitness",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "200",
+              "title": "Foundations of Physical Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "295",
+              "title": "Practicum in Physical Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Art & Design",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/graphic-art-design/graphic-art-design",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "221",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "172",
+              "title": "Digital Illustration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "180",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCM",
+              "number": "145",
+              "title": "Introduction to Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "216",
+              "title": "Printmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "243",
+              "title": "Sculpture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "127",
+              "title": "Three Dimensional Composition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Music Education",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/music-education",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "111",
+              "title": "Music Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "113",
+              "title": "Music Theory Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Music Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "114",
+              "title": "Music Theory Lab II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "211",
+              "title": "Music Theory III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "213",
+              "title": "Music Theory Lab III",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "212",
+              "title": "Music Theory IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "214",
+              "title": "Music Theory Lab IV",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Art & Design - 2D & 3D Studio",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/graphic-art-design/graphic-art-design-2d-3d-studio",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Two Dimensional Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "216",
+              "title": "Printmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "243",
+              "title": "Sculpture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "127",
+              "title": "Three Dimensional Composition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Graphic Art & Design - 2D Studio Art",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/graphic-art-design/graphic-art-design-2d-studio-art",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "2D STUDIO ART EMPHASIS SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "216",
+              "title": "Printmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "243",
+              "title": "Sculpture I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Programming",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/programming",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "113",
+              "title": "Precalculus Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "125",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "126",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "227",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Art & Design",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/graphic-art-design/graphic-art-design-0",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS–GRAPHIC ART & DESIGN - Guided Pathway/Map",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "221",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "283",
+              "title": "Graphic Animation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCM",
+              "number": "281",
+              "title": "Digital Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "172",
+              "title": "Digital Illustration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Two Dimensional Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCM",
+              "number": "180",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "145",
+              "title": "Introduction to Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "216",
+              "title": "Printmaking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "243",
+              "title": "Sculpture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Introduction to Geology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VCM",
+              "number": "270",
+              "title": "Supervised Study in Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "289",
+              "title": "Portfolio",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "250",
+              "title": "Introduction to Technical Illustration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "127",
+              "title": "Three Dimensional Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "203",
+              "title": "Art History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Religious Studies",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/general-studies/religious-studies",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "History of World Religions",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "106",
+              "title": "Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "119",
+              "title": "Interpreting the Bible",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "101",
+              "title": "Introduction to Geology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "151",
+              "title": "Survey of the Old Testament",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "102",
+              "title": "Introduction to Geology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "152",
+              "title": "Survey of the New Testament",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "206",
+              "title": "History of American Christianity",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Information Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/health-information-technology/health-information-technology",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "115",
+              "title": "Pathophysiology and Pharmacology for HIT",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "134",
+              "title": "HIT Legal and Ethical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "154",
+              "title": "Health Data Content and Structure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "158",
+              "title": "Introduction to the Clinical Environment for HIT",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "294",
+              "title": "Current Trends in Health Information",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "131",
+              "title": "Classification Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "132",
+              "title": "Revenue Cycle Management and Documentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "160",
+              "title": "HIT Professional Practices Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "223",
+              "title": "Data Management for HIT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "230",
+              "title": "Medical Coding Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "232",
+              "title": "Medical Coding Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "240",
+              "title": "Ambulatory Coding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "255",
+              "title": "Principles of Supervision in HIT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "291",
+              "title": "CCS Exam Preparation",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "254",
+              "title": "Organizational Improvement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "292",
+              "title": "HIT Exam Review",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "296",
+              "title": "Professional Practices Simulations",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Medical Scribe",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/health-information-technology/medical-scribe",
+      "total_credits": 43,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "115",
+              "title": "Pathophysiology and Pharmacology for HIT",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "134",
+              "title": "HIT Legal and Ethical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "154",
+              "title": "Health Data Content and Structure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "158",
+              "title": "Introduction to the Clinical Environment for HIT",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "294",
+              "title": "Current Trends in Health Information",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "160",
+              "title": "HIT Professional Practices Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "223",
+              "title": "Data Management for HIT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Billing and Coding",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/health-information-technology/medical-billing-and-coding",
+      "total_credits": 57,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "115",
+              "title": "Pathophysiology and Pharmacology for HIT",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "134",
+              "title": "HIT Legal and Ethical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "154",
+              "title": "Health Data Content and Structure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "158",
+              "title": "Introduction to the Clinical Environment for HIT",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "294",
+              "title": "Current Trends in Health Information",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "131",
+              "title": "Classification Skills Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "132",
+              "title": "Revenue Cycle Management and Documentation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "160",
+              "title": "HIT Professional Practices Experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "223",
+              "title": "Data Management for HIT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "230",
+              "title": "Medical Coding Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "232",
+              "title": "Medical Coding Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "240",
+              "title": "Ambulatory Coding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "291",
+              "title": "CCS Exam Preparation",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Information",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/health-information-technology/health-information",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "294",
+              "title": "Current Trends in Health Information",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "115",
+              "title": "Pathophysiology and Pharmacology for HIT",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts - Hotel and Restaurant Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/hotel-and-restaurant-management/culinary-arts-hotel-and-restaurant-management",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "112",
+              "title": "Sanitation, Safety, and Food Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "125",
+              "title": "Food Preparation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMM",
+              "number": "240",
+              "title": "Hospitality Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "122",
+              "title": "Fundamentals of Quantity Cooking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "111",
+              "title": "Foundations in Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMM",
+              "number": "241",
+              "title": "Restaurant Service Management I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "101",
+              "title": "Orientation to the Hospitality Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "262",
+              "title": "Restaurant Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "213",
+              "title": "Food Purchasing and Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMM",
+              "number": "251",
+              "title": "Front Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMM",
+              "number": "120",
+              "title": "Beverage Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "163",
+              "title": "Foundation of Healthy Cooking Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Culinary Arts - Hotel and Restaurant Management Level 2",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/hotel-and-restaurant-management/culinary-arts-hotel-and-restaurant-management-level-2",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "HOTEL AND RESTAURANT MANAGEMENT LEVEL 2 SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "111",
+              "title": "Foundations in Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMM",
+              "number": "240",
+              "title": "Hospitality Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMM",
+              "number": "241",
+              "title": "Restaurant Service Management I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMM",
+              "number": "251",
+              "title": "Front Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Culinary Arts - Hotel and Restaurant Management Level 1",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/hotel-and-restaurant-management/culinary-arts-hotel-and-restaurant-management-level-1",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "HOTEL AND RESTAURANT MANAGEMENT LEVEL I SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "122",
+              "title": "Fundamentals of Quantity Cooking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "163",
+              "title": "Foundation of Healthy Cooking Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "213",
+              "title": "Food Purchasing and Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Culinary Arts - Culinary and Hospitality Introduction",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/hotel-and-restaurant-management-nutrition-science-management/culinary-arts-culinary-and-hospitality",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "CULINARY AND HOSPITALITY INTRODUCTION SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "101",
+              "title": "Orientation to the Hospitality Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "112",
+              "title": "Sanitation, Safety, and Food Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "125",
+              "title": "Food Preparation",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts - Hotel and Restaurant Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/hotel-and-restaurant-management/culinary-arts-hotel-and-restaurant-management-0",
+      "total_credits": 49,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "112",
+              "title": "Sanitation, Safety, and Food Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "125",
+              "title": "Food Preparation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMM",
+              "number": "240",
+              "title": "Hospitality Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "122",
+              "title": "Fundamentals of Quantity Cooking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "111",
+              "title": "Foundations in Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMM",
+              "number": "241",
+              "title": "Restaurant Service Management I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "101",
+              "title": "Orientation to the Hospitality Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "262",
+              "title": "Restaurant Management and Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "213",
+              "title": "Food Purchasing and Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMM",
+              "number": "251",
+              "title": "Front Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMM",
+              "number": "120",
+              "title": "Beverage Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "163",
+              "title": "Foundation of Healthy Cooking Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "HVAC - Heating Systems Specialist",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/hvacr/hvac-heating-systems-specialist",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "HVAC HEATING SYSTEMS SPECIALIST SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigerant Transition and Recovery Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC - Service Procedure Specialist",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/hvacr/hvac-service-procedure-specialist",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVACR Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVACR Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "127",
+              "title": "HVACR Electric Motors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC - Electrical Specialist",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/hvacr/hvac-electrical-specialist",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "HVAC ELECTRICAL SPECIALIST SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVACR Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVACR Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "127",
+              "title": "HVACR Electric Motors",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC/R Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/hvacr/hvacr-technology",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVACR Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVACR Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "127",
+              "title": "HVACR Electric Motors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "134",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigerant Transition and Recovery Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "203",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "205",
+              "title": "System Sizing and Air Distribution",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Commercial Air Conditioning Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Troubleshooting HVACR Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology – CNC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/machine-tool-technology/machine-tool-technology-cnc",
+      "total_credits": 76,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Print Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "Metrology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "147",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "148",
+              "title": "Introduction to Machine Shop I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "107",
+              "title": "Machining Calculations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "149",
+              "title": "Introduction to Machine Shop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "150",
+              "title": "Introduction to Machine Shop II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "171",
+              "title": "Intermediate Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "112",
+              "title": "Computer Numeric Control Turning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "113",
+              "title": "Computer Numeric Control Milling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "120",
+              "title": "Basic Set-up for Computer Numerical Control Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "221",
+              "title": "Advanced Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "215",
+              "title": "Quality Control and Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "220",
+              "title": "Intermediate Set-up for Computer Numerical Control Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "222",
+              "title": "Computer Numerical Control Graphics: Turning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "223",
+              "title": "Computer Numerical Control Graphics Programming: Milling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "224",
+              "title": "Multi-Axis Turning Programming and Setup",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "225",
+              "title": "Multi-Axis Milling Programming and Setup",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "226",
+              "title": "CNC Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "227",
+              "title": "CNC Additive Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology - Computer Numerical Control",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/machine-tool-technology/machine-tool-technology-computer-numerical-control",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "112",
+              "title": "Computer Numeric Control Turning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "113",
+              "title": "Computer Numeric Control Milling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "120",
+              "title": "Basic Set-up for Computer Numerical Control Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "221",
+              "title": "Advanced Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "215",
+              "title": "Quality Control and Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "220",
+              "title": "Intermediate Set-up for Computer Numerical Control Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "222",
+              "title": "Computer Numerical Control Graphics: Turning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "223",
+              "title": "Computer Numerical Control Graphics Programming: Milling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology - Level I Machine Tool Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/machine-tool-technology/machine-tool-technology-level-i-machine-tool-technology",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Print Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "Metrology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "147",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "148",
+              "title": "Introduction to Machine Shop I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "107",
+              "title": "Machining Calculations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "149",
+              "title": "Introduction to Machine Shop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "150",
+              "title": "Introduction to Machine Shop II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "171",
+              "title": "Intermediate Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology - Tool & Die Repair",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/machine-tool-technology/machine-tool-technology-tool-die-repair-0",
+      "total_credits": 76,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Print Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "Metrology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "147",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "148",
+              "title": "Introduction to Machine Shop I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "107",
+              "title": "Machining Calculations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "149",
+              "title": "Introduction to Machine Shop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "150",
+              "title": "Introduction to Machine Shop II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "171",
+              "title": "Intermediate Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "156",
+              "title": "Jig and Fixture Construction Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "164",
+              "title": "Trim Steel Welding & Grinding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "158",
+              "title": "Die Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "221",
+              "title": "Advanced Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "153",
+              "title": "Pads, Pressures, and Auxiliary Die Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "154",
+              "title": "Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "160",
+              "title": "Die Construction and Tryout",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "161",
+              "title": "Die Maintenance and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "162",
+              "title": "Precision Grinding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "165",
+              "title": "Root Cause Analysis in Die Repair",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "215",
+              "title": "Quality Control and Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "261",
+              "title": "Intermediate Die Maintenance & Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology - Tool & Die Repair",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/machine-tool-technology/machine-tool-technology-tool-die-repair",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "153",
+              "title": "Pads, Pressures, and Auxiliary Die Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "154",
+              "title": "Metallurgy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "160",
+              "title": "Die Construction and Tryout",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "161",
+              "title": "Die Maintenance and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "162",
+              "title": "Precision Grinding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "165",
+              "title": "Root Cause Analysis in Die Repair",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "215",
+              "title": "Quality Control and Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "261",
+              "title": "Intermediate Die Maintenance & Repair",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Art & Design - Digital Graphics",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/graphic-art-design/graphic-art-design-digital-graphics",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "DIGITAL GRAPHICS EMPHASIS SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "221",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "172",
+              "title": "Digital Illustration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "180",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "145",
+              "title": "Introduction to Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Medical Assisting",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/medical-assistant/medical-assisting",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Medical Business Practices I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "Clinical Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "Clinical Specialties for Medical Assistants",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "128",
+              "title": "Medical Law and Ethics for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "102",
+              "title": "Medical Assisting Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Medical Assisting Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "124",
+              "title": "Medical Business Practices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Medical Laboratory Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "214",
+              "title": "Medical Assisting Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "230",
+              "title": "Medical Assistant Preceptorship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "217",
+              "title": "Microscopy for the Medical Office",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "219",
+              "title": "Radiology for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "222",
+              "title": "Medical Transcription I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/medical-laboratory-technician/medical-laboratory-assistant",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "131",
+              "title": "Laboratory Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "132",
+              "title": "Laboratory Techniques II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "286",
+              "title": "Clinical Lab Practicum for MLA",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/medical-assistant/medical-assisting-0",
+      "total_credits": 41,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Medical Business Practices I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "Clinical Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "Clinical Specialties for Medical Assistants",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "128",
+              "title": "Medical Law and Ethics for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "102",
+              "title": "Medical Assisting Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Medical Assisting Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "124",
+              "title": "Medical Business Practices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "126",
+              "title": "Medical Laboratory Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "214",
+              "title": "Medical Assisting Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "230",
+              "title": "Medical Assistant Preceptorship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing - UAB/WSCC Joint Enrollment Program of Study",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/nursing/nursing-uabwscc-joint-enrollment-program-of-study",
+      "total_credits": 165,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "104",
+              "title": "Introduction to Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Fundamental Concepts of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "401",
+              "title": "Professional Nursing Concepts for RNs",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "306",
+              "title": "Joint Enrollment Success",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Nursing Concepts I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "402",
+              "title": "Professional Leadership Development for RNs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "405",
+              "title": "Evidence-Based Nursing Practice and Informatics for RNs",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "7th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Nursing Concepts II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "Evidence Based Clinical Reasoning",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "403",
+              "title": "Systems Leadership for RNs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "8th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "404",
+              "title": "Quality and Patient Safety for RNs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "407",
+              "title": "Transitional Care Coordination Across The Lifespan for RNs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "9th Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence Based Clinical Reasoning",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "406",
+              "title": "Applied Pathophysiology Across the Lifespan for RNs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "408",
+              "title": "Population Health for RNs",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature Courses that can be taken for the sequence (WSCC course options): (Only if ENG 101/102 Completed)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "English Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "262",
+              "title": "English Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "271",
+              "title": "World Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272",
+              "title": "World Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Courses that can be completed for the sequence (WSCC course options):",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/nursing/nursing",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Fundamental Concepts of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Nursing Concepts I",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Nursing Concepts II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "Evidence Based Clinical Reasoning",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence Based Clinical Reasoning",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Medical Laboratory Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/medical-laboratory-technician/medical-laboratory-technician",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "131",
+              "title": "Laboratory Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "111",
+              "title": "Urinalysis and Body Fluids",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "121",
+              "title": "Hematology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "151",
+              "title": "Clinical Chemistry",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "294",
+              "title": "Medical Laboratory Practicum – Hematology and Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "297",
+              "title": "Medical Laboratory Practicum – Chemistry and Immunology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "191",
+              "title": "Clinical Immunohematology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "141",
+              "title": "MLT Microbiology I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "181",
+              "title": "Clinical Immunology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "142",
+              "title": "MLT Microbiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "295",
+              "title": "Medical Laboratory Practicum - Microbiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "296",
+              "title": "Medical Laboratory Practicum - Immunohematology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "293",
+              "title": "MLT Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing - Mobility Track",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/nursing/nursing-mobility-track",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Note the following general education requirements:",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "209",
+              "title": "Concepts for Healthcare Transition Students",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence Based Clinical Reasoning",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - UAB/WSCC Joint Enrollment Program of Study for Mobility Students",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/nursing/nursing-uabwscc-joint-enrollment-program-of-study-for-mobility-students",
+      "total_credits": 150,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "104",
+              "title": "Introduction to Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "209",
+              "title": "Concepts for Healthcare Transition Students",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "306",
+              "title": "Joint Enrollment Success",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "401",
+              "title": "Professional Nursing Concepts for RNs",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "402",
+              "title": "Professional Leadership Development for RNs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "7th Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence Based Clinical Reasoning",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "403",
+              "title": "Systems Leadership for RNs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "405",
+              "title": "Evidence-Based Nursing Practice and Informatics for RNs",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "8th Semester",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NRN",
+              "number": "404",
+              "title": "Quality and Patient Safety for RNs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "407",
+              "title": "Transitional Care Coordination Across The Lifespan for RNs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "9th Semester",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NRN",
+              "number": "406",
+              "title": "Applied Pathophysiology Across the Lifespan for RNs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRN",
+              "number": "408",
+              "title": "Population Health for RNs",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature Courses that can be taken for the sequence (WSCC course options) (Only if ENG 101/102 Completed)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "English Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "262",
+              "title": "English Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "271",
+              "title": "World Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272",
+              "title": "World Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Courses that can be completed for the sequence (WSCC course options):",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Culinary Arts - Culinary/Nutrition Management Level 3",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/nutrition-science-management/culinary-arts-culinarynutrition-management-level-3",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "CULINARY/NUTRITION MANAGEMENT LEVEL 3 SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "111",
+              "title": "Foundations in Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "173",
+              "title": "Culinary Arts Apprenticeship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "123",
+              "title": "Applied Quantity Cooking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Culinary Arts - Culinary/Nutrition Management Level 2",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/nutrition-science-management/culinary-arts-culinarynutrition-management-level-2",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "CULINARY/NUTRITION MANAGEMENT LEVEL 2 SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "213",
+              "title": "Food Purchasing and Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "201",
+              "title": "Meat Preparation and Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "163",
+              "title": "Foundation of Healthy Cooking Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "205",
+              "title": "Intro to Garde Manger",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Culinary Arts - Culinary/Nutrition Management Level 1",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/nutrition-science-management/culinary-arts-culinarynutrition-management-level-1",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "CULINARY/NUTRITION MANAGEMENT LEVEL 1 SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "115",
+              "title": "Advanced Food Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "224",
+              "title": "Personal and Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMM",
+              "number": "105",
+              "title": "Principles of Hospitality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "122",
+              "title": "Fundamentals of Quantity Cooking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Culinary Arts - Culinary/Nutrition Science Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/nutrition-science-management/culinary-arts-culinarynutrition-science-management",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "112",
+              "title": "Sanitation, Safety, and Food Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "125",
+              "title": "Food Preparation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "115",
+              "title": "Advanced Food Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "224",
+              "title": "Personal and Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "111",
+              "title": "Foundations in Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "101",
+              "title": "Orientation to the Hospitality Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "173",
+              "title": "Culinary Arts Apprenticeship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMM",
+              "number": "105",
+              "title": "Principles of Hospitality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "213",
+              "title": "Food Purchasing and Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "201",
+              "title": "Meat Preparation and Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "122",
+              "title": "Fundamentals of Quantity Cooking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "226",
+              "title": "Introduction to Wellness",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "163",
+              "title": "Foundation of Healthy Cooking Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "205",
+              "title": "Intro to Garde Manger",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "123",
+              "title": "Applied Quantity Cooking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "HVAC/R",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/hvacr/hvacr",
+      "total_credits": 55,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVACR Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVACR Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "127",
+              "title": "HVACR Electric Motors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "134",
+              "title": "Ice Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigerant Transition and Recovery Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "203",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "205",
+              "title": "System Sizing and Air Distribution",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Commercial Air Conditioning Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "210",
+              "title": "Troubleshooting HVACR Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts - Culinary/Nutrition Science Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/nutrition-science-management/culinary-arts-culinarynutrition-science-management-0",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "112",
+              "title": "Sanitation, Safety, and Food Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "125",
+              "title": "Food Preparation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "115",
+              "title": "Advanced Food Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "224",
+              "title": "Personal and Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "111",
+              "title": "Foundations in Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "101",
+              "title": "Orientation to the Hospitality Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "173",
+              "title": "Culinary Arts Apprenticeship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMM",
+              "number": "105",
+              "title": "Principles of Hospitality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "213",
+              "title": "Food Purchasing and Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "201",
+              "title": "Meat Preparation and Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "122",
+              "title": "Fundamentals of Quantity Cooking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "226",
+              "title": "Introduction to Wellness",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUA",
+              "number": "163",
+              "title": "Foundation of Healthy Cooking Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "205",
+              "title": "Intro to Garde Manger",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUA",
+              "number": "123",
+              "title": "Applied Quantity Cooking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Paralegal",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/paralegal/paralegal",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "101",
+              "title": "Introduction to Paralegal Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "102",
+              "title": "Basic Legal Research and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "103",
+              "title": "Advanced Legal Research and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "210",
+              "title": "Real Property Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "211",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "160",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "230",
+              "title": "Domestic Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "262",
+              "title": "Civil Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "240",
+              "title": "Wills, Trusts, and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "291",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant (PTA)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/physical-therapist-assistant/physical-therapist-assistant-pta",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester-Fall Semester ONLY",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "200",
+              "title": "PT Issues and Trends",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "202",
+              "title": "PTA Communication Skills",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "220",
+              "title": "Functional Anatomy and Kinesiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "222",
+              "title": "Functional Anatomy and Kinesiology Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "240",
+              "title": "Physical Disabilities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "250",
+              "title": "Therapeutic Procedures I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "258",
+              "title": "Introduction to the Clinical Environment",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "260",
+              "title": "Clinical Education I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester-Spring Semester ONLY",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "230",
+              "title": "Neuroscience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "231",
+              "title": "Rehabilitation Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "232",
+              "title": "Orthopedics for the PTA",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "241",
+              "title": "Physical Disabilities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "251",
+              "title": "Therapeutic Procedures II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "266",
+              "title": "Clinical Field Work I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "290",
+              "title": "Therapeutic Exercise",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester-Summer Semester ONLY",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "201",
+              "title": "PTA Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "268",
+              "title": "Clinical Practicum",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Occupational Therapy Assistant (OTA)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/occupational-therapy-assistant/occupational-therapy-assistant-ota",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Humanities I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OTA",
+              "number": "210",
+              "title": "Occupational Therapy Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "211",
+              "title": "Practical Anatomy & Kinesiology Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "212",
+              "title": "Practical Anatomy and Kinesiology Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "213",
+              "title": "Treatment Planning and Implementation: Part I Theory - Pediatrics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "214",
+              "title": "Treatment Planning and Implementation: Part I Lab - Pediatrics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "217",
+              "title": "Orientation to Fieldwork",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "218",
+              "title": "Level I Fieldwork – A",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "219",
+              "title": "Level I Fieldwork – B",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "221",
+              "title": "Medical Conditions in O.T.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OTA",
+              "number": "215",
+              "title": "The Psychiatric Environment and Group Process in O.T.",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "216",
+              "title": "The Psychiatric Environment and Group Process in O.T. Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "220",
+              "title": "Documentation for the OTA",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "222",
+              "title": "Treatment Planning and Implementation: Part II Theory – Adult",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "223",
+              "title": "Treatment Planning and Implementation: Part II Lab – Adult",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "224",
+              "title": "Occupational Activity Analysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "225",
+              "title": "Occupational Activity Analysis Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "226",
+              "title": "Level II Fieldwork – A",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "227",
+              "title": "Evidence Based Practice",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OTA",
+              "number": "230",
+              "title": "Professional Skills Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "231",
+              "title": "Rehabilitation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "232",
+              "title": "Splinting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "233",
+              "title": "Level II Fieldwork – B",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTA",
+              "number": "234",
+              "title": "OTA Review Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapy",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/respiratory-therapy/respiratory-therapy",
+      "total_credits": 76,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RPT",
+              "number": "210",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "211",
+              "title": "Introduction to Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "212",
+              "title": "Fundamentals of Respiratory Care I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "213",
+              "title": "Anatomy and Physiology for the RCP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "214",
+              "title": "Pharmacology for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RPT",
+              "number": "220",
+              "title": "Clinical Practice II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "221",
+              "title": "Pathology for the RCP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "222",
+              "title": "Fundamentals of Respiratory Care II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "223",
+              "title": "Acid Base Regulation and ABG Analysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RPT",
+              "number": "231",
+              "title": "Pathology for the RCP II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "234",
+              "title": "Mechanical Ventilation for the RCP",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "254",
+              "title": "Patient Assessment Techniques for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RPT",
+              "number": "230",
+              "title": "Clinical Practice III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "242",
+              "title": "Perinatal/Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "232",
+              "title": "Diagnostic Procedures for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "244",
+              "title": "Critical Care Considerations for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RPT",
+              "number": "240",
+              "title": "Clinical Practice IV",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "233",
+              "title": "Special Procedures for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "241",
+              "title": "Rehabilitation and Home Care for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "243",
+              "title": "Computer Applications for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Polysomnographic Technology (Sleep Lab)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/polysomnographic-technology-sleep-lab/polysomnographic-technology-sleep-lab",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSG",
+              "number": "110",
+              "title": "Introduction to Polysomnography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "111",
+              "title": "Polysomnographic Technology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "112",
+              "title": "Polysomnographic Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "115",
+              "title": "PSG Clinical Practice I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSG",
+              "number": "113",
+              "title": "Polysomnographic Technology III",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "114",
+              "title": "Polysomnographic Technology IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "116",
+              "title": "PSG Clinical Practice II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Robotic Welding Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/robotic-welding-technician/robotic-welding-technician",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "160",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "161",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "126",
+              "title": "Gas Metal Arc/Flux Core Arc Welding",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "162",
+              "title": "Consumable Welding Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "197",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "275",
+              "title": "Robotic Welding II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "194",
+              "title": "Intro. to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "276",
+              "title": "Robotic Welding III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection and Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Robotic Welding Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/robotic-welding-technician/robotic-welding-technician-0",
+      "total_credits": 52,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "160",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "161",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "126",
+              "title": "Gas Metal Arc/Flux Core Arc Welding",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "162",
+              "title": "Consumable Welding Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "197",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "275",
+              "title": "Robotic Welding II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "194",
+              "title": "Intro. to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "276",
+              "title": "Robotic Welding III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection and Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Nursing - WSCC/ATSU Joint Enrollment Program of Study",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/nursing/nursing-wsccatsu-joint-enrollment-program-of-study",
+      "total_credits": 166,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "104",
+              "title": "Introduction to Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Fundamental Concepts of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "370",
+              "title": "Healthcare Informatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "340",
+              "title": "Introduction to Healthcare Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "6th Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Nursing Concepts I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "410",
+              "title": "Community Health Management",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "481",
+              "title": "Healthcare Quality Assurance, Risk Management, & Utilization Review",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "7th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Nursing Concepts II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "Evidence Based Clinical Reasoning",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "400",
+              "title": "Professional Nursing Practice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "8th Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "440",
+              "title": "Leadership in Practice",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UNV",
+              "number": "400",
+              "title": "BSN Career Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "9th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence Based Clinical Reasoning",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "430",
+              "title": "Scholarly Inquiry/Evidence-Based Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "460",
+              "title": "Nursing Capstone",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature Courses that can be taken for the sequence (WSCC course options): (Only if ENG 101/102 Completed)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "English Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "262",
+              "title": "English Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "271",
+              "title": "World Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272",
+              "title": "World Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Courses that can be completed for the sequence (WSCC course options):",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Robotic Welding Technician - Basic Robotic Welding Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/robotic-welding-technician/robotic-welding-technician-basic-robotic-welding-technician",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "BASIC ROBOTIC WELDING TECHNICIAN SHORT-TERM CERTIFICATE- Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "149",
+              "title": "Digital Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "160",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "161",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Salon and Spa Management - Cosmetology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/salon-and-spa-management/salon-and-spa-management-cosmetology",
+      "total_credits": 58,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Introduction to Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Introduction to Cosmetology Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "168",
+              "title": "Bacteriology and Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "143",
+              "title": "Specialty Hair Preparation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "Theory of Chemical Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Chemical Services Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Hair Coloring Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Hair Coloring Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "Basic Spa Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "Basic Spa Techniques Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "123",
+              "title": "Cosmetology Salon Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "144",
+              "title": "Hair Shaping and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "128",
+              "title": "Esthetics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "Salon Management Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "201",
+              "title": "Entrepreneurship for Salon/Spa",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "190",
+              "title": "Internship in Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "167",
+              "title": "State Board Review",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Robotic Welding Technician - Intermediate Robotic Welding Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/robotic-welding-technician/robotic-welding-technician-intermediate-robotic-welding-technician",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "INTERMEDIATE ROBOTIC WELDING TECHNICIAN SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "197",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "275",
+              "title": "Robotic Welding II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Salon and Spa Management - Cosmetology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/salon-and-spa-management/salon-and-spa-management-cosmetology-0",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Introduction to Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Introduction to Cosmetology Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "168",
+              "title": "Bacteriology and Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "143",
+              "title": "Specialty Hair Preparation Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "Theory of Chemical Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Chemical Services Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Hair Coloring Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Hair Coloring Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "163",
+              "title": "Facial Treatments",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "Basic Spa Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "Basic Spa Techniques Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "123",
+              "title": "Cosmetology Salon Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "144",
+              "title": "Hair Shaping and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "128",
+              "title": "Esthetics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "Salon Management Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "201",
+              "title": "Entrepreneurship for Salon/Spa",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "190",
+              "title": "Internship in Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "167",
+              "title": "State Board Review",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Welding - GMAW/FCAW Welding & Industrial Blueprint",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/welding-robotic-welding-technician/welding-gmawfcaw-welding-industrial-blueprint",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GMAW/FCAW WELDING & INDUSTRIAL BLUEPRINT SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "126",
+              "title": "Gas Metal Arc/Flux Core Arc Welding",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "162",
+              "title": "Consumable Welding Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding - GTAW Structural Welding & Inspection",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/welding/welding-gtaw-structural-welding-inspection",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GTAW STRUCTURAL WELDING & INSPECTION SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection and Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "232",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "259",
+              "title": "GTAW Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/welding/welding",
+      "total_credits": 55,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "104",
+              "title": "SMAW Fillet/PAC/CAC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "106",
+              "title": "Shielded Metal Arc Welding Groove",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "126",
+              "title": "Gas Metal Arc/Flux Core Arc Welding",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "162",
+              "title": "Consumable Welding Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "232",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection and Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "259",
+              "title": "GTAW Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "131",
+              "title": "Carbon Steel Fabrication Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "141",
+              "title": "Aluminum Fabrication Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "223",
+              "title": "Blueprint Reading for Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding - SMAW Structural Welding & PAC/CAC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/welding/welding-smaw-structural-welding-paccac",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "SMAW STRUCTURAL WELDING & PAC/CAC SHORT-TERM CERTIFICATE – Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "104",
+              "title": "SMAW Fillet/PAC/CAC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "106",
+              "title": "Shielded Metal Arc Welding Groove",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/welding/welding-technology",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "104",
+              "title": "SMAW Fillet/PAC/CAC",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "106",
+              "title": "Shielded Metal Arc Welding Groove",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "126",
+              "title": "Gas Metal Arc/Flux Core Arc Welding",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "162",
+              "title": "Consumable Welding Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "232",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection and Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "259",
+              "title": "GTAW Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "131",
+              "title": "Carbon Steel Fabrication Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "141",
+              "title": "Aluminum Fabrication Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "223",
+              "title": "Blueprint Reading for Fabrication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Robotic Welding Technician - Advanced Robotic Welding Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://wallacestate.cleancatalog.net/robotic-welding-technician/robotic-welding-technician-advanced-robotic-welding-technician",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ADVANCED ROBOTIC WELDING TECHNICIAN SHORT-TERM CERTIFICATE - Guided Pathway/Map",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "194",
+              "title": "Intro. to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "276",
+              "title": "Robotic Welding III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection and Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "Certification Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/al/programs/george-c-wallace-state-community-college-selma.json
+++ b/data/al/programs/george-c-wallace-state-community-college-selma.json
@@ -1,0 +1,4329 @@
+{
+  "college_slug": "george-c-wallace-state-community-college-selma",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.wccs.edu/degrees",
+  "scraped_at": "2026-06-03T21:27:32.721Z",
+  "programs": [
+    {
+      "title": "Air Conditioning and Refrigeration Tech (ACR)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/air-conditioning-and-refrigeration-tech/air-conditioning-and-refrigeration-tech-acr",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area II: Fine Arts, Humanities, and Speech, SPH 106 or SPH 107",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics, MTH 116, CIS 146",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "120",
+              "title": "Fundamentals of electric Heating Systems (Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVACR Electric Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVACR Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "127",
+              "title": "Electric Motors and Components (Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "192",
+              "title": "HVAC Apprenticeship/Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "106",
+              "title": "Workplace Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER Core",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cosmetology Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/cosmetology/cosmetology-standard-certificate",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Vocational Technical English I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area II: Humanities and Fine Arts",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences & Mathematics",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAH",
+              "number": "101",
+              "title": "Introductory Mathematics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Introduction to Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Introduction to Cosmetology Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "Theory of Chemical Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Chemical Services Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Hair Coloring Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Hair Coloring Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "Basic Spa Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "Basic Spa Techniques Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "119",
+              "title": "Business of Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "123",
+              "title": "Cosmetology Salon Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "125",
+              "title": "Career and Personal Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "144",
+              "title": "Hair Shaping and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "145",
+              "title": "Hair Shaping Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "158",
+              "title": "Employability Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPC",
+              "number": "103",
+              "title": "Oral Communication Skills",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice: Corrections & Parole Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/criminal-justice/criminal-justice-corrections-parole-standard-certificate",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "140",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "150",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "156",
+              "title": "Correctional Institutions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "157",
+              "title": "Community-Based Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "178",
+              "title": "Narcotics/Dangerous Drugs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "209",
+              "title": "Juvenile Delinquency",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "212",
+              "title": "Correctional Counseling Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "256",
+              "title": "Correctional Rehabilitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "259",
+              "title": "Issues in Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Business Administration Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/business-administration/business-administration-degree",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Math",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "177",
+              "title": "Salesmanship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "Accounting with QuickBooks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "Legal & Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Computer Information Systems Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/computer-information-systems/computer-information-systems-degree",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "Advanced Micro Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "155",
+              "title": "Introduction to Mobile App Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "161",
+              "title": "Intro to Networking Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "185",
+              "title": "Computer Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "191",
+              "title": "Intro to Computer Programming Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Intro to Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "209",
+              "title": "Advanced Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "268",
+              "title": "Software Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "269",
+              "title": "Hardware Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cosmetology Instructor Training STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/cosmetology-instructor-training/cosmetology-instructor-training-stc",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "211",
+              "title": "Teaching & Curriculum Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "212",
+              "title": "Teacher Mentorship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "221",
+              "title": "Lesson Plan Implementation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "222",
+              "title": "Audio Visual Material & Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "223",
+              "title": "Audio Visual Material & Methods Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "224",
+              "title": "Special Topics in Cosmetology Instruction",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/computer-information-systems/computer-information-systems-standard-certificate",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "Advanced Micro Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "155",
+              "title": "Introduction to Mobile App Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "185",
+              "title": "Computer Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "191",
+              "title": "Intro to Computer Programming Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Intro to Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "209",
+              "title": "Advanced Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "268",
+              "title": "Software Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "269",
+              "title": "Hardware Support",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Networking Option",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "161",
+              "title": "Intro to Networking Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice: Corrections & Parole STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/criminal-justice/criminal-justice-corrections-parole-stc",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "150",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "156",
+              "title": "Correctional Institutions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "157",
+              "title": "Community-Based Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice: Law Enforcement Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/criminal-justice/criminal-justice-law-enforcement-standard-certificate",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "116",
+              "title": "Police Patrol",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "140",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "146",
+              "title": "Criminal Evidence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "150",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "178",
+              "title": "Narcotics/Dangerous Drugs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "208",
+              "title": "Introduction to Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "209",
+              "title": "Juvenile Delinquency",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Police Organization and Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "220",
+              "title": "Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Drafting and Design Technology Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/drafting-and-design-technology/drafting-and-design-technology-degree",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Math",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 51,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "104",
+              "title": "Introduction to Computer Aided Drafting & Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "111",
+              "title": "Fundamentals of Drafting and Design Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "117",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "124",
+              "title": "Introduction to Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "127",
+              "title": "Intermediate Computer Aided Drafting and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "128",
+              "title": "Intermediate Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "125",
+              "title": "Surface Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "132",
+              "title": "Architectural Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "134",
+              "title": "Descriptive Geometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "212",
+              "title": "Intermediate Architectural Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "220",
+              "title": "Advanced Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "226",
+              "title": "Technical Illustration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "227",
+              "title": "Strength of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "233",
+              "title": "Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "236",
+              "title": "Design Project",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "239",
+              "title": "Independent Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "122",
+              "title": "Advanced Technical Drawing (Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Drafting and Design Technology Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/drafting-and-design-technology/drafting-and-design-technology-standard-certificate",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "104",
+              "title": "Introduction to Computer Aided Drafting & Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "111",
+              "title": "Fundamentals of Drafting and Design Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "117",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "124",
+              "title": "Introduction to Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "127",
+              "title": "Intermediate Computer Aided Drafting and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "128",
+              "title": "Intermediate Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "125",
+              "title": "Surface Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "132",
+              "title": "Architectural Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "134",
+              "title": "Descriptive Geometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "220",
+              "title": "Advanced Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "226",
+              "title": "Technical Illustration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "233",
+              "title": "Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "122",
+              "title": "Advanced Technical Drawing (Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice: Law Enforcement STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/criminal-justice/criminal-justice-law-enforcement-stc",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "116",
+              "title": "Police Patrol",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Police Organization and Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "220",
+              "title": "Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Electrical Technology Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/electrical-technology/electrical-technology-degree",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Math",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Principles of Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Principles of Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Residential Wiring Methods II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "Basic AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "Commercial/Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "132",
+              "title": "Commercial/Industrial Wiring II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "209",
+              "title": "Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "Motor Controls II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "231",
+              "title": "Introduction to Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "232",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "241",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Conduit Bending and Installation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/industrial-maintenance-technology/industrial-maintenance-technology-degree",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 51,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "112",
+              "title": "Industrial Maintenance Safety Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "119",
+              "title": "Principles of Mechanical Measurement and Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "121",
+              "title": "Industrial Hydraulics Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "126",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "158",
+              "title": "Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "213",
+              "title": "Industrial Motor Control II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "Applied Principles of Programmable Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "288",
+              "title": "Advanced Principles of Programmable Control",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/industrial-maintenance-technology/industrial-maintenance-technology-standard-certificate",
+      "total_credits": 48,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "112",
+              "title": "Industrial Maintenance Safety Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "119",
+              "title": "Principles of Mechanical Measurement and Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "121",
+              "title": "Industrial Hydraulics Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "126",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "213",
+              "title": "Industrial Motor Control II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "Applied Principles of Programmable Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "288",
+              "title": "Advanced Principles of Programmable Control",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Masonry/Building Trades Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/masonrybuilding-trades/masonrybuilding-trades-standard-certificate",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Vocational Technical English I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAH",
+              "number": "101",
+              "title": "Introductory Mathematics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAS",
+              "number": "111",
+              "title": "Masonry Fundamentals I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "121",
+              "title": "Brick/Block Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "131",
+              "title": "Residential/Commercial",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "151",
+              "title": "Masonry Fundamentals Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "161",
+              "title": "Concrete Block Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "162",
+              "title": "Brick Masonry Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "171",
+              "title": "Residential/Commercial",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "181",
+              "title": "Special Topics in Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "182",
+              "title": "Special Topics in Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "183",
+              "title": "Special Topics in Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "211",
+              "title": "Stone Masonry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "221",
+              "title": "Specialized Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "231",
+              "title": "Basic Cement Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "252",
+              "title": "Fireplace Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "253",
+              "title": "Brick Arches Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "271",
+              "title": "Basic Cement Masonry Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Masonry/Building Trades STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/masonrybuilding-trades/masonrybuilding-trades-stc",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAS",
+              "number": "111",
+              "title": "Masonry Fundamentals I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "121",
+              "title": "Brick/Block Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "131",
+              "title": "Residential/Commercial",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "151",
+              "title": "Masonry Fundamentals Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "161",
+              "title": "Concrete Block Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "162",
+              "title": "Brick Masonry Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "171",
+              "title": "Residential/Commercial",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "181",
+              "title": "Special Topics in Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/industrial-maintenance-technology/industrial-maintenance-technology-stc",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Principles of Industrial Maintenance I",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "104",
+              "title": "Principles of Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "112",
+              "title": "Industrial Maintenance Safety Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "119",
+              "title": "Principles of Mechanical Measurement and Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Principles of Industrial Maintenance II",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "121",
+              "title": "Industrial Hydraulics Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "126",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing: Associate Degree Nursing (ADN) Mobility Program",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/nursing/nursing-associate-degree-nursing-adn-mobility-program",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "209",
+              "title": "Concepts for Healthcare Transition Students",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence-Based Clinical Reasoning",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Modern Manufacturing Technology - Production",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/modern-manufacturing/modern-manufacturing-technology-production",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "104",
+              "title": "Workkeys Assessment and Advisement",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "120",
+              "title": "READY TO WORK I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WKO",
+              "number": "121",
+              "title": "READY TO WORK II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "102",
+              "title": "LEAN MANUFACTURING AND INDUSTRIAL SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "104",
+              "title": "BLUEPRINT READING FOR MANUFACTURING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "144",
+              "title": "MANUFACTURING SYSTEMS, METHODS, AND PROCESSES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "155",
+              "title": "METROLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "200",
+              "title": "TOTAL PRODUCTIVE MAINTENANCE",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "108",
+              "title": "INTRODUCTION TO LOGISTICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGT",
+              "number": "112",
+              "title": "WAREHOUSE OPERATIONS APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing: Associate Degree Nursing (ADN) Generic Option",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/nursing/nursing-associate-degree-nursing-adn-generic-option",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Fundamental Concepts of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Nursing Concepts I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Nursing Concepts II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "Adult Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence-Based Clinical Reasoning",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Practical Nursing (PN) Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/nursing/practical-nursing-pn-standard-certificate",
+      "total_credits": 44,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Fundamental Concepts of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Nursing Concepts I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Nursing Concepts II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "Adult Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Short-Term Certificate in Advanced Masonry",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/masonrybuilding-trades/shortterm-certificate-in-advanced-masonry",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAS",
+              "number": "272",
+              "title": "Advanced Cement Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "282",
+              "title": "Special Topics in Masonry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "290",
+              "title": "Co-op Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "291",
+              "title": "Co-op Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "292",
+              "title": "Co-op Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "293",
+              "title": "Co-op Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "294",
+              "title": "Co-op Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "295",
+              "title": "Co-op Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Administration: Information Processing Option Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/office-administration/office-administration-information-processing-option-degree",
+      "total_credits": 57,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Math",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 51,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "Legal & Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "Beginning Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "131",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "133",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "137",
+              "title": "Computerized Financial Recordkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records and Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "200",
+              "title": "Machine Transcription",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "202",
+              "title": "Legal Transcription",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "214",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Administration: Accounting Option Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/office-administration/office-administration-accounting-option-standard-certificate",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "Legal & Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "Beginning Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "131",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "133",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "137",
+              "title": "Computerized Financial Recordkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records and Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "219",
+              "title": "Accounting Concepts and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "232",
+              "title": "Excel/Powerpoint",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Office Administration: Accounting Option Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/office-administration/office-administration-accounting-option-degree",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Math",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "Legal & Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "Beginning Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "131",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "133",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "137",
+              "title": "Computerized Financial Recordkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records and Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "219",
+              "title": "Accounting Concepts and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "232",
+              "title": "Excel/Powerpoint",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Office Administration: Administrative Assistant STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/office-administration/office-administration-administrative-assistant-stc",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year – Fall",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "Beginning Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "131",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records and Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year – Spring",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "133",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Administration: Information Processing Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/office-administration/office-administration-information-processing-standard-certificate",
+      "total_credits": 48,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "Legal & Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "Beginning Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "131",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "133",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "137",
+              "title": "Computerized Financial Recordkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records and Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "200",
+              "title": "Machine Transcription",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "202",
+              "title": "Legal Transcription",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "214",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Patient Care Technician Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/patient-care-technician/patient-care-technician-standard-certificate",
+      "total_credits": 49,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Vocational Technical English I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area II: Humanities and Fine Arts",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHL",
+              "number": "206",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Directed Studies in Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HPS",
+              "number": "103",
+              "title": "Foundation Competencies for Health Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPS",
+              "number": "105",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPS",
+              "number": "118",
+              "title": "Fundamentals of Phlebotomy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPS",
+              "number": "119",
+              "title": "Phlebotomy Clinical",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Administration: Medical Transcription Option Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/office-administration/office-administration-medical-transcription-option-degree",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Math",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "Beginning Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "131",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "133",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records and Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "211",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "212",
+              "title": "Medical Transcription",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "213",
+              "title": "Adv. Medical Transcription",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "214",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding: Pipe Welding Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/welding-technology/welding-pipe-welding-standard-certificate",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Vocational Technical English I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAH",
+              "number": "101",
+              "title": "Introductory Mathematics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 50,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW Fillet OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW Fillet PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blue Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "115",
+              "title": "GTAW Carbon Pipe Theory (Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "116",
+              "title": "GTAW Stainless Pipe Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "SMAW Grooves Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW Fillet OFC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW Fillet PAC/CAC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "Shielded Metal Arc Welding Grooves Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "155",
+              "title": "GTAW Carbon Pipe Lab (Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "156",
+              "title": "GTAW Stainless Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "217",
+              "title": "SMAW Carbon Pipe Theory (Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "258",
+              "title": "Certification Lab (Elective)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "Orientation to College",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding: Structural Welding Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/welding-technology/welding-structural-welding-certificate",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Vocational Technical English I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAH",
+              "number": "101",
+              "title": "Introductory Mathematics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW Fillet OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW Fillet PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blue Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW Fillet OFC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW Fillet PAC/CAC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "Shielded Metal Arc Welding Grooves Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Office Administration: Medical Transcription Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/office-administration/office-administration-medical-transcription-standard-certificate",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Math",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "Beginning Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "126",
+              "title": "Advanced Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "131",
+              "title": "Business English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "133",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records and Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "211",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "212",
+              "title": "Medical Transcription",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "213",
+              "title": "Adv. Medical Transcription",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "214",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology Standard Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.wccs.edu/electrical-technology/electrical-technology-standard-certificate",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Math",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Additional General Education Courses, Major Courses and Electives",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Principles of Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Principles of Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Residential Wiring Methods II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "Basic AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "Commercial/Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "132",
+              "title": "Commercial/Industrial Wiring II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "209",
+              "title": "Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "Motor Controls II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "231",
+              "title": "Introduction to Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "232",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "241",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Conduit Bending and Installation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/al/programs/john-c-calhoun-state-community-college.json
+++ b/data/al/programs/john-c-calhoun-state-community-college.json
@@ -1,0 +1,12748 @@
+{
+  "college_slug": "john-c-calhoun-state-community-college",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.calhoun.edu/degrees",
+  "scraped_at": "2026-06-03T21:27:38.210Z",
+  "programs": [
+    {
+      "title": "Advanced Manufacturing Technology/Industrial Maintenance Facilities (F.A.M.E.)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/advanced-manufacturing-technologyindustrial-maintenance-facilities-fame",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "150",
+              "title": "Technical Cooperative Education I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "151",
+              "title": "Technical Cooperative Education II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "209",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "152",
+              "title": "Technical Cooperative Education III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "231",
+              "title": "Introduction to Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "120",
+              "title": "Fundamentals of Electric Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "153",
+              "title": "Technical Cooperative Education IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "Motor Controls II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "154",
+              "title": "Technical Cooperative Education V",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "232",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing, A.A.S. F.A.M.E. (Federation for Advanced Manufacturing Education)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/advanced-manufacturing-aas-fame-federation-for-advanced-manufacturing",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Core Requirements",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Core Requirements",
+          "credits_required": 50,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "209",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "Motor Controls II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "231",
+              "title": "Introduction to Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "232",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "182",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/advanced-manufacturing-shortterm-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "COURSE REQUIREMENTS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Aerospace Welding & Manufacturing – Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/advanced-aerospace-welding-manufacturing-shortterm-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Course Requirements",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARS",
+              "number": "178",
+              "title": "Aerospace Mechanical Assembly",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "278",
+              "title": "Composite Materials Fabrication and Assembly",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "251",
+              "title": "Specialized Welding Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "253",
+              "title": "Welding Certification Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Additive Manufacturing Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/additive-manufacturing-technology-shortterm-certificate",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ADDITIVE MANUFACTURING REQUIREMENTS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "108",
+              "title": "Introduction to 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "112",
+              "title": "Orientation to Additive Manufacturing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "162",
+              "title": "Additive Manufacturing Processes - Polymers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "164",
+              "title": "Additive Manufacturing Processes - Metals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "261",
+              "title": "Reverse Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "210",
+              "title": "Design for Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "257",
+              "title": "Introduction to Material Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "282",
+              "title": "Special Topics in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Additive Manufacturing Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/additive-manufacturing-technology-aas",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "257",
+              "title": "Introduction to Material Science",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADVANCED MANUFACTURING CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADDITIVE MANUFACTURING REQUIREMENTS",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "108",
+              "title": "Introduction to 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "112",
+              "title": "Orientation to Additive Manufacturing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "162",
+              "title": "Additive Manufacturing Processes - Polymers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "164",
+              "title": "Additive Manufacturing Processes - Metals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "255",
+              "title": "Application of Design (Capstone)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "261",
+              "title": "Reverse Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "Foundations for Metal Sculpture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "100",
+              "title": "Engineering Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "239",
+              "title": "Introduction to Geometric Dimensioning and Tolerancing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "210",
+              "title": "Design for Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "282",
+              "title": "Special Topics in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aerospace Technology Short Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/aerospace-technology-short-term-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "COURSE REQUIREMENTS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "278",
+              "title": "Composite Materials Fabrication and Assembly",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "280",
+              "title": "Surface Preparation and Coatings",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aerospace Technology/Non-Destructive Testing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/aerospace-technologynondestructive-testing",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "151",
+              "title": "Welding Principles, Theory and Symbols",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "161",
+              "title": "NDT Eddy Current Testing Inspection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "163",
+              "title": "NDT Magnetic Particle Inspection",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aerospace Technology/Welding, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/aerospace-technologywelding-aas",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADVANCED MANUFACTURING CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AEROSPACE FUNDAMENTAL COURSE REQUIREMENTS",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "151",
+              "title": "Welding Principles, Theory and Symbols",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "176",
+              "title": "Electrical/Electronic Assembly",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "178",
+              "title": "Aerospace Mechanical Assembly",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "278",
+              "title": "Composite Materials Fabrication and Assembly",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "280",
+              "title": "Surface Preparation and Coatings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "282",
+              "title": "Integrated Assembly Project",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AEROSPACE/WELDING COURSE REQUIREMENTS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARS",
+              "number": "153",
+              "title": "Gas Tungsten Arc and Plasma Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "251",
+              "title": "Specialized Welding Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "253",
+              "title": "Welding Certification Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Aerospace Technology/Aerospace Fundamentals Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/aerospace-technologyaerospace-fundamentals-shortterm-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AEROSPACE FUNDAMENTALS COURSE REQUIREMENTS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "176",
+              "title": "Electrical/Electronic Assembly",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "178",
+              "title": "Aerospace Mechanical Assembly",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning and Refrigeration Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/air-conditioning-and-refrigeration-shortterm-certificate",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AIR CONDITIONING & REFRIGERATION COURSE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "120",
+              "title": "Fundamentals of Electric Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aerospace Technology/Structures & Assembly, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/aerospace-technologystructures-assembly-aas",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADVANCED MANUFACTURING CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AEROSPACE FUNDAMENTAL COURSE REQUIREMENTS",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "151",
+              "title": "Welding Principles, Theory and Symbols",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "176",
+              "title": "Electrical/Electronic Assembly",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "178",
+              "title": "Aerospace Mechanical Assembly",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "279",
+              "title": "Adv. Composite Materials Fabrication & Assembly",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "280",
+              "title": "Surface Preparation and Coatings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "282",
+              "title": "Integrated Assembly Project",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AEROSPACE/STRUCTURES & ASSEMBLY COURSE REQUIREMENTS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARS",
+              "number": "276",
+              "title": "Instrumentation Attachments and Adhesive Bonding Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "278",
+              "title": "Composite Materials Fabrication and Assembly",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "284",
+              "title": "Specialized Coating Processes",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning and Refrigeration/ACR Fundamentals Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/air-conditioning-and-refrigerationacr-fundamentals-shortterm-certificate",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AIR CONDITIONING & REFRIGERATION FUNDAMENTALS COURSE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "120",
+              "title": "Fundamentals of Electric Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVAC/R Electrical Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning and Refrigeration/Advanced ACR Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/air-conditioning-and-refrigerationadvanced-acr-shortterm-certificate",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ADVANCED ACR COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVAC/R Electrical Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigeration Transition and Recovery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "149",
+              "title": "Heat Pump Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "205",
+              "title": "System Sizing and Air Distribution",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning & Refrigeration, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/air-conditioning-refrigeration-aas",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADVANCED MANUFACTURING CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AIR CONDITIONING & REFRIGERATION CORE CLASSES",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "120",
+              "title": "Fundamentals of Electric Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVAC/R Electrical Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AIR CONDITIONING ELECTIVES: Choose 15-18 credit hours",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVAC/R Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "126",
+              "title": "Commercial Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "135",
+              "title": "Mechanical Gas Safety Codes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "141",
+              "title": "Environmental Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigeration Transition and Recovery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "149",
+              "title": "Heat Pump Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "151",
+              "title": "Duct Design & Fabrication",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "187",
+              "title": "Special Topics in ACR",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "200",
+              "title": "Review for Contractors Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "203",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "205",
+              "title": "System Sizing and Air Distribution",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Commercial Air Conditioning Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "211",
+              "title": "Building Automation and Engineering I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "212",
+              "title": "Building Automation and Engineering II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Design Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/architectural-design-technology-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "112",
+              "title": "Orientation to Additive Manufacturing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "114",
+              "title": "Design Innovation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "255",
+              "title": "Application of Design (Capstone)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "109",
+              "title": "Introduction to Building Information - Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "132",
+              "title": "Architectural Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "222",
+              "title": "Advanced Architectural Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "126",
+              "title": "Basic Computer Aided Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Aerospace Welding - Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/basic-aerospace-welding-shortterm-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Course Requirements",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "151",
+              "title": "Welding Principles, Theory and Symbols",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "153",
+              "title": "Gas Tungsten Arc and Plasma Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Air Conditioning & Refrigeration/HVAC Building Automation & Engineering",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/air-conditioning-refrigerationhvac-building-automation-engineering",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Building Automation & Engineering Core Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "122",
+              "title": "HVAC/R Electrical Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "126",
+              "title": "Commercial Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Commercial Air Conditioning Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "211",
+              "title": "Building Automation and Engineering I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "212",
+              "title": "Building Automation and Engineering II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Basic Welding Automation Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/basic-welding-automation-shortterm-certificate",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "100",
+              "title": "Introduction to Applied Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "160",
+              "title": "Robotics Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "182",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection & Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Architectural Design Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/architectural-design-technology-aas",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "APPLIED TECHNOLOGY CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ARCHITECTURAL COURSE REQUIREMENTS",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "112",
+              "title": "Orientation to Additive Manufacturing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "114",
+              "title": "Design Innovation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "255",
+              "title": "Application of Design (Capstone)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "109",
+              "title": "Introduction to Building Information - Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "132",
+              "title": "Architectural Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "213",
+              "title": "Civil Drafting, Plat Maps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "222",
+              "title": "Advanced Architectural Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "225",
+              "title": "Structural Steel Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "100",
+              "title": "Engineering Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "126",
+              "title": "Basic Computer Aided Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/electrical-technology-shortterm-certificate",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ELECTRICAL TECHNOLOGY COURSE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Design Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/engineering-design-technology-aas",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "257",
+              "title": "Introduction to Material Science",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "APPLIED TECHNOLOGY CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ENGINEERING COURSE REQUIREMENTS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "108",
+              "title": "Introduction to 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "112",
+              "title": "Orientation to Additive Manufacturing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "114",
+              "title": "Design Innovation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "208",
+              "title": "Intermediate 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "210",
+              "title": "Design for Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "255",
+              "title": "Application of Design (Capstone)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "100",
+              "title": "Engineering Orientation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "126",
+              "title": "Basic Computer Aided Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "127",
+              "title": "Mechanical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "128",
+              "title": "Advanced Computer Aided Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "239",
+              "title": "Introduction to Geometric Dimensioning and Tolerancing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electrical Technology Entry Level Electrician Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/electrical-technology-entry-level-electrician-shortterm-certificate",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ENTRY LEVEL ELECTRICIAN COURSE REQUIREMENTS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "Commercial/Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "209",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "241",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/electrical-technology-aas",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADVANCED MANUFACTURING CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "BASIC ELECTRICITY COURSE REQUIREMENTS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ENTRY LEVEL ELECTRICIAN COURSE REQUIREMENTS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "Commercial/Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "209",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "241",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "RESIDENTIAL/COMMERCIAL/INDUSTRIAL COURSE REQUIREMENTS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "Motor Controls II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "231",
+              "title": "Introduction to Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "232",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Design Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/engineering-design-technology-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "108",
+              "title": "Introduction to 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "112",
+              "title": "Orientation to Additive Manufacturing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "114",
+              "title": "Design Innovation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "210",
+              "title": "Design for Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "255",
+              "title": "Application of Design (Capstone)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "127",
+              "title": "Mechanical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "126",
+              "title": "Basic Computer Aided Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/engineering-technology-shortterm-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Industrial Maintenance Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/industrial-maintenance-shortterm-certificate",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance/HVAC, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/industrial-maintenancehvac-aas",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADVANCED MANUFACTURING CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "BASIC ELECTRICITY COURSE REQUIREMENTS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "HVAC COURSE REQUIREMENTS",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "120",
+              "title": "Fundamentals of Electric Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigeration Transition and Recovery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "205",
+              "title": "System Sizing and Air Distribution",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "Commercial/Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "241",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Controls in Automation, Robotics, and Instrumentation, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/industrial-controls-in-automation-robotics-and-instrumentation-aas",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADVANCED MANUFACTURING CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "BASIC CORE COURSE REQUIREMENTS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FUNDAMENTAL COURSE REQUIREMENTS",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "250",
+              "title": "Introduction to Flexible Manufacturing Cells",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "209",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "231",
+              "title": "Introduction to Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "232",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "104",
+              "title": "Industrial Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "214",
+              "title": "Control and Troubleshooting Flow, Level, Temperature, Pressure and Level Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance/Mechanical, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/industrial-maintenancemechanical-aas",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADVANCED MANUFACTURING CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "BASIC ELECTRICITY COURSE REQUIREMENTS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ELECTRO/MECHANICAL COURSE REQUIREMENTS",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "147",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "148",
+              "title": "Introduction to Machine Shop I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "149",
+              "title": "Introduction to Machine Shop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "150",
+              "title": "Introduction to Machine Shop II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "182",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance/Electrical, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/industrial-maintenanceelectrical-aas",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADVANCED MANUFACTURING CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "BASIC ELECTRICITY COURSE REQUIREMENTS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ELECTRO/ELECTRONIC COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "118",
+              "title": "Commercial/Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "209",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "212",
+              "title": "Motor Controls II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "231",
+              "title": "Introduction to Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "232",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology Advanced CNC Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/machine-tool-technology-advanced-cnc-shortterm-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "219",
+              "title": "Computer Numerical Control Graphics: Turning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "220",
+              "title": "Computer Numerical Control Graphics: Milling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "281",
+              "title": "Special Topics in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "282",
+              "title": "Special Topics in Machine Tool Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/machine-tool-technology-aas",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADVANCED MANUFACTURING CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MACHINE TOOL CORE CLASSES",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "138",
+              "title": "Milling I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "147",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "148",
+              "title": "Introduction to Machine Shop I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "149",
+              "title": "Introduction to Machine Shop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "150",
+              "title": "Introduction to Machine Shop II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MACHINE TOOL ELECTIVES: Choose 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "219",
+              "title": "Computer Numerical Control Graphics: Turning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "220",
+              "title": "Computer Numerical Control Graphics: Milling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "107",
+              "title": "Machining Calculations I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology – Basic CNC Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/machine-tool-technology-basic-cnc-shortterm-certificate",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIREMENTS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "140",
+              "title": "Basic CNC Turning I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "141",
+              "title": "Basic CNC Milling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "212",
+              "title": "Advanced Computer Numerical Control Turning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "213",
+              "title": "Advanced Computer Numerical Control Milling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "241",
+              "title": "CNC Milling Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "242",
+              "title": "CNC Milling Lab II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "243",
+              "title": "CNC Turning Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "244",
+              "title": "CNC Turning Lab II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/machine-tool-technology-shortterm-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "147",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "148",
+              "title": "Introduction to Machine Shop I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology Tool and Die Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/machine-tool-technology-tool-and-die-shortterm-certificate",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "141",
+              "title": "Basic CNC Milling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "144",
+              "title": "Electrical Discharge Machining I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "158",
+              "title": "Die Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "159",
+              "title": "Basic Formability",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "160",
+              "title": "Die Construction and Tryout",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "161",
+              "title": "Die Maintenance and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "162",
+              "title": "Precision Grinding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "163",
+              "title": "Precision Grinding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "241",
+              "title": "CNC Milling Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology Manual Machining Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/machine-tool-technology-manual-machining-shortterm-certificate",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "107",
+              "title": "Machining Calculations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "121",
+              "title": "Basic Blueprint Reading for Machinists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "138",
+              "title": "Milling I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "147",
+              "title": "Introduction to Machine Shop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "148",
+              "title": "Introduction to Machine Shop I Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "149",
+              "title": "Introduction to Machine Shop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "150",
+              "title": "Introduction to Machine Shop II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "162",
+              "title": "Precision Grinding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "163",
+              "title": "Precision Grinding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Process Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/process-technology-shortterm-certificate",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PCT",
+              "number": "100",
+              "title": "Fundamentals of Process Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PCT",
+              "number": "105",
+              "title": "Process Technology I - Equipment",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PCT",
+              "number": "115",
+              "title": "Instrumentation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PCT",
+              "number": "220",
+              "title": "Process Technology II, Systems",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Robotics/Mechatronics Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/roboticsmechatronics-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ROBOTICS/MECHATRONICS COURSE REQUIREMENTS",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "209",
+              "title": "Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "231",
+              "title": "Introduction to Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "232",
+              "title": "Advanced Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "139",
+              "title": "Introduction to Robotic Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "250",
+              "title": "Introduction to Flexible Manufacturing Cells",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/welding-technology-aas",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADVANCED MANUFACTURING CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "WELDING CORE CLASSES",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "100",
+              "title": "Introduction to Applied Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW Fillet/PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "228",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "WELDING ELECTIVES: Choose 18 credit hours",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARS",
+              "number": "151",
+              "title": "Welding Principles, Theory and Symbols",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "153",
+              "title": "Gas Tungsten Arc and Plasma Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "251",
+              "title": "Specialized Welding Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "253",
+              "title": "Welding Certification Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding Groove",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW Fillet/PAC/CAC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "131",
+              "title": "Carbon Steel Fabrication Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "141",
+              "title": "Aluminum Fabrication Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "155",
+              "title": "GTAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "157",
+              "title": "Consumable Welding Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "160",
+              "title": "Robotics Lab I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "166",
+              "title": "Flux Core Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "182",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "217",
+              "title": "SMAW Carbon Pipe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "218",
+              "title": "Certification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection & Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "259",
+              "title": "GTAW Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Process Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/process-technology-aas",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ADVANCED MANUFACTURING CORE COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "Precision Measurement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "104",
+              "title": "Introduction to Thermal/Electrical Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "105",
+              "title": "Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "106",
+              "title": "Quality Control Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "113",
+              "title": "Foundations of Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROCESS TECHNOLOGY COURSE REQUIREMENTS",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PCT",
+              "number": "100",
+              "title": "Fundamentals of Process Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PCT",
+              "number": "105",
+              "title": "Process Technology I - Equipment",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PCT",
+              "number": "115",
+              "title": "Instrumentation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PCT",
+              "number": "215",
+              "title": "Instrumentation II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PCT",
+              "number": "220",
+              "title": "Process Technology II, Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PCT",
+              "number": "230",
+              "title": "Process Technology III, Operations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PCT",
+              "number": "240",
+              "title": "Process Troubleshooting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "104",
+              "title": "Introduction to Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology - Aerospace Welding Short Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/welding-technology-aerospace-welding-short-certificate",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Course Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARS",
+              "number": "151",
+              "title": "Welding Principles, Theory and Symbols",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "153",
+              "title": "Gas Tungsten Arc and Plasma Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "251",
+              "title": "Specialized Welding Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARS",
+              "number": "253",
+              "title": "Welding Certification Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "228",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "141",
+              "title": "Aluminum Fabrication Methods",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology: Basic Manufacturing & Fabrication Welding Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/welding-technology-basic-manufacturing-fabrication-welding-shortterm",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding Groove",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "182",
+              "title": "Special Topics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "218",
+              "title": "Certification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "228",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "259",
+              "title": "GTAW Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Automotive Electrician Technician Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/automotive-technology/automotive-electrician-technician-shortterm-certificate",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "162",
+              "title": "Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "212",
+              "title": "Advanced Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Welding Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/welding-technology-shortterm-certificate",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW Fillet/PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW Fillet/PAC/CAC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Automotive Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/automotive-technology/automotive-technology-aas",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAJOR COURSE REQUIREMENTS",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "101",
+              "title": "Fundamentals of Automotive Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "121",
+              "title": "Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "122",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "124",
+              "title": "Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "130",
+              "title": "Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "133",
+              "title": "Motor Vehicle Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "162",
+              "title": "Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "212",
+              "title": "Advanced Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "220",
+              "title": "Advanced Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "224",
+              "title": "Man Transmission and Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "230",
+              "title": "Auto Transmission and Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "239",
+              "title": "Engine Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "244",
+              "title": "Engine Performance and Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "246",
+              "title": "Automotive Emissions",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Brakes and Suspension Technician Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/automotive-technology/brakes-and-suspension-technician-shortterm-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "121",
+              "title": "Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "122",
+              "title": "Steering and Suspension",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "130",
+              "title": "Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Equipment Service - Electrical Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/automotive-technology/equipment-service-electrical-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "162",
+              "title": "Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "212",
+              "title": "Advanced Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "234",
+              "title": "Diesel Electronic Systems Cab-Chassis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Airframe, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/aviation-technology/aviation-airframe-aas",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Course Requirements",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Course Requirements",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "101",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "Weight and Balance, Ground Handling and Servicing, Cleaning and Corrosion Control",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "Technical Preparation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "Materials and Processes",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Airframe Course Requirements",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "110",
+              "title": "Non-Metallic Structures and Welding",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "111",
+              "title": "Aircraft Sheet Metal Structures",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "112",
+              "title": "Airframe Systems I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "113",
+              "title": "Airframe Systems II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "114",
+              "title": "Airframe Systems III",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "115",
+              "title": "Airframe Systems IV",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Powerplant, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/aviation-technology/aviation-powerplant-aas",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Course Requirements",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Course Requirements",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "101",
+              "title": "Basic Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "Weight and Balance, Ground Handling and Servicing, Cleaning and Corrosion Control",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "Technical Preparation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "Materials and Processes",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Powerplant Course Requirements",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMP",
+              "number": "220",
+              "title": "Reciprocating Engines and Theory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMP",
+              "number": "221",
+              "title": "Turbine Engines Theory and Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMP",
+              "number": "222",
+              "title": "Reciprocating Engines Inspections and Propellers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMP",
+              "number": "223",
+              "title": "Reciprocating Engine Overhaul",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMP",
+              "number": "224",
+              "title": "Turbine Engine Inspection and Overhaul",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Technology A.A.S. Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/business-administration/accounting-technology-aas-concentration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "Modern Business Mathematics with Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAJOR COURSE REQUIREMENTS",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "254",
+              "title": "Business Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "Accounting with QuickBooks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "247",
+              "title": "Financial Markets and Institutions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "248",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "253",
+              "title": "Individual Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "272",
+              "title": "Business Statistics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "289",
+              "title": "Business Strategy Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "197E",
+              "title": "Microsoft Excel Expert",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Business Administration, A.A.S. Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/business-administration/business-administration-aas-concentration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "Modern Business Mathematics with Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAJOR COURSE REQUIREMENTS",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "Accounting with QuickBooks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "247",
+              "title": "Financial Markets and Institutions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "272",
+              "title": "Business Statistics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "289",
+              "title": "Business Strategy Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "197E",
+              "title": "Microsoft Excel Expert",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/business-administration/business-shortterm-certificate",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Entrepreneurship Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/business-administration/entrepreneurship-shortterm-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "Accounting with QuickBooks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Management A.A.S. Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/business-administration/office-management-aas-concentration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "Modern Business Mathematics with Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAJOR COURSE REQUIREMENTS",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "Accounting with QuickBooks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "289",
+              "title": "Business Strategy Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "197A",
+              "title": "Microsoft Access Expert",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "197E",
+              "title": "Microsoft Excel Expert",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "197W",
+              "title": "Microsoft Word Expert",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "197K",
+              "title": "Microsoft Outlook",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Accounting Essentials Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/business-administration/accounting-essentials-shortterm-certificate",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "254",
+              "title": "Business Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "Accounting with QuickBooks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "248",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "253",
+              "title": "Individual Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "197E",
+              "title": "Microsoft Excel Expert",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Manufacturing Engineering Technology Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/advanced-manufacturing/manufacturing-engineering-technology-shortterm-certificate",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "108",
+              "title": "Introduction to 3D Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "111",
+              "title": "Manufacturing Safety Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "112",
+              "title": "Orientation to Additive Manufacturing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "114",
+              "title": "Design Innovation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Paralegal A.A.S. Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/business-administration/paralegal-aas-concentration",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "Modern Business Mathematics with Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAJOR COURSE REQUIREMENTS",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "101",
+              "title": "Introduction to Paralegal Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "102",
+              "title": "Basic Legal Research and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "160",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "210",
+              "title": "Real Property Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "230",
+              "title": "Domestic Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "240",
+              "title": "Wills, Trusts, and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "262",
+              "title": "Civil Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRL",
+              "number": "282",
+              "title": "Law Office Management and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Auxiliary Teacher Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/child-development/auxiliary-teacher-certificate",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Course Requirements",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Tax Professional Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/business-administration/tax-professional-shortterm-certificate",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "254",
+              "title": "Business Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "Accounting with QuickBooks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "253",
+              "title": "Individual Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "197E",
+              "title": "Microsoft Excel Expert",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Child Development, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/child-development/child-development-aas",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAJOR COURSE REQUIREMENTS",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "Child Growth and Development Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "202",
+              "title": "Children’s Creative Experiences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children’s Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Program Planning for Educating Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "Infant and Toddler Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Educating Children with Exceptional Needs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "214",
+              "title": "Families and Communities in Early Childcare and Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "215",
+              "title": "Supervised Practical Experiences in Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Child Development Administration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/child-development/child-development-administration",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "Administration of Child Development Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Computer Information Systems A.A.S. Cybersecurity/IT Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/computer-information-systems/computer-information-systems-aas-cybersecurityit-concentration",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAJOR COURSE REQUIREMENTS",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals (CompTIA Tech+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I (CompTIA Linux+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "214",
+              "title": "Security Analysis (CompTIA PenTest+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "235",
+              "title": "Data Analytics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance (CompTIA A+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "267",
+              "title": "Enterprise Virtualization (CompTIA Cloud+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "270",
+              "title": "Cisco CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "271",
+              "title": "Cisco CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "272",
+              "title": "Cisco CCNA III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "276",
+              "title": "Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "277",
+              "title": "Network Services Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security (CompTIA Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "282",
+              "title": "Computer Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "101",
+              "title": "Introduction to Systems Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Child Development Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/child-development/child-development-shortterm-certificate",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAJOR COURSE REQUIREMENTS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "Child Growth and Development Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "202",
+              "title": "Children’s Creative Experiences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Program Planning for Educating Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Educating Children with Exceptional Needs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Computer Information Systems A.A.S. Programming Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/computer-information-systems/computer-information-systems-aas-programming-concentration",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAJOR COURSE REQUIREMENTS",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals (CompTIA Tech+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I (CompTIA Linux+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Introduction to Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "209",
+              "title": "Advanced Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "222",
+              "title": "Database Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "235",
+              "title": "Data Analytics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "255",
+              "title": "Java Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "266",
+              "title": "Software Engineering with Secure Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "267",
+              "title": "Enterprise Virtualization (CompTIA Cloud+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security (CompTIA Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "283",
+              "title": "Software Development Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "101",
+              "title": "Introduction to Systems Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems A.A.S. Systems Engineering Technology Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/computer-information-systems/computer-information-systems-aas-systems-engineering-technology",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Core Requirements",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Course Requirements",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "IT Fundamentals (CompTIA Tech+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I (CompTIA Linux+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Introduction to Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "235",
+              "title": "Data Analytics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "266",
+              "title": "Software Engineering with Secure Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "267",
+              "title": "Enterprise Virtualization (CompTIA Cloud+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security (CompTIA Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "101",
+              "title": "Introduction to Systems Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "231",
+              "title": "Systems Modeling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "232",
+              "title": "Systems Modeling II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "233",
+              "title": "Systems Modeling III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "241",
+              "title": "Systems Engineering Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Information Systems Cisco CCNA Preparation Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/computer-information-systems/computer-information-systems-cisco-ccna-preparation-shortterm",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "270",
+              "title": "Cisco CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "271",
+              "title": "Cisco CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "272",
+              "title": "Cisco CCNA III",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engines Technician Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/automotive-technology/engines-technician-shortterm-certificate",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "124",
+              "title": "Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "220",
+              "title": "Advanced Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems Computer Science Essentials Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/computer-information-systems/computer-information-systems-computer-science-essentials-shortterm",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Information Systems Computer Technician Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/computer-information-systems/computer-information-systems-computer-technician-shortterm-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I (CompTIA Linux+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance (CompTIA A+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "270",
+              "title": "Cisco CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security (CompTIA Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Tune Up or Drivability Technician Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/automotive-technology/tune-up-or-drivability-technician-shortterm-certificate",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "162",
+              "title": "Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "212",
+              "title": "Advanced Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "239",
+              "title": "Engine Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "244",
+              "title": "Engine Performance and Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "246",
+              "title": "Automotive Emissions",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems Programming Essentials Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/computer-information-systems/computer-information-systems-programming-essentials-shortterm",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "255",
+              "title": "Java Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems Server Administration Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/computer-information-systems/computer-information-systems-server-administration-shortterm",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "267",
+              "title": "Enterprise Virtualization (CompTIA Cloud+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "276",
+              "title": "Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "277",
+              "title": "Network Services Administration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems - Systems Engineering Technology Essentials Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/computer-information-systems/computer-information-systems-systems-engineering-technology-essentials",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "REQUIREMENTS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SYS",
+              "number": "231",
+              "title": "Systems Modeling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "232",
+              "title": "Systems Modeling II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "233",
+              "title": "Systems Modeling III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYS",
+              "number": "241",
+              "title": "Systems Engineering Technology Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Information Systems Software Applications Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/computer-information-systems/computer-information-systems-software-applications-shortterm",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "197A",
+              "title": "Microsoft Access Expert",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "197E",
+              "title": "Microsoft Excel Expert",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "197W",
+              "title": "Microsoft Word Expert",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems Cybersecurity Essentials Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/computer-information-systems/computer-information-systems-cybersecurity-essentials-shortterm",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "214",
+              "title": "Security Analysis (CompTIA PenTest+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security (CompTIA Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "282",
+              "title": "Computer Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Criminal Justice - Associate of Applied Science Degree",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/criminal-justice/criminal-justice-associate-of-applied-science-degree",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Course Requirements",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Course Requirements",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "140",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "150",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "160",
+              "title": "Introduction to Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "208",
+              "title": "Introduction to Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "209",
+              "title": "Juvenile Delinquency",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "230",
+              "title": "Criminalistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "238",
+              "title": "Crime Scene Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Security Short-Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/criminal-justice/security-shortterm-certificate",
+      "total_credits": 34,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "MAJOR COURSE REQUIREMENTS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "290",
+              "title": "Selected Topics - Seminar in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "171",
+              "title": "Security Risk Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Security Management Area of Focus - Choose 3 of the following:",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "166",
+              "title": "Private and Retail Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "167",
+              "title": "Industrial Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "169",
+              "title": "Security Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "170",
+              "title": "Introduction to Physical Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Cybersecurity Area of Focus - Choose 3 of the following:",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux I (CompTIA Linux+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "214",
+              "title": "Security Analysis (CompTIA PenTest+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "282",
+              "title": "Computer Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "167",
+              "title": "Industrial Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting, Long Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/dental-assisting/dental-assisting-long-certificate",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "100",
+              "title": "Introduction to Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "101",
+              "title": "Pre-clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "102",
+              "title": "Dental Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "103",
+              "title": "Anatomy and Physiology for Dental Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAT",
+              "number": "104",
+              "title": "Basic Sciences for Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "111",
+              "title": "Clinical Practice I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "112",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "116",
+              "title": "Preclinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAT",
+              "number": "113",
+              "title": "Dental Health Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "114",
+              "title": "Dental Office Administration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "122",
+              "title": "Clinical Practice II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "123",
+              "title": "Dental Assisting Seminar",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/dental-hygiene/dental-hygiene-aas",
+      "total_credits": 76,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Core Requirements",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHY",
+              "number": "110",
+              "title": "Dental Hygiene Theory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "112",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "114",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "116",
+              "title": "Dental Anatomy, Histology and Embryology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "118",
+              "title": "Anatomy, Embryology, and Histology of the Head and Neck",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "120",
+              "title": "Dental Materials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "122",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "124",
+              "title": "Dental Hygiene Theory II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "126",
+              "title": "Periodontology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "128",
+              "title": "Pharmacology/Medical Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "130",
+              "title": "Biological Chemistry and Applied Nutrition",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "132",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "134",
+              "title": "Dental Hygiene Theory III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "210",
+              "title": "General and Oral Pathology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "212",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "214",
+              "title": "Dental Hygiene Theory IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "216",
+              "title": "Dental Research",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "217",
+              "title": "Community Dental Health",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "218",
+              "title": "Clinical Dental Hygiene IV",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHY",
+              "number": "220",
+              "title": "Dental Hygiene Theory V",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/diesel-technology/diesel-technology",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Course Requirements",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "103",
+              "title": "Introduction to Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Course Requirements",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEM",
+              "number": "104",
+              "title": "Basic Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "105",
+              "title": "Preventive Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "122",
+              "title": "Heavy Vehicle Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "124",
+              "title": "Electronic Engine Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "125",
+              "title": "Heavy Vehicle Drive Trains",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "126",
+              "title": "Advanced Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "127",
+              "title": "Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "128",
+              "title": "Heavy Vehicle Drive Train Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "129",
+              "title": "Diesel Engine Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "130",
+              "title": "Electrical/Electronic Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "135",
+              "title": "Heavy Vehicle Steering and Suspension Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "137",
+              "title": "Heating, Air Conditioning, and Refrigeration Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "139",
+              "title": "Diesel Emissions and Aftertreatment Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "154",
+              "title": "Vehicle Maintenance & Safe Operating Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "156",
+              "title": "CDL License Test Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEM",
+              "number": "234",
+              "title": "Diesel Electronic Systems Cab-Chassis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician (EMT) Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/emergency-medical-services/emergency-medical-technician-emt-certificate",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting, AAS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/dental-assisting/dental-assisting-aas",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "100",
+              "title": "Introduction to Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "101",
+              "title": "Pre-clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "102",
+              "title": "Dental Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "103",
+              "title": "Anatomy and Physiology for Dental Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAT",
+              "number": "104",
+              "title": "Basic Sciences for Dental Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "111",
+              "title": "Clinical Practice I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "112",
+              "title": "Dental Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "116",
+              "title": "Preclinical Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAT",
+              "number": "113",
+              "title": "Dental Health Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "114",
+              "title": "Dental Office Administration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "122",
+              "title": "Clinical Practice II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "123",
+              "title": "Dental Assisting Seminar",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Gen Ed Requirements for the AAS Degree",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/emergency-medical-services/paramedic-aas",
+      "total_credits": 73,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "SEMESTER 1",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER 2",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "Advanced Emergency Medical Technician Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER 3",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Cardiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic Patient Assessment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "Paramedic Applied Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic Clinical I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER 4",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "Paramedic Medical Emergencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Trauma Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "Paramedic Special Populations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER 5",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "Paramedic Transition to the Workforce",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Advanced Competencies for the Paramedic",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "Paramedic Field Preceptorship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "Paramedic Team Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic - Long Term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/emergency-medical-services/paramedic-long-term-certificate",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "SEMESTER 1",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER 2",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "Advanced Emergency Medical Technician Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER 3",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Cardiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic Patient Assessment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "Paramedic Applied Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic Clinical I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER 4",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "Paramedic Medical Emergencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Trauma Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "Paramedic Special Populations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER 5",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "Paramedic Transition to the Workforce",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Advanced Competencies for the Paramedic",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "Paramedic Field Preceptorship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "Paramedic Team Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies - Art Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-art-concentration",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "203",
+              "title": "Art History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "204",
+              "title": "Art History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Two-dimensional Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "126",
+              "title": "Color",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "127",
+              "title": "Three-dimensional Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "270",
+              "title": "Professional Studio Practice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "General Studies - Biology Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-biology-concentration",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "Principles of Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "125",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Advanced Emergency Medical Technician (AEMT) Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/emergency-medical-services/advanced-emergency-medical-technician-aemt-certificate",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "Advanced Emergency Medical Technician Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies - Business Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-business-concentration",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "271",
+              "title": "Business Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "272",
+              "title": "Business Statistics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "General Studies - Chemistry Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-chemistry-concentration",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "125",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "221",
+              "title": "Organic Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "222",
+              "title": "Organic Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "126",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "213",
+              "title": "General Physics with Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "214",
+              "title": "General Physics with Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies - Child Development",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-child-development",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Core Requirements",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Concentration Area V Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children’s Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "Administration of Child Development Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "Infant and Toddler Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "General Studies - Biotechnology Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-biotechnology-concentration",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "105",
+              "title": "Introduction to Biotechnology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "107",
+              "title": "Cell Culture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "203",
+              "title": "Techniques in Molecular Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "252",
+              "title": "Directed Studies in Biotechnology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "254",
+              "title": "Advanced Topics in Biotechnology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "256",
+              "title": "Biotechnology Internship",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies - Computer Science Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-computer-science-concentration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "113",
+              "title": "Precalculus Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "125",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "126",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "General Studies - Criminal Justice Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-criminal-justice-concentration",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "General Studies - General Education Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-general-education-concentration",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies - English Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-english-concentration",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "english"
+    },
+    {
+      "title": "General Studies - Graphic Design",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-graphic-design",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Core Requirements",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "203",
+              "title": "Art History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Concentration Area V Courses",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "221",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "253",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "299",
+              "title": "Art Portfolio",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "180",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "232",
+              "title": "Advanced Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "General Studies - Music Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-music-concentration",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "106",
+              "title": "Fundamentals of Oral Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "111",
+              "title": "Music Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "113",
+              "title": "Music Theory Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUL",
+              "number": "101",
+              "title": "Class Piano I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUL",
+              "number": "102",
+              "title": "Class Piano II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies - History Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-history-concentration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "United States History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "United States History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "history"
+    },
+    {
+      "title": "General Studies - Mathematics Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-mathematics-concentration",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "213",
+              "title": "General Physics with Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "214",
+              "title": "General Physics with Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "113",
+              "title": "Precalculus Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "125",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "126",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "227",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "237",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "238",
+              "title": "Applied Differential Equations I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "General Studies - Physics Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-physics-concentration",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "213",
+              "title": "General Physics with Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "214",
+              "title": "General Physics with Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "125",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "126",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "227",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies - Pre-Engineering Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-preengineering-concentration",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "213",
+              "title": "General Physics with Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "214",
+              "title": "General Physics with Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "125",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "126",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "227",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "238",
+              "title": "Applied Differential Equations I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies - Psychology Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-psychology-concentration",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies - Pre-Nursing Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-prenursing-concentration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "104",
+              "title": "Introduction to Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "General Studies - Social Work Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-social-work-concentration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SWT",
+              "number": "130",
+              "title": "The Community and the Social Worker",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies - Sociology Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-sociology-concentration",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "247",
+              "title": "Marriage and the Family",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies - Theatre Concentration (Acting, Technical/Design, and Musical Theatre)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-theatre-concentration-acting-technicaldesign-and-musical-theatre",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "120",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "113",
+              "title": "Theatre Workshop I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "114",
+              "title": "Theatre Workshop II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "115",
+              "title": "Theatre Workshop III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "124",
+              "title": "Theatre Technology Scenery & Lighting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "131",
+              "title": "Acting Techniques I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "210",
+              "title": "Introduction to Theatrical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "213",
+              "title": "Theatre Workshop IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "241",
+              "title": "Voice and Speech for the Performer",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Medical Laboratory Assistant (MLA) Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/medical-laboratory-science/medical-laboratory-assistant-mla-shortterm-certificate",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "MAJOR COURSE REQUIREMENTS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "Cardiopulmonary Resuscitation I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "131",
+              "title": "Laboratory Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "132",
+              "title": "Laboratory Techniques II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "286",
+              "title": "Clinical Laboratory Practicum for MLA",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/music/music-technology-aas",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAJOR COURSE REQUIREMENTS",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETP",
+              "number": "267",
+              "title": "Innovation and Creativity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "153",
+              "title": "Audio Engineering Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "201",
+              "title": "Survey of the Recording Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "250",
+              "title": "Music Technology Practicum and Portfolio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "251",
+              "title": "Advanced Audio Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "253",
+              "title": "Digital Audio Workstation Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "254",
+              "title": "Advanced Digital Audio Workstations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "255",
+              "title": "MIDI Production and Synthesis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "291",
+              "title": "Audio for Visual Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "293",
+              "title": "Mixing Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUL",
+              "number": "101",
+              "title": "Class Piano I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "103",
+              "title": "Survey of Popular Music",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Basic Musicianship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "292",
+              "title": "Songwriting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTV",
+              "number": "119",
+              "title": "Video Production I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Technology Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/music-technology/music-technology-shortterm-certificate",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Course Requirements",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETP",
+              "number": "267",
+              "title": "Innovation and Creativity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "153",
+              "title": "Audio Engineering Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "201",
+              "title": "Survey of the Recording Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "253",
+              "title": "Digital Audio Workstation Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "254",
+              "title": "Advanced Digital Audio Workstations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Basic Musicianship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "292",
+              "title": "Songwriting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing: Practical Nursing Program Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/nursing/nursing-practical-nursing-program-certificate",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Fundamentals Concepts of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Nursing Concepts I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Nursing Concepts II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "Evidence Based Clinical Reasoning",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "General Studies - Dance Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-dance-concentration",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "101",
+              "title": "Dance Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CONCENTRATION AREA V COURSES",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNC",
+              "number": "110",
+              "title": "Introduction to Dance Styles",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "143",
+              "title": "Ballet Technique I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "144",
+              "title": "Ballet Technique II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "160",
+              "title": "Dance Workshop I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "161",
+              "title": "Dance Workshop II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "234",
+              "title": "Choreography I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "235",
+              "title": "Choreography II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "267",
+              "title": "Jazz Dance I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "268",
+              "title": "Jazz Dance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNC",
+              "number": "281",
+              "title": "Dance Pedagogy I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Medical Laboratory Technician (MLT), A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/medical-laboratory-science/medical-laboratory-technician-mlt-aas",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION CORE REQUIREMENTS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "104",
+              "title": "Introduction to Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FALL - 1st YEAR",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "121",
+              "title": "Hematology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "131",
+              "title": "Laboratory Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "181",
+              "title": "MLT Immunology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SPRING - 1st YEAR",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "141",
+              "title": "MLT Microbiology I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "151",
+              "title": "MLT Clinical Chemistry",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SUMMER - 1st YEAR",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "142",
+              "title": "MLT Microbiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "111",
+              "title": "Urinalysis and Body Fluids",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FALL - 2nd YEAR",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "161",
+              "title": "MLT Integrated Laboratory Simulation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "191",
+              "title": "MLT Immunohematology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "295",
+              "title": "Medical Laboratory Practicum - Microbiology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SPRING 2nd YEAR",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "293",
+              "title": "MLT Medical Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "294",
+              "title": "Medical Laboratory Practicum - Hematology and Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "296",
+              "title": "Medical Laboratory Practicum - Immunohematology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "297",
+              "title": "Medical Laboratory Practicum - Chemistry and Immunology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "RN BRIDGE PROGRAM",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/nursing/rn-bridge-program",
+      "total_credits": 41,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence Based Clinical Reasoning.",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/nursing/nursing-aas",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Fundamentals Concepts of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Nursing Concepts I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Nursing Concepts II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "Evidence Based Clinical Reasoning",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence Based Clinical Reasoning.",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Physical Therapist Assistant, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/physical-therapist-assistant/physical-therapist-assistant-aas",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FALL - FIRST YEAR",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "106",
+              "title": "Medical Terminology for Health Professions",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "200",
+              "title": "Physical Therapy Issues and Trends",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "220",
+              "title": "Functional Anatomy and Kinesiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "221",
+              "title": "Kinesiology Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "250",
+              "title": "Therapeutic Procedures I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SPRING - FIRST YEAR",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "230",
+              "title": "Neuroscience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "240",
+              "title": "Physical Disabilities I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "251",
+              "title": "Therapeutic Procedures II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "252",
+              "title": "Physical Agents and Therapeutic Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SUMMER - FIRST YEAR",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "202",
+              "title": "PTA Communication Skills",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "232",
+              "title": "Orthopedics for the PTA",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "290",
+              "title": "Therapeutic Exercise",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FALL - SECOND YEAR",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "231",
+              "title": "Rehabilitation Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "241",
+              "title": "Physical Disabilities II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "260",
+              "title": "Clinical Education I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "266",
+              "title": "Clinical Field Work I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SPRING - SECOND YEAR",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "201",
+              "title": "Physical Therapy Assistant Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "261",
+              "title": "Clinical Education II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "263",
+              "title": "Clinical Affiliation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "267",
+              "title": "Clinical Field Work II",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Work Technician, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/social-work-technology/social-work-technician-aas",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Core Requirements",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Introductory Spanish I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Course Requirements",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "209",
+              "title": "Juvenile Delinquency",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWT",
+              "number": "109",
+              "title": "Techniques of Behavior Modification I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWT",
+              "number": "130",
+              "title": "The Community and the Social Worker",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWT",
+              "number": "131",
+              "title": "Problems of Children and Youth",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWT",
+              "number": "133",
+              "title": "Geriatrics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWT",
+              "number": "200",
+              "title": "History of Social Welfare in the U.S.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "116",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/surgical-technology/surgical-technology-aas",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "106",
+              "title": "Medical Terminology for Health Professions",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM CORE REQUIREMENTS",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SUR",
+              "number": "100",
+              "title": "Principles of Surgical Technology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "102",
+              "title": "Applied Surgical Technologies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "107",
+              "title": "Surgical Anatomy and Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "108",
+              "title": "Pharmacology for the Surgical Technologist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "103",
+              "title": "Surgical Procedures",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "104",
+              "title": "Surgical Practicum I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "105",
+              "title": "Surgical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "106",
+              "title": "Role Transition in Surgical Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "204",
+              "title": "Surgical Practicum III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapy, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/respiratory-therapy/respiratory-therapy-aas",
+      "total_credits": 76,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Core Requirements",
+          "credits_required": 52,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RPT",
+              "number": "210",
+              "title": "Clinical Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "211",
+              "title": "Introduction to Respiratory Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "212",
+              "title": "Fundamentals of Respiratory Care I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "213",
+              "title": "Anatomy and Physiology for the RCP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "214",
+              "title": "Pharmacology for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "220",
+              "title": "Clinical Practice II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "221",
+              "title": "Pathology for the RCP I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "222",
+              "title": "Fundamentals for Respiratory Care II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "223",
+              "title": "Acid-Base Regulation and ABG Analysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "230",
+              "title": "Clinical Practice III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "231",
+              "title": "Pathology for the RCP II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "232",
+              "title": "Diagnostic Procedures for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "233",
+              "title": "Special Procedures for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "234",
+              "title": "Mechanical Ventilation for the RCP",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "240",
+              "title": "Clinical Practice IV",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "241",
+              "title": "Rehabilitation and Home Care for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "242",
+              "title": "Perinatal / Pediatric Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "243",
+              "title": "Computer Applications for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "244",
+              "title": "Critical Care Considerations for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPT",
+              "number": "254",
+              "title": "Patient Assessment Techniques for the RCP",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies - Music Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-music-technology",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Core Requirements",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Concentration Area V Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MIC",
+              "number": "153",
+              "title": "Audio Engineering Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "201",
+              "title": "Survey of the Recording Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "251",
+              "title": "Advanced Audio Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "253",
+              "title": "Digital Audio Workstation Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "255",
+              "title": "MIDI Production and Synthesis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "291",
+              "title": "Audio for Visual Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "293",
+              "title": "Mixing Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Theatre Design and Technology, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/theatre/theatre-design-and-technology-aas",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Core Requirements",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "120",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Concentration Area V Courses",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THR",
+              "number": "113",
+              "title": "Theatre Workshop I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "114",
+              "title": "Theatre Workshop II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "115",
+              "title": "Theatre Workshop III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "124",
+              "title": "Theatre Technology Scenery & Lighting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "131",
+              "title": "Acting Techniques I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "210",
+              "title": "Introduction to Theatrical Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "221",
+              "title": "Scenographic Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "213",
+              "title": "Theatre Workshop IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "216",
+              "title": "Theatrical Makeup",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "224",
+              "title": "Scene Painting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "241",
+              "title": "Voice and Speech for the Performer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "296",
+              "title": "Directed Studies in Theatre",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Film and Digital Photography Short-term Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/visual-communications/film-and-digital-photography-shortterm-certificate",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Course Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "176",
+              "title": "Filmmaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "276",
+              "title": "Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTV",
+              "number": "115",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "130",
+              "title": "Film History and Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "145",
+              "title": "Introduction to Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "146",
+              "title": "Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies - Religious Studies Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/general-studies/general-studies-religious-studies-concentration",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Course Requirements",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "116",
+              "title": "Introduction to Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Concentration Area V Courses",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "History of World Religions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "151",
+              "title": "Survey of the Old Testament",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "152",
+              "title": "Survey of the New Testament",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Film and Multimedia Production, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/visual-communications/film-and-multimedia-production-aas",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Course Requirements",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Courses",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "176",
+              "title": "Filmmaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "276",
+              "title": "Filmmaking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "277",
+              "title": "Filmmaking III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAP",
+              "number": "122",
+              "title": "Storytelling and Previsualization Process/Project",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "283",
+              "title": "3D Graphics and Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "253",
+              "title": "Digital Audio Workstation Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "291",
+              "title": "Audio for Visual Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTV",
+              "number": "115",
+              "title": "Audio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "130",
+              "title": "Film History and Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "145",
+              "title": "Introduction to Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "146",
+              "title": "Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "172",
+              "title": "Digital Illustration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "282",
+              "title": "Advanced Digital Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "285",
+              "title": "Multimedia Production",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "289",
+              "title": "Portfolio",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Video Game Production, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/visual-communications/video-game-production-aas",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Core Requirements",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Video Game Production Core Coursework",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "299",
+              "title": "Art Portfolio",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAP",
+              "number": "101",
+              "title": "CGI Software Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAP",
+              "number": "104",
+              "title": "Introduction to Game Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAP",
+              "number": "107",
+              "title": "Concept Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAP",
+              "number": "121",
+              "title": "CGI Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAP",
+              "number": "122",
+              "title": "Storytelling and Previsualization Process/Project",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAP",
+              "number": "123",
+              "title": "CGI Shading, Lighting, and Rendering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAP",
+              "number": "124",
+              "title": "Game Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAP",
+              "number": "126",
+              "title": "Game Design: Narrative Games",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAP",
+              "number": "207",
+              "title": "Game Industry Survey: Esports and Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAP",
+              "number": "224",
+              "title": "Digital Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "253",
+              "title": "Digital Audio Workstation Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MIC",
+              "number": "291",
+              "title": "Audio for Visual Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "232",
+              "title": "Advanced Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Communications Graphics and Digital Design, A.A.S.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.calhoun.edu/visual-communications/visual-communications-graphics-and-digital-design-aas",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Course Requirements",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Coursework",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "126",
+              "title": "Color",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "221",
+              "title": "Computer Graphics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "253",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "254",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAP",
+              "number": "122",
+              "title": "Storytelling and Previsualization Process/Project",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "283",
+              "title": "3D Graphics and Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ORI",
+              "number": "110",
+              "title": "Freshman Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTV",
+              "number": "119",
+              "title": "Video Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTV",
+              "number": "219",
+              "title": "Video Production II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "145",
+              "title": "Introduction to Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "150",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "172",
+              "title": "Digital Illustration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "180",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "232",
+              "title": "Advanced Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "281",
+              "title": "Digital Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "282",
+              "title": "Advanced Digital Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VCM",
+              "number": "289",
+              "title": "Portfolio",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/al/programs/northwest-shoals-community-college.json
+++ b/data/al/programs/northwest-shoals-community-college.json
@@ -1,0 +1,7790 @@
+{
+  "college_slug": "northwest-shoals-community-college",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.nwscc.edu/degrees",
+  "scraped_at": "2026-06-03T21:27:41.546Z",
+  "programs": [
+    {
+      "title": "Accounting Technology - AOT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/accounting-technology/accounting-technology-aot",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Mathematics and Computer Science",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "114",
+              "title": "Introduction to Accounting Database Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "246",
+              "title": "Microcomputer Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "247",
+              "title": "Advanced Accounting Applications on the Microcomputer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "253",
+              "title": "Individual Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "254",
+              "title": "Business Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "256",
+              "title": "Cost Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Minor Requirements: Business Management and Supervision",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "279",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting Technology Bookkeeping",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/accounting-technology/accounting-technology-bookkeeping",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "114",
+              "title": "Introduction to Accounting Database Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "246",
+              "title": "Microcomputer Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Air Conditioning/Refrigeration Technology ACR Basic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/air-conditioningrefrigeration-technology/air-conditioningrefrigeration-technology-acr-basic",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning/Refrigeration Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/air-conditioningrefrigeration-technology/air-conditioningrefrigeration-technology",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVACR Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "126",
+              "title": "Commercial Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigeration Transition and Recovery Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "181",
+              "title": "Special Topics in Air Conditioning and Refrigeration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "149",
+              "title": "Heat Pump Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "203",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "205",
+              "title": "System Sizing and Air Distribution",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Commercial Air Conditioning Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Minor Requirements: Heating, Air Conditioning, Ventilation, and Refrigeration Maintenance",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning/Refrigeration Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/air-conditioningrefrigeration-technology/air-conditioningrefrigeration-technology-0",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area III: Natural Science and Mathematics",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "111",
+              "title": "Principles of Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "119",
+              "title": "Fundamentals of Gas Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "121",
+              "title": "Principles of Electricity for HVACR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVACR Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "126",
+              "title": "Commercial Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigeration Transition and Recovery Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "148",
+              "title": "Heat Pump Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "181",
+              "title": "Special Topics in Air Conditioning and Refrigeration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "203",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "205",
+              "title": "System Sizing and Air Distribution",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Commercial Air Conditioning Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning/Refrigeration Technology ACR Level 2",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/air-conditioningrefrigeration-technology/air-conditioningrefrigeration-technology-acr-level-2",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "112",
+              "title": "HVACR Service Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "209",
+              "title": "Commercial Air Conditioning Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "205",
+              "title": "System Sizing and Air Distribution",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning/Refrigeration Technology ACR Level 1",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/air-conditioningrefrigeration-technology/air-conditioningrefrigeration-technology-acr-level-1",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "113",
+              "title": "Refrigeration Piping Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "123",
+              "title": "HVACR Electrical Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "126",
+              "title": "Commercial Heating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "181",
+              "title": "Special Topics in Air Conditioning and Refrigeration I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/allied-health-linkage-programs/dental-hygiene",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "104",
+              "title": "Introduction to Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/allied-health-linkage-programs/dental-assisting",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Technology - Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/accounting-technology/accounting-technology-certificate",
+      "total_credits": 39,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "114",
+              "title": "Introduction to Accounting Database Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "246",
+              "title": "Microcomputer Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "247",
+              "title": "Advanced Accounting Applications on the Microcomputer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "253",
+              "title": "Individual Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "254",
+              "title": "Business Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "256",
+              "title": "Cost Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Air Conditioning/Refrigeration Technology ACR Level 3",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/air-conditioningrefrigeration-technology/air-conditioningrefrigeration-technology-acr-level-3",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACR",
+              "number": "132",
+              "title": "Residential Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "147",
+              "title": "Refrigeration Transition and Recovery Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACR",
+              "number": "203",
+              "title": "Commercial Refrigeration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Information Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/allied-health-linkage-programs/health-information-technology",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "211",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Human Services",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/allied-health-linkage-programs/human-services",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/allied-health-linkage-programs/physical-therapist-assistant",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "211",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapy",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/allied-health-linkage-programs/respiratory-therapy",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "* BIO 103 highly recommended prior to BIO 201 & 202. * BIO 201, ENG 101, and MTH 100 must be completed by the June 1 application deadline. The other courses may be completed at Wallace.",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Service Technology Advanced STC II - Advanced",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/automotive-service-technology/automotive-service-technology-advanced-stc-ii-advanced",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "212",
+              "title": "Advanced Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "224",
+              "title": "Manual Transmission and Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "230",
+              "title": "Auto Transmission and Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "239",
+              "title": "Engine Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "244",
+              "title": "Engine Performance and Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "246",
+              "title": "Automotive Emissions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "220",
+              "title": "Advanced Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Occupational Therapy Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/allied-health-linkage-programs/occupational-therapy-assistant",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "211",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Essentials of Automotive Service Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/automotive-service-technology/essentials-of-automotive-service-technology",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "101",
+              "title": "Fundamentals of Automotive Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "121",
+              "title": "Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "124",
+              "title": "Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Cabinetmaking Advanced",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/cabinetmaking/cabinetmaking-advanced",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAB",
+              "number": "102",
+              "title": "Introduction to Lumber and Wood Products",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "104",
+              "title": "Cabinet Shop Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "141",
+              "title": "Woodfinishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "230",
+              "title": "Estimating Costs in Cabinetmaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Service Technology STC 1 - Basic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/automotive-service-technology/automotive-service-technology-stc-1-basic",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "101",
+              "title": "Fundamentals of Automotive Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "121",
+              "title": "Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "122",
+              "title": "Steering, Suspension and Alignment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "124",
+              "title": "Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "130",
+              "title": "Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "133",
+              "title": "Motor Vehicle Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "162",
+              "title": "Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Carpentry Advanced",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/carpentry/carpentry-advanced",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUC",
+              "number": "113",
+              "title": "Basic Construction Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUC",
+              "number": "115",
+              "title": "Roof and Ceiling Framing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUC",
+              "number": "131",
+              "title": "Interior and Exterior Finishes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUC",
+              "number": "156",
+              "title": "Residential Repair and Remodeling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cabinetmaking Basic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/cabinetmaking/cabinetmaking-basic",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAB",
+              "number": "101",
+              "title": "Introduction to Cabinetmaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "103",
+              "title": "Sizes, Dimension, and Joints",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "110",
+              "title": "Equipment Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "204",
+              "title": "Cabinetmaking and Millwork",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Service Technology - AOT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/automotive-service-technology/automotive-service-technology-aot",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "101",
+              "title": "Fundamentals of Automotive Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "Electrical Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "121",
+              "title": "Braking Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "122",
+              "title": "Steering, Suspension and Alignment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "124",
+              "title": "Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "130",
+              "title": "Drive Train and Axles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "162",
+              "title": "Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "224",
+              "title": "Manual Transmission and Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "230",
+              "title": "Auto Transmission and Transaxle",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "239",
+              "title": "Engine Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "244",
+              "title": "Engine Performance and Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Minor Requirements: Automotive Engineering Technolgy/Technician",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "133",
+              "title": "Motor Vehicle Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "212",
+              "title": "Advanced Electrical and Electronic Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "220",
+              "title": "Advanced Automotive Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "246",
+              "title": "Automotive Emissions",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Carpentry Basic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/carpentry/carpentry-basic",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAR",
+              "number": "111",
+              "title": "Construction Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "112",
+              "title": "Floors, Walls, Site Prep",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "113",
+              "title": "Floors, Walls, Site Prep Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "114",
+              "title": "Construction Basics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Carpentry/Cabinetmaking",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/carpentrycabinetmaking/carpentrycabinetmaking",
+      "total_credits": 48,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAB",
+              "number": "101",
+              "title": "Introduction to Cabinetmaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "102",
+              "title": "Introduction to Lumber and Wood Products",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "103",
+              "title": "Sizes, Dimension, and Joints",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "104",
+              "title": "Cabinet Shop Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "110",
+              "title": "Equipment Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "141",
+              "title": "Woodfinishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "204",
+              "title": "Cabinetmaking and Millwork",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "230",
+              "title": "Estimating Costs in Cabinetmaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "111",
+              "title": "Construction Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "112",
+              "title": "Floors, Walls, Site Prep",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "113",
+              "title": "Floors, Walls, Site Prep Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "114",
+              "title": "Construction Basics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Minor Requirements: Building/Construction Finishing, Management, and Inspection Maintenance",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUC",
+              "number": "113",
+              "title": "Basic Construction Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUC",
+              "number": "115",
+              "title": "Roof and Ceiling Framing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUC",
+              "number": "131",
+              "title": "Interior and Exterior Finishes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUC",
+              "number": "156",
+              "title": "Residential Repair and Remodeling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Carpentry/Cabinetmaking",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/carpentrycabinetmaking/carpentrycabinetmaking-0",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "102",
+              "title": "Introduction to Lumber and Wood Products",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "103",
+              "title": "Sizes, Dimension, and Joints",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "104",
+              "title": "Cabinet Shop Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "110",
+              "title": "Equipment Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "141",
+              "title": "Woodfinishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "204",
+              "title": "Cabinetmaking and Millwork",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAB",
+              "number": "230",
+              "title": "Estimating Costs in Cabinetmaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUC",
+              "number": "156",
+              "title": "Residential Repair and Remodeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "113",
+              "title": "Floors, Walls, Site Prep Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "114",
+              "title": "Construction Basics Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUC",
+              "number": "113",
+              "title": "Basic Construction Print Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUC",
+              "number": "115",
+              "title": "Roof and Ceiling Framing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUC",
+              "number": "131",
+              "title": "Interior and Exterior Finishes",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Chemical Laboratory Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/chemistry/chemical-laboratory-technician",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "Principles of Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "112",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Child Development AAS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/child-development/child-development-aas",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area II: Humanities and Fine Arts",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHS",
+              "number": "111",
+              "title": "Physical Science I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Science",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "247",
+              "title": "Marriage and the Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "Child Growth and Development Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "202",
+              "title": "Children’s Creative Experiences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children’s Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Program Planning for Educating Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "Administration of Child Development Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "Infant and Toddler Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Educating Children with Exceptional Needs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "215",
+              "title": "Supervised Practical Experience in Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Auxiliary Teacher STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/child-development/auxiliary-teacher-stc",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/computer-information-systems-technology/computer-information-systems-technology",
+      "total_credits": 120,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Cyber Security Option: Area V: Technical Concentration and Electives",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "Advanced Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "148",
+              "title": "Post Advanced Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "157",
+              "title": "Introduction to App Development with Swift",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "205",
+              "title": "Control Language and Utilities Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Introduction to Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "209",
+              "title": "Advanced Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "214",
+              "title": "Security Analysis (PEN Testing)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "220",
+              "title": "App Development with Swift",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "227",
+              "title": "App Development with Swift II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "Cyber Defense",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "246",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "249",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "255",
+              "title": "Java Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "297",
+              "title": "Co-Op for CIS II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Software Development Option: Area V: Technical Concentration and Electives",
+          "credits_required": 57,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "Advanced Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "148",
+              "title": "Post Advanced Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "155",
+              "title": "Introduction to Mobile App Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "157",
+              "title": "Introduction to App Development with Swift",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "205",
+              "title": "Control Language and Utilities Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Introduction to Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "209",
+              "title": "Advanced Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "220",
+              "title": "App Development with Swift",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "227",
+              "title": "App Development with Swift II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "Cyber Defense",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "249",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "255",
+              "title": "Java Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "297",
+              "title": "Co-Op for CIS II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Technology Cyber Security Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/computer-information-systems-technology/computer-technology-cyber-security-technician",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "157",
+              "title": "Introduction to App Development with Swift",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "Network Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "214",
+              "title": "Security Analysis (PEN Testing)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "Cyber Defense",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "249",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "263",
+              "title": "Computer Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "246",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Technology Software Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/computer-information-systems-technology/computer-technology-software-technician",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "Advanced Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "148",
+              "title": "Post Advanced Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "157",
+              "title": "Introduction to App Development with Swift",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "205",
+              "title": "Control Language and Utilities Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "220",
+              "title": "App Development with Swift",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "227",
+              "title": "App Development with Swift II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "249",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Child Development STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/child-development/child-development-stc",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "Child Growth and Development Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "202",
+              "title": "Children’s Creative Experiences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children’s Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "Methods and Materials for Teaching Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Program Planning for Educating Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "Children’s Health and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "215",
+              "title": "Supervised Practical Experience in Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "Administration of Child Development Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "Infant and Toddler Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Educating Children with Exceptional Needs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "214",
+              "title": "Families and Communities in Early Care and Education Programs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education STC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/child-development/early-childhood-education-stc",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "Introduction of Early Care and Education of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "Child Growth and Development Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "Children’s Literature and Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Swift Programming",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/computer-information-systems-technology/swift-programming",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "157",
+              "title": "Introduction to App Development with Swift",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "220",
+              "title": "App Development with Swift",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "227",
+              "title": "App Development with Swift II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Salon and Spa Management Instructor Training",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/cosmetology-instructor-training/salon-and-spa-management-instructor-training",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "211",
+              "title": "Teaching and Curriculum Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "212",
+              "title": "Teacher Mentorship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "213",
+              "title": "Lesson Plan Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "214",
+              "title": "Lesson Plan Methods and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "221",
+              "title": "Lesson Plan Implementation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "222",
+              "title": "Instructional Materials and Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "223",
+              "title": "Instructional Materials and Methods Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "224",
+              "title": "Special Topics in Cosmetology Instruction",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "291",
+              "title": "Co-Op",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "162",
+              "title": "Special Topics in Cosmetology/Teaching Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "125",
+              "title": "Career and Personal Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "167",
+              "title": "State Board Review",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Microcomputer Applications",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/computer-information-systems-technology/microcomputer-applications",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "147",
+              "title": "Advanced Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "148",
+              "title": "Post Advanced Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "249",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Salon and Spa Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/cosmetology/salon-and-spa-management-0",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "190",
+              "title": "Internship in Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "Salon Management Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Introduction to Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Introduction to Cosmetology Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "Theory of Chemical Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Chemical Services Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Hair Coloring Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Hair Coloring Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "Basic Spa Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "Basic Spa Techniques Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "123",
+              "title": "Cosmetology Salon Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "167",
+              "title": "State Board Review",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "144",
+              "title": "Hair Shaping and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "145",
+              "title": "Hair Shaping Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Computer-Aided Design",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/design-engineering-technology/computeraided-design",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "104",
+              "title": "Basic Computer Aided Drafting and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "127",
+              "title": "Intermediate Computer Aided Drafting and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "231",
+              "title": "Advanced Cad",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "111",
+              "title": "Fundamentals of Drafting and Design Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Salon and Spa Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/cosmetology/salon-and-spa-management",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area II: Humanities and Fine Arts",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "190",
+              "title": "Internship in Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "201",
+              "title": "Entrepreneurship for Salon/Spa",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "Salon Management Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Introduction to Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Introduction to Cosmetology Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "Theory of Chemical Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Chemical Services Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Hair Coloring Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Hair Coloring Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "Basic Spa Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "Basic Spa Techniques Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "123",
+              "title": "Cosmetology Salon Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "144",
+              "title": "Hair Shaping and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "145",
+              "title": "Hair Shaping Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "167",
+              "title": "State Board Review",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/criminal-justice/criminal-justice",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area II: Humanities and Fine Arts",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "116",
+              "title": "Mathematical Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area IV: History, Social and Behavioral Science",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POL",
+              "number": "211",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "140",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "146",
+              "title": "Criminal Evidence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "216",
+              "title": "Police Organization and Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "220",
+              "title": "Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Design Engineering Technology - AAS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/design-engineering-technology/design-engineering-technology-aas",
+      "total_credits": 41,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Success Requirement",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "Student Success",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AREA I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AREA III: Mathematics & Natural Science",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Technical Physics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AREA V: Technical Specialties",
+          "credits_required": 51,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "104",
+              "title": "Basic Computer Aided Drafting and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "111",
+              "title": "Fundamentals of Drafting and Design Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "114",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "117",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "124",
+              "title": "Intro to Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "127",
+              "title": "Intermediate Computer Aided Drafting and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "128",
+              "title": "Intermediate Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "181",
+              "title": "Special Topics in Drafting and Design Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "220",
+              "title": "Advanced Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "231",
+              "title": "Advanced Cad",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "236",
+              "title": "Design Project",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Diagnostic Imaging - Radiography (Curriculum)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/diagnostic-imaging-radiography/diagnostic-imaging-radiography-curriculum",
+      "total_credits": 73,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester I (Fall)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "111",
+              "title": "Introduction to Radiography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "112",
+              "title": "Radiography Procedures I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "113",
+              "title": "Patient Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "114",
+              "title": "Clinical Education I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester II (Spring)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "122",
+              "title": "Radiographic Procedures II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "124",
+              "title": "Clinical Education II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "125",
+              "title": "Imaging Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester III (Summer)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "135",
+              "title": "Exposure Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "136",
+              "title": "Radiation Protection and Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "134",
+              "title": "Clinical Education III",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester IV (Fall)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "212",
+              "title": "Image Evaluation and Pathology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "214",
+              "title": "Clinical Education IV",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester V (Spring)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "227",
+              "title": "Review Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "224",
+              "title": "Clinical Education V",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/diagnostic-medical-sonography/diagnostic-medical-sonography",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Requisites",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Technical Physics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester I (Fall)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "202",
+              "title": "Foundations of Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "204",
+              "title": "Sectional Anatomy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "205",
+              "title": "Abdominal Sonography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "216",
+              "title": "Sonographic Principles & Instrumentation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "229",
+              "title": "Sonography Preceptorship",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester II (Spring)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "206",
+              "title": "Gynecologic Sonography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "207",
+              "title": "Abdominal Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "217",
+              "title": "Sonographic Principles & Instrumentation II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "220",
+              "title": "Obstetrical Sonography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "230",
+              "title": "Sonography Preceptorship II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester III (Summer)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "221",
+              "title": "Obstetrical Sonography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "225",
+              "title": "Superficial Sonography",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "231",
+              "title": "Sonography Preceptorship III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "240",
+              "title": "Sonography Principles & Instrumentation Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester IV (Fall)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "232",
+              "title": "Sonography Preceptorship IV",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "241",
+              "title": "Abdominal and Ob/Gyn Sonography Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "245",
+              "title": "Sonography Case Presentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "250",
+              "title": "Introduction to Advanced Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology - Career Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/electrical-technology/electrical-technology-career-certificate",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Technical Concentration",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Residential Wiring Methods II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "131",
+              "title": "Commercial/Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "217",
+              "title": "Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "234",
+              "title": "Industrial Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "235",
+              "title": "Industrial Motor Controls II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "114",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "241",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "242",
+              "title": "Journeyman Master Prep Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Conduit Bending and Installation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "245",
+              "title": "Electrical Grounding Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/electrical-technology/electrical-technology",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "109",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Residential Wiring Methods II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "131",
+              "title": "Commercial/Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "217",
+              "title": "Transformers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "241",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "242",
+              "title": "Journeyman Master Prep Exam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Conduit Bending and Installation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "245",
+              "title": "Electrical Grounding Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Minor Requirements: Automotive Manufacturing Technology for Electrical Technology",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "234",
+              "title": "Industrial Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "235",
+              "title": "Industrial Motor Controls II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "114",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology Commercial Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/electrical-technology/electrical-technology-commercial-technician",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "131",
+              "title": "Commercial/Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "241",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "244",
+              "title": "Conduit Bending and Installation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology Residential Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/electrical-technology/electrical-technology-residential-technician",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "114",
+              "title": "Residential Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Residential Wiring Methods II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "108",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "Wiring Methods",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services AEMT Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/emergency-medical-services/emergency-medical-services-aemt-certificate",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "Advanced Emergency Medical Technician Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology Industrial Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/electrical-technology/electrical-technology-industrial-technician",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "234",
+              "title": "Industrial Motor Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "235",
+              "title": "Industrial Motor Controls II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "114",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "117",
+              "title": "AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services Paramedic Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/emergency-medical-services/emergency-medical-services-paramedic-certificate",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "EMS Concentration",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "189",
+              "title": "Applied Anatomy and Physiology for the Paramedic",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Paramedic Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Cardiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic Patient Assessment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "Paramedic Applied Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic Clinical I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "Paramedic Medical Emergencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Trauma Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "Paramedic Special Populations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "Paramedic Transition to the Workplace",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Advanced Competencies for Paramedic",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "Paramedic Field Preceptorship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "Paramedic Team Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services EMT Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/emergency-medical-services/emergency-medical-services-emt-certificate",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/emergency-medical-services/emergency-medical-services",
+      "total_credits": 57,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "EMS Concentration",
+          "credits_required": 47,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "Emergency Medical Technician Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "189",
+              "title": "Applied Anatomy and Physiology for the Paramedic",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Paramedic Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Cardiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic Patient Assessment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "Paramedic Applied Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic Clinical I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "Paramedic Medical Emergencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Trauma Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "Paramedic Special Populations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "Paramedic Transition to the Workplace",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Advanced Competencies for Paramedic",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "Paramedic Field Preceptorship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "Paramedic Team Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Optional Advanced EMT Track",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "Advanced Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "Advanced Emergency Medical Technician Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems Technology: Basic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/industrial-maintenance-technology/industrial-systems-technology-basic",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "158",
+              "title": "Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems Technology - Career Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/industrial-maintenance-technology/industrial-systems-technology-career-certificate",
+      "total_credits": 39,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "158",
+              "title": "Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "161",
+              "title": "Blueprint Reading for Industrial Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "206",
+              "title": "Industrial Motors I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "222",
+              "title": "Special Topics: Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "280",
+              "title": "Special Topics Computer Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems Technology: Electrical Option",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/industrial-maintenance-technology/industrial-systems-technology-electrical-option",
+      "total_credits": 55,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Technical Physics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "158",
+              "title": "Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "161",
+              "title": "Blueprint Reading for Industrial Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "206",
+              "title": "Industrial Motors I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "213",
+              "title": "Industrial Motor Control II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "222",
+              "title": "Special Topics: Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "253",
+              "title": "Industrial Robotics Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "254",
+              "title": "Robot Maintenance and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "280",
+              "title": "Special Topics Computer Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems Technology: Electrical",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/industrial-maintenance-technology/industrial-systems-technology-electrical",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "206",
+              "title": "Industrial Motors I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "213",
+              "title": "Industrial Motor Control II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Education",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/general-education/general-education",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area II: Humanities and Fine Arts",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Electives",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "Student Success",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems Technology: Instrumentation",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/industrial-maintenance-technology/industrial-systems-technology-instrumentation",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "207",
+              "title": "Industrial Automatic Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "114",
+              "title": "Instrumentation Operation and Calibration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems Technology: FAME Option",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/industrial-maintenance-technology/industrial-systems-technology-fame-option",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Technical Physics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 49,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "142",
+              "title": "F.A.M.E Manufacturing Core Exercise 2, Workplace Visual Organization (5S)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "144",
+              "title": "FAME MANUFACTURING CORE EXERCISE 3, LEAN MANUFACTURING",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "146",
+              "title": "FAME MANUFACTURING CORE EXERCISE 4, PROBLEM SOLVING",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "148",
+              "title": "FAME MANUFACTURING CORE EXERCISE 5, MACHINE RELIABILITY",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "158",
+              "title": "Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "161",
+              "title": "Blueprint Reading for Industrial Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "206",
+              "title": "Industrial Motors I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "213",
+              "title": "Industrial Motor Control II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "222",
+              "title": "Special Topics: Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "254",
+              "title": "Robot Maintenance and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "280",
+              "title": "Special Topics Computer Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems Technology: Instrumentation Option",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/industrial-maintenance-technology/industrial-systems-technology-instrumentation-option",
+      "total_credits": 55,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Technical Physics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "158",
+              "title": "Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "161",
+              "title": "Blueprint Reading for Industrial Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "206",
+              "title": "Industrial Motors I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "207",
+              "title": "Industrial Automatic Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "222",
+              "title": "Special Topics: Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "280",
+              "title": "Special Topics Computer Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "114",
+              "title": "Instrumentation Operation and Calibration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "Sensors Technology and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems Technology: Mechanical",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/industrial-maintenance-technology/industrial-systems-technology-mechanical",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "106",
+              "title": "Elements of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems Technology: Mechanical Option",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/industrial-maintenance-technology/industrial-systems-technology-mechanical-option",
+      "total_credits": 55,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area III: Natural Sciences and Mathematics",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Technical Physics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "106",
+              "title": "Elements of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "121",
+              "title": "Industrial Hydraulics Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "127",
+              "title": "Principles of Industrial Pumps and Piping Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "158",
+              "title": "Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "161",
+              "title": "Blueprint Reading for Industrial Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "206",
+              "title": "Industrial Motors I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "222",
+              "title": "Special Topics: Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "280",
+              "title": "Special Topics Computer Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "105",
+              "title": "Lathes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "182",
+              "title": "Special Topics - Advanced Maintenance Welding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems Technology: Mechatronics Option",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/industrial-maintenance-technology/industrial-systems-technology-mechatronics-option",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area III: Mathematics and Natural Sciences",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "100",
+              "title": "Intermediate College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "Technical Physics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration",
+          "credits_required": 54,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "158",
+              "title": "Industrial Wiring I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "Industrial Motor Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "Principles of Industrial Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "Fundamentals of Industrial Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "Principles of Industrial Maintenance Welding and Metal Cutting Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "161",
+              "title": "Blueprint Reading for Industrial Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "Introduction to Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "206",
+              "title": "Industrial Motors I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "254",
+              "title": "Robot Maintenance and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "280",
+              "title": "Special Topics Computer Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Shop Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/machine-shop-technology/machine-shop-technology",
+      "total_credits": 46,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Machine Shop Electives",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSP",
+              "number": "101",
+              "title": "Basic Machining Technology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "102",
+              "title": "Intermediate Machining Technology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "103",
+              "title": "Advanced Machining Technology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "104",
+              "title": "Basic Machining Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "107",
+              "title": "Milling Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "112",
+              "title": "Basic Computer Numerical Control Turning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "115",
+              "title": "Advanced Milling Machines",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "142",
+              "title": "Advanced Machining Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "181",
+              "title": "Special Topics - Grinding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "221",
+              "title": "Advance Blueprinting",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Minor Requirements: Automotive Manufacturing Technology for Machine Shop",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "153",
+              "title": "Lathes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "166",
+              "title": "Basic Print Reading for Machinist",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "155",
+              "title": "Metrology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "255",
+              "title": "Basic Computer Numerical Control Milling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Shop Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/machine-shop-technology/machine-shop-technology-0",
+      "total_credits": 52,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 52,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSP",
+              "number": "101",
+              "title": "Basic Machining Technology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "102",
+              "title": "Intermediate Machining Technology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "103",
+              "title": "Advanced Machining Technology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "104",
+              "title": "Basic Machining Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "153",
+              "title": "Lathes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "107",
+              "title": "Milling Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "112",
+              "title": "Basic Computer Numerical Control Turning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "255",
+              "title": "Basic Computer Numerical Control Milling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "115",
+              "title": "Advanced Milling Machines",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "166",
+              "title": "Basic Print Reading for Machinist",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "155",
+              "title": "Metrology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "142",
+              "title": "Advanced Machining Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "181",
+              "title": "Special Topics - Grinding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "221",
+              "title": "Advance Blueprinting",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting Technology: Medical Billing and Coding Option",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/medical-assisting-technology/medical-assisting-technology-medical-billing-and-coding-option",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Medical Administrative Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Medical Administrative Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Medical Office Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "230",
+              "title": "Medical Coding Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "232",
+              "title": "Medical Coding Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "242",
+              "title": "Office Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/medical-assisting-technology/medical-assisting-technology",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area I: Written Composition",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area II: Humanities and Fine Arts",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration and Electives",
+          "credits_required": 47,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "107",
+              "title": "Student Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "Clinical Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Medical Administrative Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Medical Administrative Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "125",
+              "title": "Laboratory Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "128",
+              "title": "Medical Law and Ethics for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "200",
+              "title": "Management of Office Emergencies",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "211",
+              "title": "Clinical Procedures II for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "215",
+              "title": "Laboratory Procedures II for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "216",
+              "title": "Pharmacology for the Medical Office",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Medical Office Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "228",
+              "title": "Medical Assistant Review Course",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "229",
+              "title": "Medical Assisting Preceptorship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "230",
+              "title": "Medical Coding Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting Technology: Phlebotomy Option",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/medical-assisting-technology/medical-assisting-technology-phlebotomy-option",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "125",
+              "title": "Laboratory Procedures I for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "215",
+              "title": "Laboratory Procedures II for the Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "239",
+              "title": "Phlebotomy Preceptorship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/nursing/practical-nursing",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester I",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Fundamental Concepts of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester II",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Nursing Concepts",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester III",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Nursing Concepts II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "Evidence Based Clinical Reasoning",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/nurse-assistant/nursing-assistant",
+      "total_credits": 4,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NAS",
+              "number": "100",
+              "title": "Long Term Care Nursing Assistant",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Registered Nursing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/nursing/registered-nursing",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester I (Fall)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Fundamental Concepts of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester II (Spring)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Nursing Concepts",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester III (Summer)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Nursing Concepts II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "Evidence Based Clinical Reasoning",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester IV (Fall)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester V (Spring)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence Based Clinical Reasoning",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Medical Laboratory Technology - AAS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/medical-laboratory-technology/medical-laboratory-technology-aas",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequistes",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester I (Spring)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "121",
+              "title": "Hematology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "131",
+              "title": "Laboratory Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "141",
+              "title": "MLT Microbiology I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester II (Summer)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "142",
+              "title": "MLT Microbiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "151",
+              "title": "MLT Clinical Chemistry",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester III (Fall)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "111",
+              "title": "Urinalysis & Body Fluids",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "162",
+              "title": "Integrated Clinical and Laboratory Simulation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "181",
+              "title": "Clinical Immunology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "191",
+              "title": "MLT Immunohematology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester IV (Spring)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "293",
+              "title": "MLT Clinical Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "294",
+              "title": "Medical Laboratory Practicum Hematology and Urinalysis",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "295",
+              "title": "Medical Laboratory Practicum Microbiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "296",
+              "title": "Medical Laboratory Practicum Immunohematology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "297",
+              "title": "Medical Laboratory Practicum Chemistry and Immunology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Registered Nursing: Mobility (Healthcare Transition)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/nursing/registered-nursing-mobility-healthcare-transition",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester I (Spring)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "209",
+              "title": "Concepts for Healthcare Transition Students",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester II (Fall)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Advanced Nursing Concepts",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester III (Spring)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "Advanced Evidence Based Clinical Reasoning",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Business Office Management - AAS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/office-administration/business-office-management-aas",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Technical Courses and Electives",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "134",
+              "title": "Career and Professional Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records/Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "232",
+              "title": "The Computerized Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "243",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "246",
+              "title": "Microcomputer Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "The Legal and Social Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "279",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Salon & Spa AAS - Barbering Option",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/salon-and-spa-management/salon-spa-aas-barbering-option",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area II: Humanities and Fine Arts",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Area V: Technical Concentration",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAL",
+              "number": "201",
+              "title": "Entrepreneurship for Salon/Spa",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAL",
+              "number": "133",
+              "title": "Salon Management Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "Theory of Chemical Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Chemical Services Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Hair Coloring Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Hair Coloring Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "144",
+              "title": "Hair Shaping and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "167",
+              "title": "State Board Review",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "190",
+              "title": "Internship in Cosmetology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "108",
+              "title": "Introduction to Barbering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "109",
+              "title": "Bacteriology and Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "110",
+              "title": "Orientation to Barbering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "111",
+              "title": "Introduction to Barbering Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "112",
+              "title": "Science of Barbering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAR",
+              "number": "113",
+              "title": "Fundamentals of Barbering Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Water and Wastewater Management and Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/water-and-wastewater/water-and-wastewater-management-and-technology",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WMT",
+              "number": "100",
+              "title": "Water Supply and Wastewater Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WMT",
+              "number": "101",
+              "title": "Introduction to Water Treatment Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WMT",
+              "number": "102",
+              "title": "Introduction to Wastewater Treatment Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WMT",
+              "number": "120",
+              "title": "Sanitary Chemistry and Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WMT",
+              "number": "213",
+              "title": "Water and Wastewater Instrumentation and Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WMT",
+              "number": "214",
+              "title": "Basic Hydraulics for Water and Wastewater Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WMT",
+              "number": "291",
+              "title": "Municipal Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Welding Basic SMAW (Stick)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/welding/welding-basic-smaw-stick",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW Fillet/Pac/Cac",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW Fillet/Pac/CAC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "286",
+              "title": "SMAW Fillet/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "287",
+              "title": "SMAW Fillet/OFC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Business Office Management - Career Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/office-administration/business-office-management-career-certificate",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "Intermediate Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "Word Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "Records/Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Welding FCAW/GMAW (MIG/Flux Cored)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/welding/welding-fcawgmaw-migflux-cored",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection & Testing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding - AOT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/welding/welding-aot",
+      "total_credits": 48,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Area V: Technical Concentration and Major Requirements",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW Fillet/Pac/Cac",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "115",
+              "title": "GTAW Carbon Pipe Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding Groove Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW Fillet/Pac/CAC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "Shielded Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "155",
+              "title": "GTAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "217",
+              "title": "SMAW Carbon Pipe Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection & Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Minor Requirements: Automotive Manufacturing Technology for Welding",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "178",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Gas Tungsten Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "286",
+              "title": "SMAW Fillet/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "287",
+              "title": "SMAW Fillet/OFC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding SMAW Groove and Pipe (STICK)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/welding/welding-smaw-groove-and-pipe-stick",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding Groove Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "Shielded Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "217",
+              "title": "SMAW Carbon Pipe Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding GTAW Plate and Pipe (TIG)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/welding/welding-gtaw-plate-and-pipe-tig",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "115",
+              "title": "GTAW Carbon Pipe Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "155",
+              "title": "GTAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "178",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Gas Tungsten Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding - Career Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/welding/welding-career-certificate",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 54,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW Fillet/Pac/Cac",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "115",
+              "title": "GTAW Carbon Pipe Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "Shielded Metal Arc Welding Groove Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW Fillet/Pac/CAC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "Shielded Metal Arc Welding Groove Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "155",
+              "title": "GTAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "217",
+              "title": "SMAW Carbon Pipe Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection & Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW Carbon Pipe Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "286",
+              "title": "SMAW Fillet/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "287",
+              "title": "SMAW Fillet/OFC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "178",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "180",
+              "title": "Gas Tungsten Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology Basic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.nwscc.edu/welding/welding-technology-basic",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW Fillet/Pac/Cac",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "Industrial Blueprint Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW Fillet/Pac/CAC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "Gas Metal Arc/Flux Cored Arc Welding Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "219",
+              "title": "Welding Inspection & Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "286",
+              "title": "SMAW Fillet/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "287",
+              "title": "SMAW Fillet/OFC Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/al/programs/southern-union-state-community-college.json
+++ b/data/al/programs/southern-union-state-community-college.json
@@ -1,0 +1,8672 @@
+{
+  "college_slug": "southern-union-state-community-college",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.suscc.edu/degrees",
+  "scraped_at": "2026-06-03T21:27:51.200Z",
+  "programs": [
+    {
+      "title": "Automotive Service Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/automotive-service-technology/automotive-service-technology",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "101",
+              "title": "FUNDAMENTALS OF AUTOMOTIVE TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "ELECTRICAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "162",
+              "title": "ELECTRICAL AND ELECTRONIC SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "121",
+              "title": "BRAKING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "122",
+              "title": "STEERING & SUSPENSION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "124",
+              "title": "AUTOMOTIVE ENGINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "239",
+              "title": "ENGINE PERFORMANCE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "130",
+              "title": "DRIVE TRAIN AND AXLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "224",
+              "title": "MANUAL TRANSMISSION AND TRANSAXLE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "230",
+              "title": "AUTOMATIC TRANSMISSION AND TRANSAXLE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "220",
+              "title": "ADVANCED AUTOMOTIVE ENGINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "244",
+              "title": "ENGINE PERFORMANCE AND DIAGNOSTICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "246",
+              "title": "AUTOMOTIVE EMISSIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "133",
+              "title": "MOTOR VEHICLE AIR CONDITIONING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC MACHINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "162",
+              "title": "SOLID STATE FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "166",
+              "title": "MOTORS AND TRANSFORMERS I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Service",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/automotive-service-technology/automotive-service",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "101",
+              "title": "FUNDAMENTALS OF AUTOMOTIVE TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "ELECTRICAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "162",
+              "title": "ELECTRICAL AND ELECTRONIC SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "121",
+              "title": "BRAKING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "122",
+              "title": "STEERING & SUSPENSION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "124",
+              "title": "AUTOMOTIVE ENGINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "239",
+              "title": "ENGINE PERFORMANCE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology - Powerplant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/aviation-maintenance-technology/aviation-maintenance-technology-powerplant-0",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "101",
+              "title": "BASIC ELECTRICITY",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "TECHNICAL PREPARATION",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "MATERIALS AND PROCESSES",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "WEIGHT AND BALANCE, GROUND HANDLING AND SERVICING, CLEANING AND CORROSION CONTROL",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMP",
+              "number": "220",
+              "title": "RECIPROCATING ENGINES AND THEORY",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMP",
+              "number": "222",
+              "title": "RECIPROCATING ENGINE INSPECTIONS AND PROPELLERS",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMP",
+              "number": "223",
+              "title": "RECIPROCATING ENGINE OVERHAUL",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMP",
+              "number": "221",
+              "title": "TURBINE ENGINE THEORY AND SYSTEMS",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMP",
+              "number": "224",
+              "title": "TURBINE ENGINE INSPECTION AND OVERHAUL",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Maintenance Technology - Airframe",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/aviation-maintenance-technology/aviation-maintenance-technology-airframe",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "101",
+              "title": "BASIC ELECTRICITY",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "TECHNICAL PREPARATION",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "MATERIALS AND PROCESSES",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "WEIGHT AND BALANCE, GROUND HANDLING AND SERVICING, CLEANING AND CORROSION CONTROL",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "110",
+              "title": "NON-METALLIC STRUCTURES AND WELDING",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "111",
+              "title": "AIRCRAFT SHEET METAL STRUCTURES",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "112",
+              "title": "AIRFRAME SYSTEMS I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "113",
+              "title": "AIRFRAME SYSTEMS II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "114",
+              "title": "AIRFRAME SYSTEMS III",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "115",
+              "title": "AIRFRAME SYSTEMS IV",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/business-management/business-management",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "INTRODUCTION TO BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "MICROCOMPUTER APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "210",
+              "title": "INTRODUCTION TO ACCOUNTING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "PRINCIPLES OF MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "279",
+              "title": "SMALL BUSINESS MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "PRINCIPLES OF ACCOUNTING I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "BUSINESS COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "LEGAL AND SOCIAL ENVIRONMENT OF BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "113",
+              "title": "SPREADSHEET SOFTWARE APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "ACCOUNTING WITH QUICKBOOKS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Aviation Maintenance Technology - Airframe",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/aviation-maintenance-technology/aviation-maintenance-technology-airframe-0",
+      "total_credits": 56,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "101",
+              "title": "BASIC ELECTRICITY",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "TECHNICAL PREPARATION",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "MATERIALS AND PROCESSES",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "WEIGHT AND BALANCE, GROUND HANDLING AND SERVICING, CLEANING AND CORROSION CONTROL",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "110",
+              "title": "NON-METALLIC STRUCTURES AND WELDING",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "111",
+              "title": "AIRCRAFT SHEET METAL STRUCTURES",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "112",
+              "title": "AIRFRAME SYSTEMS I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "113",
+              "title": "AIRFRAME SYSTEMS II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "114",
+              "title": "AIRFRAME SYSTEMS III",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "115",
+              "title": "AIRFRAME SYSTEMS IV",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/business-management/business-management-0",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "INTRODUCTION TO BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "MICROCOMPUTER APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "231",
+              "title": "PRINCIPLES OF MACROECONOMICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "BUSINESS COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "PRINCIPLES OF ACCOUNTING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "PRINCIPLES OF MARKETING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "232",
+              "title": "PRINCIPLES OF MICROECONOMICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "ACCOUNTING WITH QUICKBOOKS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "PRINCIPLES OF MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "276",
+              "title": "HUMAN RESOURCE MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "279",
+              "title": "SMALL BUSINESS MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "LEGAL AND SOCIAL ENVIRONMENT OF BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Automotive Service Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/automotive-service-technology/automotive-service-technology-0",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "101",
+              "title": "FUNDAMENTALS OF AUTOMOTIVE TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "112",
+              "title": "ELECTRICAL FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "162",
+              "title": "ELECTRICAL AND ELECTRONIC SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "121",
+              "title": "BRAKING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "122",
+              "title": "STEERING & SUSPENSION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "124",
+              "title": "AUTOMOTIVE ENGINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "239",
+              "title": "ENGINE PERFORMANCE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "130",
+              "title": "DRIVE TRAIN AND AXLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "224",
+              "title": "MANUAL TRANSMISSION AND TRANSAXLE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "230",
+              "title": "AUTOMATIC TRANSMISSION AND TRANSAXLE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUM",
+              "number": "220",
+              "title": "ADVANCED AUTOMOTIVE ENGINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "244",
+              "title": "ENGINE PERFORMANCE AND DIAGNOSTICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "246",
+              "title": "AUTOMOTIVE EMISSIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUM",
+              "number": "133",
+              "title": "MOTOR VEHICLE AIR CONDITIONING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Business Management - Accounting",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/business-management/business-management-accounting",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "BUSINESS COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "131",
+              "title": "BUSINESS ENGLISH",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "PRINCIPLES OF ACCOUNTING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "242",
+              "title": "PRINCIPLES OF ACCOUNTING II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "245",
+              "title": "ACCOUNTING WITH QUICKBOOKS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "263",
+              "title": "LEGAL AND SOCIAL ENVIRONMENT OF BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "275",
+              "title": "PRINCIPLES OF MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "113",
+              "title": "SPREADSHEET SOFTWARE APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Aviation Maintenance Technology - Airframe",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/aviation-maintenance-technology/aviation-maintenance-technology-airframe-1",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "101",
+              "title": "BASIC ELECTRICITY",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "WEIGHT AND BALANCE, GROUND HANDLING AND SERVICING, CLEANING AND CORROSION CONTROL",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "TECHNICAL PREPARATION",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "MATERIALS AND PROCESSES",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management - Supervision",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/business-management/business-management-supervision",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "INTRODUCTION TO BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "BUSINESS COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "279",
+              "title": "SMALL BUSINESS MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Child Development",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/child-development/child-development",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "INTRODUCTION TO EARLY CARE & EDUCATION OF CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "CHILDREN'S LITERATURE AND LANGUAGE DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "GENERAL PSYCHOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "CHILD GROWTH AND DEVELOPMENT PRINCIPLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "202",
+              "title": "CHILDREN'S CREATIVE EXPERIENCES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "MICROCOMPUTER APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "METHODS AND MATERIALS FOR TEACHING YOUNG CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "CHILDREN'S HEALTH AND SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "224",
+              "title": "SCHOOL-AGE CHILDCARE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHS",
+              "number": "111",
+              "title": "PHYSICAL SCIENCE I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "PROGRAM PLANNING FOR EDUCATING YOUNG CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "ADMINISTRATION OF CHILD DEVELOPMENT PROGRAMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "INFANT AND TODDLER EDUCATION PROGRAMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "214",
+              "title": "FAMILIES AND COMMUNITIES IN EARLY CARE AND EDUCATION PROGRAMS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "EDUCATING CHILDREN WITH EXCEPTIONAL NEEDS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "215",
+              "title": "SUPERVISED PRACTICAL EXPERIENCE IN CHILD DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "INTRODUCTION TO BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "FIRST AID",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Aviation Maintenance Technology - Powerplant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/aviation-maintenance-technology/aviation-maintenance-technology-powerplant-1",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "101",
+              "title": "BASIC ELECTRICITY",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "WEIGHT AND BALANCE, GROUND HANDLING AND SERVICING, CLEANING AND CORROSION CONTROL",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "TECHNICAL PREPARATION",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "MATERIALS AND PROCESSES",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Child Development Associate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/child-development/child-development-associate",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "INTRODUCTION TO EARLY CARE & EDUCATION OF CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "CHILD GROWTH AND DEVELOPMENT PRINCIPLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "METHODS AND MATERIALS FOR TEACHING YOUNG CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Aviation Maintenance Technology - Powerplant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/aviation-maintenance-technology/aviation-maintenance-technology-powerplant",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "101",
+              "title": "BASIC ELECTRICITY",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "TECHNICAL PREPARATION",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "MATERIALS AND PROCESSES",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "WEIGHT AND BALANCE, GROUND HANDLING AND SERVICING, CLEANING AND CORROSION CONTROL",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMP",
+              "number": "220",
+              "title": "RECIPROCATING ENGINES AND THEORY",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMP",
+              "number": "222",
+              "title": "RECIPROCATING ENGINE INSPECTIONS AND PROPELLERS",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMP",
+              "number": "223",
+              "title": "RECIPROCATING ENGINE OVERHAUL",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMP",
+              "number": "221",
+              "title": "TURBINE ENGINE THEORY AND SYSTEMS",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMP",
+              "number": "224",
+              "title": "TURBINE ENGINE INSPECTION AND OVERHAUL",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/business-management/business-management-1",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "BUSINESS COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "MICROCOMPUTER APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "BEGINNING KEYBOARDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "131",
+              "title": "BUSINESS ENGLISH",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Basic CNC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/cnc-machining/basic-cnc",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSP",
+              "number": "111",
+              "title": "INTRODUCTION TO COMPUTER NUMERICAL CONTROL",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "212",
+              "title": "COMPUTER NUMERICAL CONTROL LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "243",
+              "title": "CNC TURNING LAB I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CNC Machining",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/cnc-machining/cnc-machining-0",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "104",
+              "title": "BASIC MACHINING CALCULATIONS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "121",
+              "title": "BASIC BLUEPRINT READING FOR MACHINISTS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "125",
+              "title": "INTRODUCTION TO MACHINING TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "292",
+              "title": "MSSC QUALITY PRACTICES AND MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "105",
+              "title": "LATHES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "107",
+              "title": "MILLING MACHINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "METROLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "293",
+              "title": "MSSC MANUFACTURING PROCESSES AND PRODUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "112",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL TURNING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "140",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL TURNING PROGRAMMING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "243",
+              "title": "CNC TURNING LAB I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "111",
+              "title": "INTRODUCTION TO COMPUTER NUMERICAL CONTROL",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "212",
+              "title": "COMPUTER NUMERICAL CONTROL LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "109",
+              "title": "ORIENTATION TO COMPUTER ASSISTED MANUFACTURING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSP",
+              "number": "113",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL MILLING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "128",
+              "title": "GEOMETRIC DIMENSIONING AND TOLERANCE I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "213",
+              "title": "ADVANCED COMPUTER NUMERICAL CONTROL MILLING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "223",
+              "title": "COMPUTER NUMERICAL CONTROL GRAPHICS PROGRAMMING: MILLING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Conventional Machining",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/cnc-machining/conventional-machining",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSP",
+              "number": "104",
+              "title": "BASIC MACHINING CALCULATIONS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "105",
+              "title": "LATHES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "107",
+              "title": "MILLING MACHINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "121",
+              "title": "BASIC BLUEPRINT READING FOR MACHINISTS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "125",
+              "title": "INTRODUCTION TO MACHINING TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "METROLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Child Development",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/child-development/child-development-1",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "INTRODUCTION TO EARLY CARE & EDUCATION OF CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "CHILD GROWTH AND DEVELOPMENT PRINCIPLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "202",
+              "title": "CHILDREN'S CREATIVE EXPERIENCES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "CHILDREN'S LITERATURE AND LANGUAGE DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "METHODS AND MATERIALS FOR TEACHING YOUNG CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "PROGRAM PLANNING FOR EDUCATING YOUNG CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "CHILDREN'S HEALTH AND SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "INFANT AND TODDLER EDUCATION PROGRAMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "FIRST AID",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Child Development",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/child-development/child-development-0",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "100",
+              "title": "INTRODUCTION TO EARLY CARE & EDUCATION OF CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "203",
+              "title": "CHILDREN'S LITERATURE AND LANGUAGE DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "MICROCOMPUTER APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "201",
+              "title": "CHILD GROWTH AND DEVELOPMENT PRINCIPLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "202",
+              "title": "CHILDREN'S CREATIVE EXPERIENCES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "204",
+              "title": "METHODS AND MATERIALS FOR TEACHING YOUNG CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "206",
+              "title": "CHILDREN'S HEALTH AND SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "224",
+              "title": "SCHOOL-AGE CHILDCARE",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "PROGRAM PLANNING FOR EDUCATING YOUNG CHILDREN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "208",
+              "title": "ADMINISTRATION OF CHILD DEVELOPMENT PROGRAMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "209",
+              "title": "INFANT AND TODDLER EDUCATION PROGRAMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "FIRST AID",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Cosmetology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/cosmetology/cosmetology-0",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "INTRODUCTION TO COSMETOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "INTRODUCTION TO COSMETOLOGY LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "137",
+              "title": "HAIR SHAPING AND DESIGN THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "145",
+              "title": "HAIR SHAPING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "THEORY OF CHEMICAL SERVICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "CHEMICAL SERVICES LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "HAIR COLORING THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "HAIR COLORING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "BASIC SPA TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "BASIC SPA TECHNIQUES LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "144",
+              "title": "HAIR SHAPING AND DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "123",
+              "title": "COSMETOLOGY SALON PRACTICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "162",
+              "title": "SPECIAL TOPICS IN COSMETOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "167",
+              "title": "STATE BOARD REVIEW",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "INTRODUCTION TO BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "BUSINESS COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "279",
+              "title": "SMALL BUSINESS MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CNC Machining",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/cnc-machining/cnc-machining",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "104",
+              "title": "BASIC MACHINING CALCULATIONS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "121",
+              "title": "BASIC BLUEPRINT READING FOR MACHINISTS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "125",
+              "title": "INTRODUCTION TO MACHINING TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "292",
+              "title": "MSSC QUALITY PRACTICES AND MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "105",
+              "title": "LATHES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "107",
+              "title": "MILLING MACHINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "127",
+              "title": "METROLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "293",
+              "title": "MSSC MANUFACTURING PROCESSES AND PRODUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "112",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL TURNING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "140",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL TURNING PROGRAMMING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "243",
+              "title": "CNC TURNING LAB I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "111",
+              "title": "INTRODUCTION TO COMPUTER NUMERICAL CONTROL",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "109",
+              "title": "ORIENTATION TO COMPUTER ASSISTED MANUFACTURING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "212",
+              "title": "COMPUTER NUMERICAL CONTROL LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CNC Milling",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/cnc-machining/cnc-milling",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSP",
+              "number": "113",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL MILLING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "213",
+              "title": "ADVANCED COMPUTER NUMERICAL CONTROL MILLING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "223",
+              "title": "COMPUTER NUMERICAL CONTROL GRAPHICS PROGRAMMING: MILLING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician (EMT) Basic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/emergency-medical-services/emergency-medical-technician-emt-basic",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "EMERGENCY MEDICAL TECHNICIAN",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "EMERGENCY MEDICAL TECHNICIAN CLINICAL",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cosmetology Instructor Training",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/cosmetology-instructor-training/cosmetology-instructor-training",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "211",
+              "title": "TEACHING AND CURRICULUM DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "212",
+              "title": "TEACHER MENTORSHIP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "214",
+              "title": "LESSON PLAN METHODS AND DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "221",
+              "title": "LESSON PLAN IMPLEMENTATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "222",
+              "title": "AUDIO VISUAL MATERIALS AND METHODS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "223",
+              "title": "AUDIO VISUAL MATERIALS AND METHODS APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "224",
+              "title": "SPECIAL TOPICS IN COSMETOLOGY INSTRUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "225",
+              "title": "SPECIAL TOPICS IN COSMETOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cosmetology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/cosmetology/cosmetology",
+      "total_credits": 48,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "INTRODUCTION TO COSMETOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "INTRODUCTION TO COSMETOLOGY LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "137",
+              "title": "HAIR SHAPING AND DESIGN THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "145",
+              "title": "HAIR SHAPING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "THEORY OF CHEMICAL SERVICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "CHEMICAL SERVICES LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "HAIR COLORING THEORY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "HAIR COLORING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "BASIC SPA TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "BASIC SPA TECHNIQUES LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "144",
+              "title": "HAIR SHAPING AND DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "123",
+              "title": "COSMETOLOGY SALON PRACTICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "162",
+              "title": "SPECIAL TOPICS IN COSMETOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "167",
+              "title": "STATE BOARD REVIEW",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CNC Turning",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/cnc-machining/cnc-turning",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTT",
+              "number": "140",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL TURNING PROGRAMMING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "243",
+              "title": "CNC TURNING LAB I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSP",
+              "number": "112",
+              "title": "BASIC COMPUTER NUMERICAL CONTROL TURNING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/criminal-justice/criminal-justice",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "INTRODUCTION TO CRIMINAL JUSTICE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "110",
+              "title": "INTRODUCTION TO LAW ENFORCEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "103",
+              "title": "WEIGHT TRAINING (Beginning)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "MICROCOMPUTER APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "140",
+              "title": "CRIMINAL LAW AND PROCEDURE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "150",
+              "title": "INTRODUCTION TO CORRECTIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "160",
+              "title": "INTRODUCTION TO SECURITY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "211",
+              "title": "AMERICAN NATIONAL GOVERNMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Additive Manufacturing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/engineering-and-design/additive-manufacturing",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "160",
+              "title": "ADDITIVE MANUFACTURING PRODUCTION TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "161",
+              "title": "SPECIALIZED SOFTWARE TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "162",
+              "title": "ADDITIVE MANUFACTURING PROCESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "114",
+              "title": "DESIGN INNOVATION",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician (EMT) Advanced",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/emergency-medical-services/emergency-medical-technician-emt-advanced",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Second Term",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "ADVANCED EMERGENCY MEDICAL TECHNICIAN",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "ADVANCED EMERGENCY MEDICAL TECHNICIAN CLINICAL",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician (EMT) Paramedic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/emergency-medical-services/emergency-medical-technician-emt-paramedic",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Third Term",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "PARAMEDIC CARDIOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "PARAMEDIC PATIENT ASSESSMENT",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "PARAMEDIC CLINICAL I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "PARAMEDIC APPLIED PHARMACOLOGY",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "PARAMEDIC MEDICAL EMERGENCIES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "PARAMEDIC TRAUMA MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "PARAMEDIC SPECIAL POPULATIONS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "PARAMEDIC CLINICAL II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "PARAMEDIC TRANSITION TO THE WORKFORCE",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "ADVANCED COMPETENCIES FOR PARAMEDIC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "PARAMEDIC FIELD PRECEPTORSHIP",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "PARAMEDIC TEAM LEADERSHIP",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician (EMT) Paramedic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/emergency-medical-services/emergency-medical-technician-emt-paramedic-0",
+      "total_credits": 58,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "EMERGENCY MEDICAL TECHNICIAN",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "EMERGENCY MEDICAL TECHNICIAN CLINICAL",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "ADVANCED EMERGENCY MEDICAL TECHNICIAN",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "ADVANCED EMERGENCY MEDICAL TECHNICIAN CLINICAL",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "PARAMEDIC CARDIOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "PARAMEDIC PATIENT ASSESSMENT",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "PARAMEDIC CLINICAL I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "PARAMEDIC APPLIED PHARMACOLOGY",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "PARAMEDIC MEDICAL EMERGENCIES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "PARAMEDIC TRAUMA MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "PARAMEDIC SPECIAL POPULATIONS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "PARAMEDIC CLINICAL II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "PARAMEDIC TRANSITION TO THE WORKFORCE",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "ADVANCED COMPETENCIES FOR PARAMEDIC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "PARAMEDIC FIELD PRECEPTORSHIP",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "PARAMEDIC TEAM LEADERSHIP",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering and Design",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/engineering-and-design/engineering-and-design",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "104",
+              "title": "BASIC COMPUTER AIDED DRAFTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "109",
+              "title": "FREEHAND SKETCHING",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "202",
+              "title": "INTRODUCTION TO TECHNOLOGY DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "112",
+              "title": "ORIENTATION TO ADDITIVE MANUFACTURING",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "127",
+              "title": "INTERMEDIATE COMPUTER AIDED DRAFTING AND DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "125",
+              "title": "SURFACE DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "233",
+              "title": "INTERMEDIATE 3D MODELING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "217",
+              "title": "MACHINE DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "160",
+              "title": "ADDITIVE MANUFACTURING PRODUCTION TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "161",
+              "title": "SPECIALIZED SOFTWARE TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "162",
+              "title": "ADDITIVE MANUFACTURING PROCESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "114",
+              "title": "DESIGN INNOVATION",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "PRECISION MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "261",
+              "title": "REVERSE ENGINEERING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "238",
+              "title": "SPECIAL TOPICS IN CAD",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "212",
+              "title": "INTERMEDIATE ARCHITECTURAL DRAFTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "132",
+              "title": "ARCHITECTURAL DRAFTING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Emergency Medical Technician (EMT) Paramedic",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/emergency-medical-services/emergency-medical-technician-emt-paramedic-1",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "118",
+              "title": "EMERGENCY MEDICAL TECHNICIAN",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "119",
+              "title": "EMERGENCY MEDICAL TECHNICIAN CLINICAL",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "155",
+              "title": "ADVANCED EMERGENCY MEDICAL TECHNICIAN",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "156",
+              "title": "ADVANCED EMERGENCY MEDICAL TECHNICIAN CLINICAL",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "PARAMEDIC CARDIOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "PARAMEDIC PATIENT ASSESSMENT",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "PARAMEDIC CLINICAL I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "257",
+              "title": "PARAMEDIC APPLIED PHARMACOLOGY",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "HUMAN ANATOMY AND PHYSIOLOGY I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "245",
+              "title": "PARAMEDIC MEDICAL EMERGENCIES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "PARAMEDIC TRAUMA MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "247",
+              "title": "PARAMEDIC SPECIAL POPULATIONS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "248",
+              "title": "PARAMEDIC CLINICAL II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "HUMAN ANATOMY AND PHYSIOLOGY II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "GENERAL PSYCHOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "253",
+              "title": "PARAMEDIC TRANSITION TO THE WORKFORCE",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "ADVANCED COMPETENCIES FOR PARAMEDIC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "255",
+              "title": "PARAMEDIC FIELD PRECEPTORSHIP",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "256",
+              "title": "PARAMEDIC TEAM LEADERSHIP",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "FUNDAMENTALS OF PUBLIC SPEAKING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Education",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/general-education/general-education",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Must complete a minimum of six (6) credit hours but no more than seven (7) credit hours for Area II: Humanities and Fine Arts",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ORI",
+              "number": "101",
+              "title": "ORIENTATION TO COLLEGE",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced CAD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/engineering-and-design/advanced-cad",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Reverse Engineering",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "101",
+              "title": "PRECISION MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "261",
+              "title": "REVERSE ENGINEERING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "238",
+              "title": "SPECIAL TOPICS IN CAD",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heating & Air Conditioning",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/heat-air-conditioning/heating-air-conditioning",
+      "total_credits": 84,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "111",
+              "title": "REFRIGERATION PRINCIPLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "121",
+              "title": "PRINCIPLES OF ELECTRICITY FOR HVAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "122",
+              "title": "HVACR ELECTRICAL CIRCUITS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "113",
+              "title": "REFRIGERATION PIPING PRACTICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "123",
+              "title": "HVACR ELECTRICAL COMPONENTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "147",
+              "title": "REFRIGERATION TRANSITION AND RECOVERY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "112",
+              "title": "HVACR SERVICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "203",
+              "title": "COMMERCIAL REFRIGERATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "210",
+              "title": "TROUBLESHOOTING HVAC/R SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "134",
+              "title": "ICE MACHINES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "119",
+              "title": "FUNDAMENTALS OF GAS HEATING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "120",
+              "title": "FUNDAMENTALS OF ELECTRIC HEATING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "148",
+              "title": "HEAT PUMP SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "128",
+              "title": "LOAD CALCULATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term - Option One",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "INTRODUCTION TO BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "BUSINESS COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "279",
+              "title": "SMALL BUSINESS MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term - Option Two",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "162",
+              "title": "SOLID STATE FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "166",
+              "title": "MOTORS AND TRANSFORMERS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC MACHINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "122",
+              "title": "Advanced AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architecture/Civil",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/engineering-and-design/architecturecivil",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Civil/GIS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "212",
+              "title": "INTERMEDIATE ARCHITECTURAL DRAFTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "132",
+              "title": "ARCHITECTURAL DRAFTING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heating & Air Conditioning",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/heat-air-conditioning/heating-air-conditioning-1",
+      "total_credits": 48,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "111",
+              "title": "REFRIGERATION PRINCIPLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "121",
+              "title": "PRINCIPLES OF ELECTRICITY FOR HVAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "122",
+              "title": "HVACR ELECTRICAL CIRCUITS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "113",
+              "title": "REFRIGERATION PIPING PRACTICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "123",
+              "title": "HVACR ELECTRICAL COMPONENTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "147",
+              "title": "REFRIGERATION TRANSITION AND RECOVERY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "112",
+              "title": "HVACR SERVICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "203",
+              "title": "COMMERCIAL REFRIGERATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "210",
+              "title": "TROUBLESHOOTING HVAC/R SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "134",
+              "title": "ICE MACHINES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "119",
+              "title": "FUNDAMENTALS OF GAS HEATING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "120",
+              "title": "FUNDAMENTALS OF ELECTRIC HEATING SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "148",
+              "title": "HEAT PUMP SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "128",
+              "title": "LOAD CALCULATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic CAD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/engineering-and-design/basic-cad",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Basic CAD",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "104",
+              "title": "BASIC COMPUTER AIDED DRAFTING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "109",
+              "title": "FREEHAND SKETCHING",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "202",
+              "title": "INTRODUCTION TO TECHNOLOGY DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "112",
+              "title": "ORIENTATION TO ADDITIVE MANUFACTURING",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Commercial Industrial Wiring",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/industrial-electricity/commercial-industrial-wiring",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "WIRING METHODS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "131",
+              "title": "WIRING 1 COMMERCIAL AND INDUSTRIAL",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "132",
+              "title": "COMMERCIAL AND INDUSTRIAL WIRING II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "206",
+              "title": "OSHA SAFETY STANDARDS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Electricity",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/industrial-electricity/industrial-electricity",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER CORE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "160",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "161",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "118",
+              "title": "CONSTRUCTION WIRING NEC",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "162",
+              "title": "SOLID STATE FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "122",
+              "title": "Advanced AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "166",
+              "title": "MOTORS AND TRANSFORMERS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC MACHINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "209",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "231",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "109",
+              "title": "ELECTRICAL BLUEPRINT READING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "115",
+              "title": "INDUSTRIAL CONTROLS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "131",
+              "title": "WIRING 1 COMMERCIAL AND INDUSTRIAL",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "132",
+              "title": "COMMERCIAL AND INDUSTRIAL WIRING II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "206",
+              "title": "OSHA SAFETY STANDARDS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "110",
+              "title": "WIRING METHODS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "104",
+              "title": "INDUSTRIAL INSTRUMENTATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "105",
+              "title": "INDUSTRIAL INSTRUMENTION LAB",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "SENSORS TECHNOLOGY AND APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "263",
+              "title": "CERTIFICATION PREP LAB",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Electricity - Basic Electricity",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/industrial-electricity/industrial-electricity-basic-electricity",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WKO",
+              "number": "110",
+              "title": "NCCER CORE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "118",
+              "title": "CONSTRUCTION WIRING NEC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "160",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "161",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Intermediate CAD",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/engineering-and-design/intermediate-cad",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "3D Modeling",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DDT",
+              "number": "127",
+              "title": "INTERMEDIATE COMPUTER AIDED DRAFTING AND DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "125",
+              "title": "SURFACE DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DDT",
+              "number": "233",
+              "title": "INTERMEDIATE 3D MODELING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "217",
+              "title": "MACHINE DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Process Controls",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/industrial-electricity/industrial-process-controls",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "104",
+              "title": "INDUSTRIAL INSTRUMENTATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "105",
+              "title": "INDUSTRIAL INSTRUMENTION LAB",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "240",
+              "title": "SENSORS TECHNOLOGY AND APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "263",
+              "title": "CERTIFICATION PREP LAB",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Solid State",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/industrial-electricity/solid-state",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "162",
+              "title": "SOLID STATE FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "166",
+              "title": "MOTORS AND TRANSFORMERS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "117",
+              "title": "AC/DC MACHINES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "122",
+              "title": "Advanced AC/DC Machines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/information-systems/information-systems-0",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "INTRODUCTION TO INFORMATION SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "NETWORK COMMUNICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "MICROCOMPUTER APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "INTRODUCTION TO WEB DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C + + PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "268",
+              "title": "SOFTWARE SUPPORT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "269",
+              "title": "HARDWARE SUPPORT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "246",
+              "title": "ETHICAL HACKING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "INTRODUCTION TO WEB DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "222",
+              "title": "DATABASE MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "256",
+              "title": "ADVANCED JAVA",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heating & Air Conditioning",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/heat-air-conditioning/heating-air-conditioning-0",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "111",
+              "title": "REFRIGERATION PRINCIPLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "121",
+              "title": "PRINCIPLES OF ELECTRICITY FOR HVAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "122",
+              "title": "HVACR ELECTRICAL CIRCUITS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "113",
+              "title": "REFRIGERATION PIPING PRACTICES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "123",
+              "title": "HVACR ELECTRICAL COMPONENTS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "147",
+              "title": "REFRIGERATION TRANSITION AND RECOVERY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "112",
+              "title": "HVACR SERVICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "203",
+              "title": "COMMERCIAL REFRIGERATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "210",
+              "title": "TROUBLESHOOTING HVAC/R SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "134",
+              "title": "ICE MACHINES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems - Computer and Network Support",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/information-systems/information-systems-computer-and-network-support",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "INTRODUCTION TO INFORMATION SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "MICROCOMPUTER APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "NETWORK COMMUNICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "256",
+              "title": "ADVANCED JAVA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "246",
+              "title": "ETHICAL HACKING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "268",
+              "title": "SOFTWARE SUPPORT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "269",
+              "title": "HARDWARE SUPPORT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "277",
+              "title": "NETWORK SERVICES ADMINISTRATION",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Safety",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/mechatronics/industrial-safety",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "119",
+              "title": "PRINCIPLES OF MECHANICAL MEASUREMENT AND TECHNICAL DRAWING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "129",
+              "title": "INDUSTRIAL SAFETY AND MAINTENANCE TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Systems",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/mechatronics/industrial-systems",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "132",
+              "title": "PREVENTIVE AND PREDICTIVE MAINTENANCE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "139",
+              "title": "INTRODUCTION TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "207",
+              "title": "INDUSTRIAL AUTOMATIC CONTROLS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "ADVANCED PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Electricity - Industrial Motor Controls",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/industrial-electricity/industrial-electricity-industrial-motor-controls",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ILT",
+              "number": "109",
+              "title": "ELECTRICAL BLUEPRINT READING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "115",
+              "title": "INDUSTRIAL CONTROLS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "231",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ILT",
+              "number": "209",
+              "title": "MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Manufacturing Production Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/mechatronics/manufacturing-production-technician",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "292",
+              "title": "MSSC QUALITY PRACTICES AND MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "293",
+              "title": "MSSC MANUFACTURING PROCESSES AND PRODUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/mechatronics/mechatronics",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "129",
+              "title": "INDUSTRIAL SAFETY AND MAINTENANCE TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "292",
+              "title": "MSSC QUALITY PRACTICES AND MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "119",
+              "title": "PRINCIPLES OF MECHANICAL MEASUREMENT AND TECHNICAL DRAWING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "158",
+              "title": "INDUSTRIAL WIRING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "293",
+              "title": "MSSC MANUFACTURING PROCESSES AND PRODUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "206",
+              "title": "INDUSTRIAL MOTORS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "207",
+              "title": "INDUSTRIAL AUTOMATIC CONTROLS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "INDUSTRIAL MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "215",
+              "title": "TROUBLESHOOTING TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/mechatronics/mechatronics-0",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "129",
+              "title": "INDUSTRIAL SAFETY AND MAINTENANCE TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "292",
+              "title": "MSSC QUALITY PRACTICES AND MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "119",
+              "title": "PRINCIPLES OF MECHANICAL MEASUREMENT AND TECHNICAL DRAWING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "158",
+              "title": "INDUSTRIAL WIRING I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "293",
+              "title": "MSSC MANUFACTURING PROCESSES AND PRODUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "206",
+              "title": "INDUSTRIAL MOTORS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "207",
+              "title": "INDUSTRIAL AUTOMATIC CONTROLS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "INDUSTRIAL MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "215",
+              "title": "TROUBLESHOOTING TECHNIQUES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "132",
+              "title": "PREVENTIVE AND PREDICTIVE MAINTENANCE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "139",
+              "title": "INTRODUCTION TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "284",
+              "title": "ADVANCED PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics - Basic Electricity",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/mechatronics/mechatronics-basic-electricity",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "101",
+              "title": "DC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "103",
+              "title": "AC FUNDAMENTALS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "158",
+              "title": "INDUSTRIAL WIRING I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems - Cloud Computing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/information-systems/information-systems-cloud-computing",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "LINUX I (Fall Only)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "237",
+              "title": "VIRTUAL INFRASTUCTURE: INSTALLATION AND CONFIGURATION (SPRING ONLY)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "238",
+              "title": "CLOUD COMPUTING - INFRASTRUCTURE AND SERVICES (FALL ONLY)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems - Hardware and Software Support",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/information-systems/information-systems-hardware-and-software-support",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "*CIS 130 may be challenged.",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "268",
+              "title": "SOFTWARE SUPPORT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "269",
+              "title": "HARDWARE SUPPORT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/medical-assistant-technology/medical-assistant-0",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Academic Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "FIRST AID",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "GENERAL PSYCHOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program-Specific Courses",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "CLINICAL PROCEDURES I FOR THE MEDICAL ASSISTANT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "125",
+              "title": "LABORATORY PROCEDURES I FOR THE MEDICAL ASSISTANT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "CLINICAL SPECIALITIES FOR THE MEDICAL ASSISTANT",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "215",
+              "title": "LABORATORY PROCEDURES II FOR THE MEDICAL ASSISTANT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "216",
+              "title": "PHARMACOLOGY FOR THE MEDICAL OFFICE",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "218",
+              "title": "EKG TECHNICIAN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "228",
+              "title": "MEDICAL ASSISTANT REVIEW COURSE",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "230",
+              "title": "Medical Assisting Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "239",
+              "title": "PHLEBOTOMY PRECEPTORSHIP",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NAS",
+              "number": "100",
+              "title": "LONG TERM CARE NURSING ASSISTANT",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "BEGINNING KEYBOARDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "MICROCOMPUTER APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "HUMAN GROWTH AND DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "100",
+              "title": "EXPLORING TEACHING AS A PROFESSION",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Multicare Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/medical-assistant-technology/multicare-technician",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "CLINICAL PROCEDURES I FOR THE MEDICAL ASSISTANT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "125",
+              "title": "LABORATORY PROCEDURES I FOR THE MEDICAL ASSISTANT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "FIRST AID",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "CLINICAL SPECIALITIES FOR THE MEDICAL ASSISTANT",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "215",
+              "title": "LABORATORY PROCEDURES II FOR THE MEDICAL ASSISTANT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "218",
+              "title": "EKG TECHNICIAN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "239",
+              "title": "PHLEBOTOMY PRECEPTORSHIP",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/information-systems/information-systems",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "INTRODUCTION TO INFORMATION SYSTEMS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "199",
+              "title": "NETWORK COMMUNICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "INTRODUCTION TO WEB DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "C + + PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "268",
+              "title": "SOFTWARE SUPPORT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "269",
+              "title": "HARDWARE SUPPORT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "256",
+              "title": "ADVANCED JAVA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "BUSINESS COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "222",
+              "title": "DATABASE MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "246",
+              "title": "ETHICAL HACKING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics - Industrial Motor Controls",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/mechatronics/mechatronics-industrial-motor-controls",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "INDUSTRIAL MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/medical-assistant-technology/phlebotomy-technician",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "125",
+              "title": "LABORATORY PROCEDURES I FOR THE MEDICAL ASSISTANT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "215",
+              "title": "LABORATORY PROCEDURES II FOR THE MEDICAL ASSISTANT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "239",
+              "title": "PHLEBOTOMY PRECEPTORSHIP",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/nursing/nursing",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "HUMAN ANATOMY AND PHYSIOLOGY I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "FUNDAMENTAL CONCEPTS OF NURSING",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "HUMAN ANATOMY AND PHYSIOLOGY II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "HUMAN GROWTH AND DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "NURSING CONCEPTS I",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "NURSING CONCEPTS II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "115",
+              "title": "EVIDENCE BASED CLINICAL REASONING",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "GENERAL MICROBIOLOGY",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "ADVANCED NURSING CONCEPTS",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "ADVANCED EVIDENCE BASED CLINICAL REASONING",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Office Administration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/office-administration/office-administration-0",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "BEGINNING KEYBOARDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "INTRODUCTION TO BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "INTERMEDIATE KEYBOARDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "131",
+              "title": "BUSINESS ENGLISH",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "146",
+              "title": "MICROCOMPUTER APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "GENERAL PSYCHOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "WORD PROCESSING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "210",
+              "title": "INTRODUCTION TO ACCOUNTING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "RECORDS/INFORMATION MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "BUSINESS COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "113",
+              "title": "SPREADSHEET SOFTWARE APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Medical Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/medical-assistant-technology/administrative-medical-assistant",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "CLINICAL PROCEDURES I FOR THE MEDICAL ASSISTANT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "CLINICAL SPECIALITIES FOR THE MEDICAL ASSISTANT",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "216",
+              "title": "PHARMACOLOGY FOR THE MEDICAL OFFICE",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Administration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/office-administration/office-administration-1",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "101",
+              "title": "BEGINNING KEYBOARDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "INTRODUCTION TO BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "210",
+              "title": "INTRODUCTION TO ACCOUNTING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "103",
+              "title": "INTERMEDIATE KEYBOARDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "131",
+              "title": "BUSINESS ENGLISH",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "RECORDS/INFORMATION MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "113",
+              "title": "SPREADSHEET SOFTWARE APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "WORD PROCESSING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "OFFICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Administration - Medical",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/office-administration/office-administration-medical",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "215",
+              "title": "HEALTH INFORMATION MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "SURVEY OF HUMAN BIOLOGY",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "214",
+              "title": "MEDICAL OFFICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "216",
+              "title": "ADVANCED HEALTH INFORMATION MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/medical-assistant-technology/medical-assistant",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Academic Courses",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "FIRST AID",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "MAT Program Courses",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "CLINICAL PROCEDURES I FOR THE MEDICAL ASSISTANT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "216",
+              "title": "PHARMACOLOGY FOR THE MEDICAL OFFICE",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "125",
+              "title": "LABORATORY PROCEDURES I FOR THE MEDICAL ASSISTANT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "CLINICAL SPECIALITIES FOR THE MEDICAL ASSISTANT",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "215",
+              "title": "LABORATORY PROCEDURES II FOR THE MEDICAL ASSISTANT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "218",
+              "title": "EKG TECHNICIAN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "228",
+              "title": "MEDICAL ASSISTANT REVIEW COURSE",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "230",
+              "title": "Medical Assisting Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "239",
+              "title": "PHLEBOTOMY PRECEPTORSHIP",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant (PTA)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/physical-therapist-assistant/physical-therapist-assistant-pta",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Phase (Semesters 1-2)",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "HUMAN ANATOMY AND PHYSIOLOGY I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "HUMAN ANATOMY AND PHYSIOLOGY II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "GENERAL PSYCHOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "HUMAN GROWTH AND DEVELOPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPH",
+              "number": "107",
+              "title": "FUNDAMENTALS OF PUBLIC SPEAKING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPS",
+              "number": "105",
+              "title": "MEDICAL TERMINOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "ETHICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PTA Technical Phase (Semesters 3-5)",
+          "credits_required": 38,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "220",
+              "title": "FUNCTIONAL ANATOMY & KINESIOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "222",
+              "title": "FUNCTIONAL ANATOMY & KINESIOLOGY LAB",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "250",
+              "title": "THERAPEUTIC PROCEDURES I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "202",
+              "title": "COMMUNICATION SKILLS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "240",
+              "title": "PHYSICAL DISABILITIES I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "241",
+              "title": "PHYSICAL DISABILITIES II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "251",
+              "title": "THERAPEUTIC PROCEDURES II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "230",
+              "title": "NEUROSCIENCE",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "231",
+              "title": "REHAB TECHNIQUES",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "232",
+              "title": "ORTHOPEDICS FOR THE PTA",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "260",
+              "title": "CLINICAL EDUCATION I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "200",
+              "title": "PT ISSUES AND TRENDS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "201",
+              "title": "PTA SEMINAR",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "263",
+              "title": "CLINICAL AFFILIATION I,",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "268",
+              "title": "CLINICAL PRACTICUM",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "ADN Mobility",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/nursing/adn-mobility",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "209",
+              "title": "CONCEPTS FOR HEALTHCARE TRANSITION STUDENTS",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "GENERAL MICROBIOLOGY",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "ADVANCED NURSING CONCEPTS",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "221",
+              "title": "ADVANCED EVIDENCE BASED CLINICAL REASONING",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing Assistant / Medication Aide",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/nursing-assistant/nursing-assistant-medication-aide",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NNAS",
+              "number": "9102",
+              "title": "MEDICATION ASSISTANT",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Basic Tool & Die",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/plastics-engineering-technology/basic-tool-die",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "147",
+              "title": "MOLD DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "205",
+              "title": "Mold Maintenance and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Administration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/office-administration/office-administration",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OAD",
+              "number": "125",
+              "title": "WORD PROCESSING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "INTRODUCTION TO BUSINESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "BUSINESS COMMUNICATION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "113",
+              "title": "SPREADSHEET SOFTWARE APPLICATIONS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "131",
+              "title": "BUSINESS ENGLISH",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "138",
+              "title": "RECORDS/INFORMATION MANAGEMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OAD",
+              "number": "218",
+              "title": "OFFICE PROCEDURES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/radiologic-technology/radiologic-technology",
+      "total_credits": 75,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "HUMAN ANATOMY AND PHYSIOLOGY I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "111",
+              "title": "INTRODUCTION TO RADIOGRAPHY",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "112",
+              "title": "RADIOGRAPHY PROCEDURES I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "113",
+              "title": "PATIENT CARE",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "114",
+              "title": "CLINICAL EDUCATION I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "HUMAN ANATOMY AND PHYSIOLOGY II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "122",
+              "title": "RADIOGRAPHIC PROCEDURES II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "125",
+              "title": "IMAGING EQUIPMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "124",
+              "title": "CLINICAL EDUCATION II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "135",
+              "title": "EXPOSURE PRINCIPLES",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "136",
+              "title": "RADIATION PROTECTION AND BIOLOGY",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "134",
+              "title": "CLINICAL EDUCATION III",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "GENERAL PSYCHOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "212",
+              "title": "IMAGE EVALUATION AND PATHOLOGY",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "214",
+              "title": "CLINICAL EDUCATION IV",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "227",
+              "title": "REVIEW SEMINAR",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "224",
+              "title": "CLINICAL EDUCATION V",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/surgical-technology/surgical-technology",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "PRINCIPLES OF BIOLOGY I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "HUMAN ANATOMY AND PHYSIOLOGY I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPS",
+              "number": "105",
+              "title": "MEDICAL TERMINOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester I: Summer",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SUR",
+              "number": "100",
+              "title": "PRINCIPLES OF SURGICAL TECHNOLOGY",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "109",
+              "title": "INTRODUCTION TO SURGICAL EQUIPMENT, INSTRUMENTATION AND SUPPLIES",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester II: Fall",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SUR",
+              "number": "101",
+              "title": "INTRODUCTION TO SURGICAL TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "102",
+              "title": "APPLIED SURGICAL TECHNIQUES",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "107",
+              "title": "SURGICAL ANATOMY AND PATHOPHYSIOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "GENERAL MICROBIOLOGY",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester III: Spring",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SUR",
+              "number": "111",
+              "title": "CLINICAL PROCEDURES",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "105",
+              "title": "SURGICAL PRACTICUM II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "106",
+              "title": "ROLE TRANSITION IN SURGICAL TECHNOLOGY",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Optional Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SUR",
+              "number": "204",
+              "title": "SURGICAL PRACTICUM III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "205",
+              "title": "SURGICAL PRACTICUM IV",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Molding",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/plastics-engineering-technology/basic-molding",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "145",
+              "title": "INTRODUCTION TO MOLDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "146",
+              "title": "INTRODUCTION TO MOLDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plastics Engineering Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/plastics-engineering-technology/plastics-engineering-technology",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "145",
+              "title": "INTRODUCTION TO MOLDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "146",
+              "title": "INTRODUCTION TO MOLDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "292",
+              "title": "MSSC QUALITY PRACTICES AND MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "173",
+              "title": "MOLD SETTER SKILLS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "175",
+              "title": "MOLD SETTER SKILLS LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "INDUSTRIAL MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "147",
+              "title": "MOLD DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "293",
+              "title": "MSSC MANUFACTURING PROCESSES AND PRODUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "205",
+              "title": "Mold Maintenance and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "139",
+              "title": "INTRODUCTION TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "273",
+              "title": "MOLD PROCESSING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "275",
+              "title": "MOLD PROCESSING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "205",
+              "title": "ADVANCED MOLDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "132",
+              "title": "PREVENTIVE AND PREDICTIVE MAINTENANCE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mold Setter",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/plastics-engineering-technology/mold-setter",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "173",
+              "title": "MOLD SETTER SKILLS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "175",
+              "title": "MOLD SETTER SKILLS LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "INDUSTRIAL MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plastics Engineering Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/plastics-engineering-technology/plastics-engineering-technology-0",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "145",
+              "title": "INTRODUCTION TO MOLDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "146",
+              "title": "INTRODUCTION TO MOLDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "118",
+              "title": "FUNDAMENTALS OF INDUSTRIAL HYDRAULICS AND PNEUMATICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "292",
+              "title": "MSSC QUALITY PRACTICES AND MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "113",
+              "title": "INDUSTRIAL MOTOR CONTROLS I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "173",
+              "title": "MOLD SETTER SKILLS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "175",
+              "title": "MOLD SETTER SKILLS LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "293",
+              "title": "MSSC MANUFACTURING PROCESSES AND PRODUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "147",
+              "title": "MOLD DESIGN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTT",
+              "number": "205",
+              "title": "Mold Maintenance and Repair",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "117",
+              "title": "PRINCIPLES OF INDUSTRIAL MECHANICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "139",
+              "title": "INTRODUCTION TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "273",
+              "title": "MOLD PROCESSING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "275",
+              "title": "MOLD PROCESSING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Process Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/plastics-engineering-technology/process-technician",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "184",
+              "title": "INTRODUCTION TO PROGRAMMABLE LOGIC CONTROLLERS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "273",
+              "title": "MOLD PROCESSING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "275",
+              "title": "MOLD PROCESSING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "132",
+              "title": "PREVENTIVE AND PREDICTIVE MAINTENANCE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "139",
+              "title": "INTRODUCTION TO ROBOTIC PROGRAMMING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "205",
+              "title": "ADVANCED MOLDING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Therapeutic Massage",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/therapeutic-massage/therapeutic-massage",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSG",
+              "number": "101",
+              "title": "INTRODUCTION TO THERAPEUTIC MASSAGE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "102",
+              "title": "THERAPEUTIC MASSAGE LAB I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "104",
+              "title": "MUSCULOSKELETAL AND KINESIOLOGY I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSG",
+              "number": "105",
+              "title": "THERAPEUTIC MASSAGE SUPERVISED CLINICAL I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "202",
+              "title": "THERAPEUTIC MASSAGE LAB II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "204",
+              "title": "MUSCULOSKELETAL AND KINESIOLOGY II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSG",
+              "number": "201",
+              "title": "THERAPEUTIC MASSAGE FOR SPECIAL POPULATIONS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "203",
+              "title": "PATHOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "THERAPEUTIC MASSAGE SUPERVISED CLINICAL II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "206",
+              "title": "NATIONAL CERTIFICATION EXAM REVIEW",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Wellness and Therapeutic Massage",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/therapeutic-massage-wellness-and-sport-sciences/wellness-and-therapeutic-massage",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSG",
+              "number": "101",
+              "title": "INTRODUCTION TO THERAPEUTIC MASSAGE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "102",
+              "title": "THERAPEUTIC MASSAGE LAB I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "104",
+              "title": "MUSCULOSKELETAL AND KINESIOLOGY I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSG",
+              "number": "105",
+              "title": "THERAPEUTIC MASSAGE SUPERVISED CLINICAL I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "202",
+              "title": "THERAPEUTIC MASSAGE LAB II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "204",
+              "title": "MUSCULOSKELETAL AND KINESIOLOGY II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "ENGLISH COMPOSITION II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "226",
+              "title": "WELLNESS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSG",
+              "number": "201",
+              "title": "THERAPEUTIC MASSAGE FOR SPECIAL POPULATIONS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "203",
+              "title": "PATHOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "205",
+              "title": "THERAPEUTIC MASSAGE SUPERVISED CLINICAL II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSG",
+              "number": "206",
+              "title": "NATIONAL CERTIFICATION EXAM REVIEW",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "221",
+              "title": "PERSONAL HEALTH",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPS",
+              "number": "116",
+              "title": "OVERVIEW OF COMPLEMENTARY AND ALTERNATIVE THERAPIES",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "*MTH 100 or higher will be accepted.",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "FIRST AID",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "100",
+              "title": "FUNDAMENTALS OF FITNESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "223",
+              "title": "METHODS OF INSTRUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "105",
+              "title": "PERSONAL FITNESS",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/welding-technology/welding-technology",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "INDUSTRIAL BLUEPRINT READING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "292",
+              "title": "MSSC QUALITY PRACTICES AND MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW FILLET/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW FILLET/OFC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW FILLET/PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW FILLET/PAC/CAC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "293",
+              "title": "MSSC MANUFACTURING PROCESSES AND PRODUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "SHIELDED METAL ARC WELDING GROOVE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "SHIELDED METAL ARC WELDING GROOVE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "228",
+              "title": "GAS TUNGSTEN ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "115",
+              "title": "GTAW CARBON PIPE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "155",
+              "title": "GTAW CARBON PIPE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "217",
+              "title": "SMAW CARBON PIPE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW CARBON PIPE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "218",
+              "title": "Certification",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/welding-technology/welding-technology-0",
+      "total_credits": 54,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Term",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "291",
+              "title": "MSSC SAFETY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "INDUSTRIAL BLUEPRINT READING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Term",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "292",
+              "title": "MSSC QUALITY PRACTICES AND MEASUREMENT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW FILLET/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW FILLET/OFC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW FILLET/PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW FILLET/PAC/CAC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Term",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "293",
+              "title": "MSSC MANUFACTURING PROCESSES AND PRODUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "SHIELDED METAL ARC WELDING GROOVE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "SHIELDED METAL ARC WELDING GROOVE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "228",
+              "title": "GAS TUNGSTEN ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Term",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "294",
+              "title": "MSSC MAINTENANCE AWARENESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "115",
+              "title": "GTAW CARBON PIPE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "155",
+              "title": "GTAW CARBON PIPE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Wellness and Personal Trainer Certificate",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/wellness-and-sport-sciences/wellness-and-personal-trainer-certificate",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Survey of Human Biology may be substituted for BIO 201 and BIO 202.",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PED",
+              "number": "100",
+              "title": "FUNDAMENTALS OF FITNESS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "221",
+              "title": "PERSONAL HEALTH",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "222",
+              "title": "COMMUNITY HEALTH",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HED",
+              "number": "231",
+              "title": "FIRST AID",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "223",
+              "title": "METHODS OF INSTRUCTION",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "HUMAN ANATOMY AND PHYSIOLOGY I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "HUMAN ANATOMY AND PHYSIOLOGY II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Gas Tungsten Arc Welding",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/welding-technology/basic-gas-tungsten-arc-welding",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "120",
+              "title": "SHIELDED METAL ARC WELDING GROOVE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "125",
+              "title": "SHIELDED METAL ARC WELDING GROOVE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "228",
+              "title": "GAS TUNGSTEN ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Basic Shielded Metal Arc Welding",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/welding-technology/basic-shielded-metal-arc-welding",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "108",
+              "title": "SMAW FILLET/OFC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "122",
+              "title": "SMAW FILLET/OFC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "109",
+              "title": "SMAW FILLET/PAC/CAC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "123",
+              "title": "SMAW FILLET/PAC/CAC LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Veterinary Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/veterinary-technology/veterinary-technology",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Prerequisites",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "103",
+              "title": "PRINCIPLES OF BIOLOGY I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "ENGLISH COMPOSITION I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "GENERAL PSYCHOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "102",
+              "title": "ETHICS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester I",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VET",
+              "number": "110",
+              "title": "VETERINARY TECH CLINICS I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "113",
+              "title": "FUNDAMENTALS OF VETERINARY TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "114",
+              "title": "CLINICAL ANATOMY AND PHYSIOLOGY OF ANIMALS",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "247",
+              "title": "LABORATORY AND EXOTIC ANIMALS",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester II",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "VETERINARY TECH CLINICS II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "124",
+              "title": "CLINICAL PROCEDURES AND PATHOLOGY",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "236",
+              "title": "VETERINARY PARASITOLOGY AND MICROBIOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "126",
+              "title": "ANIMAL DISEASES AND IMMUNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "280",
+              "title": "VETERINARY DIAGNOSTIC IMAGING",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester III",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VET",
+              "number": "230",
+              "title": "VETERINARY TECH CLINICS III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "275",
+              "title": "VETERINARY ANESTHESIA AND ANALGESIA",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "246",
+              "title": "VETERINARY TECH FARM ANIMAL CLINICS",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "234",
+              "title": "ANIMAL PHARMACOLOGY AND TOXICOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester IV",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "VETERINARY TECHNOLOGY EMERGENCIES AND FIRST AID",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "240",
+              "title": "VETERINARY TECH CLINICS IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "250",
+              "title": "VETERINARY TECH PRECEPTORSHIP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "244",
+              "title": "REVIEW IN VETERINARY TECHNOLOGY",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Gas Metal Arc Welding",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/welding-technology/basic-gas-metal-arc-welding",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "110",
+              "title": "INDUSTRIAL BLUEPRINT READING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "119",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "124",
+              "title": "GAS METAL ARC/FLUX CORED ARC WELDING LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Carbon Arc Pipe Welding",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.suscc.edu/welding-technology/carbon-arc-pipe-welding",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WDT",
+              "number": "115",
+              "title": "GTAW CARBON PIPE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "155",
+              "title": "GTAW CARBON PIPE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "217",
+              "title": "SMAW CARBON PIPE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "257",
+              "title": "SMAW CARBON PIPE LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WDT",
+              "number": "218",
+              "title": "Certification",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/lib/states/al/config.ts
+++ b/lib/states/al/config.ts
@@ -87,7 +87,11 @@ const alConfig: StateConfig = {
     // / prerequisite_courses fields and flattens them into a single
     // data/al/prereqs.json keyed by course code.
     prereqs: { source: "aggregate-from-courses" },
-    // manual-only: programs — Phase 5+.
+    // Degree/program requirements for the 9 CleanCatalog colleges that yield
+    // parseable programs (14 more deferred — see data/al/DEFERRED-programs.md).
+    programs: [
+      { scripts: ["scripts/al/scrape-programs.ts"], runner: "http" },
+    ],
   },
   documentedCeilings: {
     courses: [

--- a/scripts/al/scrape-programs.ts
+++ b/scripts/al/scrape-programs.ts
@@ -1,0 +1,78 @@
+/**
+ * scrape-programs.ts — degree/program requirements for AL.
+ *
+ * Seeded from scripts/lib/discover-programs.ts (probed each AL college's
+ * catalog domain, derived from the Scorecard schoolUrl). Of 23 colleges, 9
+ * CleanCatalog installs yield parseable programs and are scraped here; the
+ * other 14 are deferred with reasons in data/al/DEFERRED-programs.md.
+ *
+ * Usage:
+ *   npx tsx scripts/al/scrape-programs.ts
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import { scrapeCleanCatalogPrograms } from "../lib/scrape-cleancatalog-programs.js";
+
+const CATALOG_YEAR = "2025-2026";
+
+async function run(
+  slug: string,
+  scrape: () => Promise<{ programs: unknown[]; catalog_year: string; catalog_url: string; college_slug: string; scraped_at: string }>,
+): Promise<void> {
+  console.log(`\n=== ${slug} ===`);
+  try {
+    const data = await scrape();
+    if (data.programs.length === 0) {
+      console.log(`  No programs found for ${slug}.`);
+      return;
+    }
+    const { matched, unmatched } = applyProgramMatching(data.programs as never);
+    console.log(`  Matcher: ${matched} matched / ${unmatched} unmatched`);
+    const outDir = path.join(process.cwd(), "data", "al", "programs");
+    fs.mkdirSync(outDir, { recursive: true });
+    const outPath = path.join(outDir, `${slug}.json`);
+    fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+    console.log(`  ✓ Wrote ${data.programs.length} programs → ${outPath}`);
+  } catch (e) {
+    console.error(`  ✗ ${slug} failed: ${e}`);
+  }
+}
+
+// The 9 CleanCatalog colleges whose /degrees index yields parseable program
+// detail pages. 5 more discovered colleges yield nothing on the default crawl
+// and are deferred — see data/al/DEFERRED-programs.md (coastal, trenholm,
+// central-alabama: non-standard catalog structure; drake-state: SmartCatalogIQ
+// URL unresolved; shelton-state: Acalog navoids needed).
+const CLEANCATALOG: { slug: string; baseUrl: string; indexPaths?: string[] }[] = [
+  { slug: "bevill-state-community-college", baseUrl: "https://catalog.bscc.edu" },
+  { slug: "chattahoochee-valley-community-college", baseUrl: "https://catalog.cv.edu" },
+  { slug: "gadsden-state-community-college", baseUrl: "https://catalog.gadsdenstate.edu" },
+  { slug: "george-c-wallace-community-college-dothan", baseUrl: "https://catalog.wallace.edu" },
+  { slug: "george-c-wallace-state-community-college-hanceville", baseUrl: "https://wallacestate.cleancatalog.net" },
+  { slug: "george-c-wallace-state-community-college-selma", baseUrl: "https://catalog.wccs.edu" },
+  { slug: "john-c-calhoun-state-community-college", baseUrl: "https://catalog.calhoun.edu" },
+  { slug: "northwest-shoals-community-college", baseUrl: "https://catalog.nwscc.edu" },
+  { slug: "southern-union-state-community-college", baseUrl: "https://catalog.suscc.edu" },
+];
+
+async function main() {
+  console.log("AL program scraper");
+
+  for (const c of CLEANCATALOG) {
+    await run(c.slug, () =>
+      scrapeCleanCatalogPrograms({
+        collegeSlug: c.slug,
+        baseUrl: c.baseUrl,
+        catalogYear: CATALOG_YEAR,
+        ...(c.indexPaths ? { indexPaths: c.indexPaths } : {}),
+      }),
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changes for someone using the site

Alabama community-college pages now show **degree/program requirements**. On `/al/program/<major>` (e.g. business administration, welding, nursing) you can see, per college, the courses each program requires — and the semester planner can now be seeded from an AL program. Alabama already had course listings, prerequisites, and transfer data; **programs were the missing dataset gating the planner**, and this fills it for 9 colleges.

Concretely: **747 programs with requirement groups across 9 colleges**, matched to 15 majors (business-administration 64, welding 43, nursing 30, engineering 30, early-childhood-education 25, computer-science 24, ...).

## What changes on the technical front

- **`scripts/al/scrape-programs.ts`** wires 9 AL colleges to the generic CleanCatalog scraper (`scripts/lib/scrape-cleancatalog-programs.ts`). Targets were found by `scripts/lib/discover-programs.ts`, which probed each college's catalog domain (derived from the College Scorecard `schoolUrl`, since AL `institutions.json` has no domains).
- **`lib/states/al/config.ts`** now declares `scrapers.programs`, so the unified `scheduled-scrape.yml` cron picks it up (CI `check:scrapers` passes).
- **`data/al/programs/*.json`** — the scraped requirement data. The runtime reads it via the program-data file fallback (these files are bundled — not in `outputFileTracingExcludes`); the import pipeline loads it into Supabase post-merge.
- **`data/al/DEFERRED-programs.md`** documents the other 14 colleges with reasons + next steps.

### Coverage (9 of 23) and why
Of 23 AL colleges, discovery found 14 on a supported catalog platform; 9 of those yielded parseable programs. Deferred (in the doc):
- **5** had a platform but no parseable programs: coastal & trenholm (CleanCatalog `/degrees` empty — non-standard structure), central-alabama (programs under category pages that don't link to detail pages), drake-state (SmartCatalogIQ URL unresolved), shelton-state (Acalog `programNavoids` needed).
- **9** had no public catalog matching a known platform (likely Modern Campus / custom / PDF).

## Test plan
- Discovery: probed all 23 AL catalog domains → 14 platform hits (12 CleanCatalog, 1 SmartCatalogIQ, 1 Acalog).
- Scrape: 9 colleges → 747 programs, all with `requirement_groups` carrying real courses; matcher 300/747 → registry slugs.
- Data integrity: each file's `college_slug` equals its filename (no planner-hiding mismatch).
- UI: `/al/program/business-administration` renders per-college requirements (Bevill/Calhoun/Gadsden/Southern Union/Wallace) via the file fallback — the same path prod uses until the Supabase import runs.
- `check:scrapers` OK (51 states × 4 datatypes); `next build` exit 0; `tsc` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)