### PR TITLE
fix: don't load AdSense on authenticated/private routes (COPPA)

### DIFF
--- a/components/AdSenseScript.tsx
+++ b/components/AdSenseScript.tsx
@@ -1,10 +1,19 @@
 "use client";
 
 import Script from "next/script";
+import { usePathname } from "next/navigation";
+import { isAdFreeRoute } from "@/lib/ad-free-routes";
 
 export default function AdSenseScript() {
   const clientId = process.env.NEXT_PUBLIC_ADSENSE_ID;
-  if (!clientId) return null;
+  const pathname = usePathname();
+
+  // Do not load Google's ad library on authenticated/private routes (the
+  // account dashboard, a saved-plan view) — viewed by signed-in students
+  // including under-18 dual-enrollees. usePathname() is reactive, so on
+  // client-side navigation INTO an ad-free route this returns null and the
+  // injected <script> is unmounted. See lib/ad-free-routes.ts.
+  if (!clientId || isAdFreeRoute(pathname)) return null;
 
   return (
     <Script

--- a/components/AdUnit.tsx
+++ b/components/AdUnit.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { isAdFreeRoute } from "@/lib/ad-free-routes";
 
 type AdFormat = "auto" | "horizontal" | "rectangle" | "vertical";
 
@@ -20,18 +22,22 @@ export default function AdUnit({ slot, format = "auto", className = "" }: AdUnit
   const adRef = useRef<HTMLModElement>(null);
   const pushed = useRef(false);
   const clientId = process.env.NEXT_PUBLIC_ADSENSE_ID;
+  const adFree = isAdFreeRoute(usePathname());
 
   useEffect(() => {
-    if (!clientId || pushed.current) return;
+    if (!clientId || adFree || pushed.current) return;
     try {
       (window.adsbygoogle = window.adsbygoogle || []).push({});
       pushed.current = true;
     } catch {
       // AdSense not loaded
     }
-  }, [clientId]);
+  }, [clientId, adFree]);
 
-  if (!clientId) return null;
+  // No ad slot on authenticated/private routes — defense-in-depth alongside
+  // AdSenseScript. Today no AdUnit is placed on such a route, but this keeps
+  // the guarantee if one is ever added. See lib/ad-free-routes.ts.
+  if (!clientId || adFree) return null;
 
   return (
     <div className={`ad-container overflow-hidden ${className}`}>

--- a/lib/__tests__/ad-free-routes.test.ts
+++ b/lib/__tests__/ad-free-routes.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isAdFreeRoute } from "@/lib/ad-free-routes";
+
+describe("isAdFreeRoute", () => {
+  it("is true for authenticated / private routes (account dashboard, saved-plan view)", () => {
+    expect(isAdFreeRoute("/account")).toBe(true);
+    expect(isAdFreeRoute("/account/settings")).toBe(true);
+    expect(isAdFreeRoute("/plan")).toBe(true);
+    expect(isAdFreeRoute("/plan/3f9c1b2a-0000-4000-8000-000000000000")).toBe(true);
+  });
+
+  it("is false for public, ad-bearing routes", () => {
+    expect(isAdFreeRoute("/")).toBe(false);
+    expect(isAdFreeRoute("/va")).toBe(false);
+    expect(isAdFreeRoute("/va/courses")).toBe(false);
+    expect(isAdFreeRoute("/va/transfer")).toBe(false);
+    expect(isAdFreeRoute("/blog/some-post")).toBe(false);
+    expect(isAdFreeRoute("/va/program/accounting")).toBe(false);
+  });
+
+  it("keeps the public per-state planner builder (/[state]/plan) ad-bearing — only the private /plan/[id] is ad-free", () => {
+    // /va/plan is the public 'build a plan' page; ads are allowed there.
+    expect(isAdFreeRoute("/va/plan")).toBe(false);
+  });
+
+  it("does not match lookalike prefixes", () => {
+    expect(isAdFreeRoute("/accounts")).toBe(false);
+    expect(isAdFreeRoute("/planning")).toBe(false);
+  });
+
+  it("handles null / undefined / empty pathnames", () => {
+    expect(isAdFreeRoute(null)).toBe(false);
+    expect(isAdFreeRoute(undefined)).toBe(false);
+    expect(isAdFreeRoute("")).toBe(false);
+  });
+});

--- a/lib/ad-free-routes.ts
+++ b/lib/ad-free-routes.ts
@@ -1,0 +1,30 @@
+/**
+ * Routes where Google AdSense must never load or render.
+ *
+ * These are authenticated / private pages — the account dashboard
+ * (`/account`) and a user's saved-plan view (`/plan/[id]`). They are seen only
+ * by signed-in students, an audience that includes under-18 dual-enrollment
+ * students, so we neither load Google's ad library (`adsbygoogle.js`) nor
+ * render any ad slot here.
+ *
+ * See docs/auth-gating-matrix.md — cross-cutting requirement:
+ * "ads OFF on every LOGIN-ONLY / account route."
+ *
+ * Single source of truth: consumed by both `AdSenseScript` (skips the library
+ * loader) and `AdUnit` (skips the ad slot), so the two cannot drift.
+ *
+ * FOLLOW-UP (needs the age-gate PR): this is the conservative line — no ads for
+ * ANY logged-in user on these private routes. A later PR introduces the 13+ age
+ * attestation and turns OFF ad personalization specifically for under-18
+ * accounts on the remaining (public) ad routes. That requires an age signal
+ * that does not exist yet, so it is intentionally out of scope here.
+ */
+export function isAdFreeRoute(pathname: string | null | undefined): boolean {
+  if (!pathname) return false;
+  return (
+    pathname === "/account" ||
+    pathname.startsWith("/account/") ||
+    pathname === "/plan" ||
+    pathname.startsWith("/plan/")
+  );
+}


### PR DESCRIPTION
## What changes for someone using the site

On the account page (`/account`) and a saved-plan page (`/plan/[id]`), Google ads no longer load at all. Those pages are seen only by signed-in students — an audience that includes under-18 dual-enrollment students — so Google's ad library stays off them entirely. Everywhere else (home, course search, college / transfer / program pages, blog) ads are unchanged.

## Why

Those pages were loading Google's `adsbygoogle.js` library, which is mounted globally in the root layout (`app/layout.tsx`). Serving Google's ad script / personalized ads to logged-in minors is a COPPA / age-appropriate-design risk, and it sits badly next to the "never monetize student-intent data" stance. The login-gating decision doc (#1169) lists *"ads OFF on every LOGIN-ONLY / account route"* as a cross-cutting requirement — this is the first of those, and the only Milestone-A item that fixes a *currently-active* exposure rather than a missing future safeguard.

## How it works

A single source-of-truth predicate `isAdFreeRoute(pathname)` (`lib/ad-free-routes.ts`), consumed by **both** the ad-library loader (`AdSenseScript`) and the ad-slot component (`AdUnit`) so the two can't drift. It's pathname-based via `usePathname()`, which is reactive — so ads stay off even when you navigate into `/account` client-side, not just on a hard load. Public routes are untouched (predicate returns `false`), so ad revenue and SEO are unaffected.

## Scope / known follow-up

Conservative line: **no ads for any logged-in user** on `/account` and `/plan/[id]`. Turning off ad *personalization* specifically for under-18 accounts on the remaining public routes needs an age signal that doesn't exist until the age-gate PR (next in Milestone A); a code comment flags this.

## Test plan

- **Unit test** (`lib/__tests__/ad-free-routes.test.ts`, 5 cases), incl. the subtle `/va/plan` (public planner → ads **ON**) vs `/plan/[id]` (private → ads **OFF**) split.
- **Dev controlled experiment:** `/` and `/va/courses` keep `adsbygoogle` (1 hit each); a 404 on a *public* path keeps it (control — proves it's path-gated, not just that 404s lack ads); `/plan` and `/account/*` drop to **0** hits.
- `npm run build` passes (typecheck + full route compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)