### PR TITLE
feat: 13+ age + Terms/Privacy consent gate at signup, add Terms page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import AdSenseScript from "@/components/AdSenseScript";
 import ThemeProvider from "@/components/ThemeProvider";
 import AuthProvider from "@/components/AuthProvider";
 import LoginModal from "@/components/auth/LoginModal";
+import ConsentPrompt from "@/components/auth/ConsentPrompt";
 import JsonLd from "@/components/JsonLd";
 import Footer from "@/components/Footer";
 import { getAllStates } from "@/lib/states/registry";
@@ -123,6 +124,7 @@ export default function RootLayout({
             {children}
             <Footer />
             <LoginModal />
+            <ConsentPrompt />
           </AuthProvider>
         </ThemeProvider>
         <Analytics />

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+// DRAFT — pending legal review before launch. This is reasonable, specific
+// boilerplate written to ship a real (non-empty) Terms page and back the
+// signup consent gate; have counsel vet/replace the copy before relying on it.
+// Bump lib/consent.ts TOS_VERSION when the substance changes materially.
+
+export const metadata: Metadata = {
+  title: "Terms of Service — Community College Path",
+  description:
+    "The terms that govern your use of Community College Path, including eligibility (13+), acceptable use, and our promises about your data.",
+};
+
+export default function TermsPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <h1 className="text-3xl font-bold mb-8">Terms of Service</h1>
+      <p className="text-sm text-gray-500 dark:text-slate-400 mb-8">
+        Effective date: June 4, 2026
+      </p>
+
+      <div className="prose prose-gray dark:prose-invert max-w-none space-y-6 text-gray-700 dark:text-slate-300">
+        <section>
+          <p>
+            Welcome to Community College Path (&ldquo;we,&rdquo; &ldquo;us&rdquo;). These Terms of
+            Service (&ldquo;Terms&rdquo;) govern your use of communitycollegepath.com (the
+            &ldquo;Service&rdquo;). By using the Service or creating an account, you agree to
+            these Terms and to our{" "}
+            <Link href="/privacy" className="text-teal-600 underline">Privacy Policy</Link>. If you
+            do not agree, please do not use the Service.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mt-8 mb-3">1. Who can use the Service</h2>
+          <p>
+            Anyone may browse the Service. To <strong>create an account</strong> you must be at
+            least <strong>13 years old</strong>. If you are under 18, please review these Terms with
+            a parent or guardian. We do not knowingly collect personal information from children
+            under 13; if you believe a child under 13 has created an account, please{" "}
+            <Link href="/contact" className="text-teal-600 underline">contact us</Link> and we will
+            delete it.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mt-8 mb-3">2. What the Service is</h2>
+          <p>
+            Community College Path helps students find courses, plan schedules, and understand
+            transfer equivalencies across public community-college systems. Course, transfer, and
+            program information is gathered from public sources and provided for planning purposes.
+            It may be incomplete or out of date &mdash; always confirm details (registration,
+            prerequisites, transferability, cost) directly with the college or university before
+            making decisions. We are not affiliated with, or endorsed by, any college, university,
+            or government agency.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mt-8 mb-3">3. Your account</h2>
+          <p>
+            You are responsible for activity under your account, and for keeping your sign-in method
+            secure. You can delete your account at any time from your account page.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mt-8 mb-3">4. Acceptable use</h2>
+          <p>
+            Please do not misuse the Service. Do not attempt to breach security or access other
+            users&apos; data, scrape at a scale that burdens our systems, or use the Service for
+            unlawful, harmful, or deceptive purposes. Automated access must respect our robots.txt.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mt-8 mb-3">5. Our promises about your data</h2>
+          <p>
+            We build this for students. <strong>We will not sell your personal information</strong>,
+            and we will not package or sell student-intent data &mdash; the courses, plans, or
+            programs you save or track &mdash; to advertisers, colleges, or universities. We hold
+            student-entered planning data (the courses and plans you choose), <strong>not</strong>{" "}
+            official transcripts or education records from a school, so this is not a FERPA
+            &ldquo;education record.&rdquo; See our{" "}
+            <Link href="/privacy" className="text-teal-600 underline">Privacy Policy</Link> for what
+            we collect and why.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mt-8 mb-3">6. Content and intellectual property</h2>
+          <p>
+            The Service, its design, and original content are ours or our licensors&apos;. Public
+            course and transfer data is presented for your personal, non-commercial planning use.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mt-8 mb-3">7. Disclaimers</h2>
+          <p>
+            The Service is provided &ldquo;as is&rdquo; and &ldquo;as available,&rdquo; without
+            warranties of any kind. We do not guarantee the accuracy, completeness, or availability
+            of any information, including course schedules, open seats, prerequisites, or transfer
+            outcomes.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mt-8 mb-3">8. Limitation of liability</h2>
+          <p>
+            To the fullest extent permitted by law, Community College Path is not liable for any
+            indirect, incidental, or consequential damages, or for decisions you make based on
+            information from the Service. Always confirm anything important with the school.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mt-8 mb-3">9. Changes to these Terms</h2>
+          <p>
+            We may update these Terms. If we make material changes, we will update the effective
+            date above and, where appropriate, ask you to re-accept. Continued use after a change
+            means you accept the updated Terms.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mt-8 mb-3">10. Contact</h2>
+          <p>
+            Questions about these Terms? <Link href="/contact" className="text-teal-600 underline">Contact us</Link>.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -9,6 +9,11 @@ import {
   type ReactNode,
 } from "react";
 import type { SupabaseClient, User } from "@supabase/supabase-js";
+import {
+  CONSENT_PENDING_KEY,
+  TOS_VERSION,
+  decideConsentAction,
+} from "@/lib/consent";
 
 // Type-only imports above don't add bundle weight. The runtime
 // `@supabase/supabase-js` code is behind a dynamic import in
@@ -26,6 +31,8 @@ export interface Profile {
   auth_provider: string | null;
   default_state: string | null;
   preferences: Record<string, unknown>;
+  tos_accepted_at: string | null;
+  tos_version: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -46,6 +53,10 @@ export interface AuthContextValue {
   closeLoginModal: () => void;
   /** Whether the login modal is currently open */
   loginModalOpen: boolean;
+  /** True when a signed-in account must accept the Terms before continuing */
+  needsConsent: boolean;
+  /** Record Terms/Privacy + 13+ acceptance for the current user */
+  acceptConsent: () => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -84,6 +95,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
+  const [needsConsent, setNeedsConsent] = useState(false);
 
   // Cached Supabase client. Null until first call to `getSupabase()`.
   const supabaseRef = useRef<SupabaseClient | null>(null);
@@ -92,26 +104,82 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
   // Subscription handle so we can unsubscribe on unmount.
   const subscriptionRef = useRef<{ unsubscribe: () => void } | null>(null);
 
-  // Fetch profile from profiles table. Uses whatever Supabase client is
-  // already loaded — called only after auth state is known, so the client
-  // is guaranteed to exist.
-  const fetchProfile = useCallback(async (userId: string) => {
-    const supabase = supabaseRef.current;
-    if (!supabase) return;
-    try {
-      const { data } = await supabase
+  // Write Terms/Privacy + 13+ acceptance to the user's own profiles row
+  // (allowed by the "Users update own profile" RLS policy). Patches local
+  // state on success so the UI reflects acceptance without a refetch.
+  const writeConsent = useCallback(
+    async (
+      supabase: SupabaseClient,
+      userId: string,
+      version: string
+    ): Promise<boolean> => {
+      const acceptedAt = new Date().toISOString();
+      const { error } = await supabase
         .from("profiles")
-        .select("*")
-        .eq("id", userId)
-        .single();
+        .update({ tos_accepted_at: acceptedAt, tos_version: version })
+        .eq("id", userId);
+      if (error) return false;
+      setProfile((p) =>
+        p ? { ...p, tos_accepted_at: acceptedAt, tos_version: version } : p
+      );
+      return true;
+    },
+    []
+  );
 
-      if (data) {
-        setProfile(data as Profile);
+  // After auth, reconcile consent: record a fresh signup's pending acceptance,
+  // or flag that an existing account must accept now. See lib/consent.ts.
+  const reconcileConsent = useCallback(
+    async (supabase: SupabaseClient, userId: string, profileData: Profile) => {
+      const pending =
+        typeof window !== "undefined"
+          ? localStorage.getItem(CONSENT_PENDING_KEY)
+          : null;
+      const action = decideConsentAction(profileData.tos_accepted_at, pending);
+      if (action === "none") {
+        if (pending) localStorage.removeItem(CONSENT_PENDING_KEY);
+        setNeedsConsent(false);
+        return;
       }
-    } catch {
-      // Profile fetch failed — user stays authenticated without profile data
-    }
-  }, []);
+      if (action === "record") {
+        const ok = await writeConsent(supabase, userId, pending as string);
+        if (ok) {
+          localStorage.removeItem(CONSENT_PENDING_KEY);
+          setNeedsConsent(false);
+        } else {
+          // write failed — fall back to prompting so consent still lands
+          setNeedsConsent(true);
+        }
+        return;
+      }
+      setNeedsConsent(true); // "prompt"
+    },
+    [writeConsent]
+  );
+
+  // Fetch profile from profiles table, then reconcile consent. Uses whatever
+  // Supabase client is already loaded — called only after auth state is known.
+  const fetchProfile = useCallback(
+    async (userId: string) => {
+      const supabase = supabaseRef.current;
+      if (!supabase) return;
+      try {
+        const { data } = await supabase
+          .from("profiles")
+          .select("*")
+          .eq("id", userId)
+          .single();
+
+        if (data) {
+          setProfile(data as Profile);
+          await reconcileConsent(supabase, userId, data as Profile);
+        }
+      } catch {
+        // Profile fetch failed — user stays authenticated without profile data
+      }
+    },
+    [reconcileConsent]
+  );
 
   /**
    * Dynamic-import + instantiate the Supabase client on first call. Wires
@@ -252,7 +320,23 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     }
     setUser(null);
     setProfile(null);
+    setNeedsConsent(false);
   }, []);
+
+  // Accept the current Terms/Privacy + 13+ attestation (used by the
+  // existing-account ConsentPrompt; signup records consent automatically).
+  const acceptConsent = useCallback(async () => {
+    const supabase = supabaseRef.current;
+    const uid = user?.id;
+    if (!supabase || !uid) return;
+    const ok = await writeConsent(supabase, uid, TOS_VERSION);
+    if (ok) {
+      if (typeof window !== "undefined") {
+        localStorage.removeItem(CONSENT_PENDING_KEY);
+      }
+      setNeedsConsent(false);
+    }
+  }, [user, writeConsent]);
 
   const openLoginModal = useCallback(() => setLoginModalOpen(true), []);
   const closeLoginModal = useCallback(() => setLoginModalOpen(false), []);
@@ -273,6 +357,8 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
         openLoginModal,
         closeLoginModal,
         loginModalOpen,
+        needsConsent,
+        acceptConsent,
       }}
     >
       {children}

--- a/components/auth/ConsentPrompt.tsx
+++ b/components/auth/ConsentPrompt.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useAuth } from "@/lib/hooks/useAuth";
+
+/**
+ * One-time consent prompt for already-signed-in accounts that predate the
+ * signup consent gate (or whose acceptance couldn't be recorded at signup —
+ * e.g. a magic link opened on a different device). Rendered in the root layout
+ * alongside LoginModal; only shows when AuthProvider sets needsConsent.
+ *
+ * Mirrors the signup checkbox: accepting attests 13+ AND agreement to the
+ * Terms and Privacy Policy, then writes profiles.tos_accepted_at.
+ */
+export default function ConsentPrompt() {
+  const { user, needsConsent, acceptConsent } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!user || !needsConsent) return null;
+
+  return (
+    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-sm rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-xl">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100">
+          One quick thing
+        </h2>
+        <p className="mt-2 text-sm text-gray-600 dark:text-slate-400">
+          We&apos;ve added Terms of Service and updated our Privacy Policy. To keep using your
+          account, please confirm you are 13 or older and agree to the{" "}
+          <Link href="/terms" target="_blank" className="text-teal-600 underline">Terms of Service</Link>{" "}
+          and{" "}
+          <Link href="/privacy" target="_blank" className="text-teal-600 underline">Privacy Policy</Link>.
+        </p>
+        <button
+          type="button"
+          onClick={async () => {
+            setSubmitting(true);
+            await acceptConsent();
+            setSubmitting(false);
+          }}
+          disabled={submitting}
+          className="mt-4 w-full rounded-lg bg-teal-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
+        >
+          {submitting ? "Saving..." : "I'm 13+ and I agree"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/auth/LoginModal.tsx
+++ b/components/auth/LoginModal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import Link from "next/link";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { getEnabledProviders } from "@/lib/auth-providers";
+import { CONSENT_PENDING_KEY, TOS_VERSION } from "@/lib/consent";
 
 /**
  * Login modal dialog — appears over the current page.
@@ -23,6 +25,7 @@ export default function LoginModal() {
   const [magicLinkSent, setMagicLinkSent] = useState(false);
   const [magicLinkError, setMagicLinkError] = useState<string | null>(null);
   const [isSending, setIsSending] = useState(false);
+  const [consent, setConsent] = useState(false);
   const dialogRef = useRef<HTMLDialogElement>(null);
   const providers = getEnabledProviders();
 
@@ -42,6 +45,8 @@ export default function LoginModal() {
       setMagicLinkSent(false);
 
       setMagicLinkError(null);
+
+      setConsent(false);
     }
   }, [loginModalOpen]);
 
@@ -61,10 +66,21 @@ export default function LoginModal() {
     return () => dialog.removeEventListener("cancel", handleCancel);
   }, [closeLoginModal]);
 
+  // Persist the accepted Terms version so AuthProvider can record it after the
+  // auth round-trip (OAuth redirect / magic-link click). See lib/consent.ts.
+  const markConsentPending = () => {
+    try {
+      localStorage.setItem(CONSENT_PENDING_KEY, TOS_VERSION);
+    } catch {
+      // localStorage blocked — the post-auth ConsentPrompt fallback captures it.
+    }
+  };
+
   const handleMagicLink = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!email.trim()) return;
+    if (!email.trim() || !consent) return;
 
+    markConsentPending();
     setIsSending(true);
     setMagicLinkError(null);
 
@@ -113,13 +129,39 @@ export default function LoginModal() {
           </button>
         </div>
 
+        {/* Age + Terms/Privacy consent — REQUIRED before any sign-in path */}
+        <label className="flex items-start gap-2 mb-5 text-xs text-gray-600 dark:text-slate-400">
+          <input
+            type="checkbox"
+            checked={consent}
+            onChange={(e) => setConsent(e.target.checked)}
+            className="mt-0.5 h-4 w-4 shrink-0 rounded border-gray-300 dark:border-slate-600 text-teal-600 focus:ring-teal-500"
+          />
+          <span>
+            I am 13 or older and agree to the{" "}
+            <Link href="/terms" target="_blank" className="text-teal-600 underline">
+              Terms of Service
+            </Link>{" "}
+            and{" "}
+            <Link href="/privacy" target="_blank" className="text-teal-600 underline">
+              Privacy Policy
+            </Link>
+            .
+          </span>
+        </label>
+
         {/* SSO Buttons — rendered dynamically from AUTH_PROVIDERS config */}
         <div className="space-y-3">
           {providers.map((provider) => (
             <button
               key={provider.id}
-              onClick={() => signInWithOAuth(provider.id)}
-              className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-600 transition"
+              onClick={() => {
+                if (!consent) return;
+                markConsentPending();
+                signInWithOAuth(provider.id);
+              }}
+              disabled={!consent}
+              className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-600 transition disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <provider.icon />
               {provider.label}
@@ -174,7 +216,7 @@ export default function LoginModal() {
             )}
             <button
               type="submit"
-              disabled={isSending}
+              disabled={isSending || !consent}
               className="mt-3 w-full rounded-lg bg-teal-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
             >
               {isSending ? "Sending..." : "Send Magic Link"}

--- a/lib/__tests__/consent.test.ts
+++ b/lib/__tests__/consent.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { decideConsentAction, TOS_VERSION } from "@/lib/consent";
+
+describe("decideConsentAction", () => {
+  it("'none' when the profile already has an acceptance timestamp", () => {
+    expect(decideConsentAction("2026-06-01T00:00:00Z", null)).toBe("none");
+    // a prior acceptance wins even if a stale pending value is lying around
+    expect(decideConsentAction("2026-06-01T00:00:00Z", TOS_VERSION)).toBe("none");
+  });
+
+  it("'record' for a fresh signup with pending consent and no prior acceptance", () => {
+    expect(decideConsentAction(null, TOS_VERSION)).toBe("record");
+    expect(decideConsentAction(undefined, "2026-06-04")).toBe("record");
+  });
+
+  it("'prompt' when authenticated but nothing accepted and nothing pending (pre-gate account / cross-device link)", () => {
+    expect(decideConsentAction(null, null)).toBe("prompt");
+    expect(decideConsentAction(undefined, undefined)).toBe("prompt");
+    expect(decideConsentAction(null, "")).toBe("prompt"); // empty pending = nothing pending
+  });
+
+  it("ships a non-empty TOS_VERSION", () => {
+    expect(typeof TOS_VERSION).toBe("string");
+    expect(TOS_VERSION.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/consent.ts
+++ b/lib/consent.ts
@@ -1,0 +1,35 @@
+/**
+ * Terms of Service / Privacy consent — shared constants + the consent-decision
+ * helper used by the signup gate (LoginModal), the recorder (AuthProvider), and
+ * the existing-account prompt (ConsentPrompt).
+ *
+ * Flow:
+ *  - LoginModal requires a "13+ and agree to Terms & Privacy" checkbox before
+ *    any sign-in. On submit it stores the accepted TOS_VERSION under
+ *    CONSENT_PENDING_KEY (localStorage survives the OAuth redirect and a
+ *    same-browser magic-link click, both back on our origin).
+ *  - On first authenticated load, AuthProvider reads the user's profile + the
+ *    pending value and calls decideConsentAction():
+ *      "none"   → profile already has tos_accepted_at; nothing to do.
+ *      "record" → fresh signup with pending consent; write tos_accepted_at.
+ *      "prompt" → authenticated but nothing accepted and nothing pending
+ *                 (a pre-consent-gate account, or a magic link opened on a
+ *                 different device) → show ConsentPrompt to accept now.
+ *
+ * Bump TOS_VERSION when the Terms change materially to force re-acceptance.
+ */
+export const TOS_VERSION = "2026-06-04";
+
+/** localStorage key holding the TOS_VERSION accepted at signup time. */
+export const CONSENT_PENDING_KEY = "ccp:consent-pending";
+
+export type ConsentAction = "none" | "record" | "prompt";
+
+export function decideConsentAction(
+  tosAcceptedAt: string | null | undefined,
+  pendingVersion: string | null | undefined,
+): ConsentAction {
+  if (tosAcceptedAt) return "none";
+  if (pendingVersion) return "record";
+  return "prompt";
+}

--- a/supabase/migrations/023_signup_consent.sql
+++ b/supabase/migrations/023_signup_consent.sql
@@ -1,0 +1,26 @@
+-- ============================================================================
+-- 023: Signup consent — Terms of Service / Privacy acceptance + 13+ attestation
+-- ============================================================================
+-- WHAT: Adds two nullable columns to `profiles` recording WHEN a user accepted
+--       the Terms of Service + Privacy Policy (and attested to being 13 or
+--       older) and WHICH Terms version they accepted.
+-- WHY:  COPPA / eligibility gate. Signup now requires a "13+ and agree to Terms
+--       & Privacy" checkbox; this is where that acceptance is stored. NULL =
+--       not yet accepted (pre-gate accounts) → the app prompts on next load.
+-- HOW:  Consent is written client-side post-auth via the existing
+--       "Users update own profile" RLS policy (auth.uid() = id) — no trigger
+--       change needed (the checkbox state isn't available to handle_new_user).
+-- CAVEATS: Purely additive + idempotent. Both columns nullable, no default, no
+--       backfill; negligible lock on a small per-user table; runs in a
+--       transaction. Reversible via DROP COLUMN.
+-- EXECUTION: Supabase Dashboard SQL Editor (or scripts/lib/run-migration.ts).
+-- ============================================================================
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS tos_accepted_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS tos_version TEXT;
+
+COMMENT ON COLUMN profiles.tos_accepted_at IS
+  'When the user accepted the Terms of Service + Privacy Policy and attested to being 13+. NULL = not yet accepted; the app prompts on next authenticated load.';
+COMMENT ON COLUMN profiles.tos_version IS
+  'Version string of the Terms the user accepted (see lib/consent.ts TOS_VERSION).';


### PR DESCRIPTION
## What changes for someone using the site

- The sign-in box now has a required checkbox: **"I am 13 or older and agree to the Terms of Service and Privacy Policy."** You can't sign in or create an account (Google **or** email magic-link) until it's checked — both buttons are greyed out until then.
- A new **Terms of Service page at `/terms`** — public, linked from the sign-in box and the Privacy Policy.
- If you already have an account (from before this), the next time you're signed in you'll see a one-time prompt to accept.

## Why

There was no Terms page and no age check at all. The audience includes under-18 dual-enrollment students, so a 13+ attestation + Terms/Privacy consent is a COPPA / eligibility requirement — and a prerequisite to pushing signups (the "grow the base" goal). This is Milestone-A item 2.

## How it works

- `lib/consent.ts` — `TOS_VERSION` + a pure `decideConsentAction()` (`none`/`record`/`prompt`), unit-tested.
- `LoginModal.tsx` — the gate. Stashes the accepted version in `localStorage` before sign-in so it survives the OAuth redirect / same-browser magic-link click.
- `AuthProvider.tsx` — on first authenticated load, records consent to the user's own `profiles` row (via the existing "Users update own profile" RLS), or sets `needsConsent` so `ConsentPrompt.tsx` asks existing users.
- Migration `023` adds `profiles.tos_accepted_at` + `tos_version` (additive, idempotent).

## ⚠️ Migration already applied to prod

Migration `023` (two nullable columns) is **already applied to Project CC**, so the feature works the moment this merges — no separate migration step. Verified: both columns present; all 6 existing profiles have `NULL tos_accepted_at` (so they'll get the one-time prompt). Reversible via `DROP COLUMN`.

## Scope / known follow-ups

- The Terms copy is reasonable boilerplate, flagged in-code as **pending legal review** — vet/replace before relying on it.
- A magic link opened on a **different device** than where consent was given falls back to the one-time prompt (same-browser is silent). Acceptable.
- Conservative 13+ gate (no birth year); the under-18 ad-personalization refinement is intentionally out of scope (a later PR).

## Test plan

- **Unit test** (`lib/__tests__/consent.test.ts`, 4 cases) for `decideConsentAction`.
- `tsc --noEmit` clean; `npm run build` passes (`/terms` prerendered static).
- **Playwright** against the worktree dev server: `/terms` renders + links resolve; modal shows the checkbox + Terms/Privacy links; **2 sign-in buttons disabled before consent, 0 after**. Screenshot confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)