### PR TITLE
feat: account deletion clears email subscription + add data export

### DIFF
--- a/app/account/AccountDashboard.tsx
+++ b/app/account/AccountDashboard.tsx
@@ -497,6 +497,27 @@ export default function AccountDashboard({
         )}
       </section>
 
+      {/* ── Your data ── */}
+      <section className="rounded-lg border border-gray-200 dark:border-slate-700 p-6 mb-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-2">
+          Your data
+        </h2>
+        <p className="text-sm text-gray-600 dark:text-slate-400 mb-4">
+          Download a copy of everything saved to your account — your profile,
+          plans, schedules, bookmarks, transfer tracking, seat alerts, and email
+          subscriptions — as a JSON file.
+        </p>
+        <a
+          href="/api/account/export"
+          className="inline-flex items-center gap-2 rounded-lg border border-gray-300 dark:border-slate-600 px-4 py-2 text-sm font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition"
+        >
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+          </svg>
+          Download my data
+        </a>
+      </section>
+
       {/* ── Danger zone ── */}
       <section className="rounded-lg border border-red-200 dark:border-red-900/50 p-6">
         <h2 className="text-lg font-semibold text-red-700 dark:text-red-400 mb-2">

--- a/app/api/account/delete/route.ts
+++ b/app/api/account/delete/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getServiceClient } from "@/lib/supabase";
 import { rateLimit, getClientKey } from "@/lib/rate-limit";
+import { escapeIlikePattern } from "@/lib/account-export";
 
 /**
  * DELETE /api/account/delete
@@ -72,8 +73,28 @@ export async function DELETE(request: Request) {
       );
     }
 
-    // 4. Use service role to delete the user (requires admin privileges)
+    // 4. Use the service role for the deletions that need admin privileges.
     const serviceClient = getServiceClient();
+
+    // 4a. Remove the email-keyed subscriber row(s) FIRST. These are NOT
+    // cascaded by deleting the auth user — `subscribers` is keyed by email and
+    // the profiles.subscriber_id FK is ON DELETE SET NULL — so without this a
+    // deleted user keeps receiving notification emails. Case-insensitive,
+    // wildcard-escaped match on the account's verified email.
+    if (user.email) {
+      const { error: subErr } = await serviceClient
+        .from("subscribers")
+        .delete()
+        .ilike("email", escapeIlikePattern(user.email));
+      if (subErr) {
+        // Non-fatal: a lingering subscriber (still unsubscribable) is better
+        // than a half-deleted account. Surface it for monitoring and proceed.
+        console.error("Subscriber cleanup on delete failed:", subErr.message);
+      }
+    }
+
+    // 4b. Delete the auth user. CASCADE handles profiles + saved_* +
+    // plan_seat_notifications.
     const { error: deleteError } =
       await serviceClient.auth.admin.deleteUser(user.id);
 

--- a/app/api/account/export/route.ts
+++ b/app/api/account/export/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getServiceClient } from "@/lib/supabase";
+import { rateLimit, getClientKey } from "@/lib/rate-limit";
+import { buildAccountExport, escapeIlikePattern } from "@/lib/account-export";
+
+/**
+ * GET /api/account/export
+ *
+ * Returns a downloadable JSON copy of everything tied to the authenticated
+ * user's account: profile, saved plans / schedules / courses / transfers,
+ * seat-watch notification history, and any email subscriptions matching the
+ * account email.
+ *
+ * Security:
+ *   - Rate-limited.
+ *   - Auth-gated on server-verified getUser(). Identity comes ONLY from the
+ *     session, never from a request parameter, so it cannot dump another user's
+ *     data. The saved_* tables, profile, and seat-watch history are read
+ *     through the user's own RLS; the email-keyed `subscribers` table is read
+ *     with the service client, scoped to the verified account email.
+ */
+export async function GET(request: Request) {
+  const { allowed } = rateLimit(getClientKey(request), 10);
+  if (!allowed) {
+    return NextResponse.json(
+      { error: "Too many requests. Please try again later." },
+      { status: 429, headers: { "Retry-After": "60" } }
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  // Own-rows reads — RLS enforces user-only access on each of these tables.
+  const [profile, plans, schedules, courses, transfers, seatNotifs] =
+    await Promise.all([
+      supabase.from("profiles").select("*").eq("id", user.id).maybeSingle(),
+      supabase.from("saved_plans").select("*").eq("user_id", user.id),
+      supabase.from("saved_schedules").select("*").eq("user_id", user.id),
+      supabase.from("saved_courses").select("*").eq("user_id", user.id),
+      supabase.from("saved_transfers").select("*").eq("user_id", user.id),
+      supabase
+        .from("plan_seat_notifications")
+        .select("*")
+        .eq("user_id", user.id),
+    ]);
+
+  // `subscribers` is email-keyed with service-role-only RLS; read via the
+  // service client, scoped to the verified account email (escaped, ILIKE).
+  let emailSubscriptions: unknown[] = [];
+  if (user.email) {
+    const { data } = await getServiceClient()
+      .from("subscribers")
+      .select("*")
+      .ilike("email", escapeIlikePattern(user.email));
+    emailSubscriptions = data ?? [];
+  }
+
+  const payload = buildAccountExport(
+    {
+      user: { id: user.id, email: user.email ?? null },
+      profile: profile.data ?? null,
+      savedPlans: plans.data ?? [],
+      savedSchedules: schedules.data ?? [],
+      savedCourses: courses.data ?? [],
+      savedTransfers: transfers.data ?? [],
+      seatNotifications: seatNotifs.data ?? [],
+      emailSubscriptions,
+    },
+    new Date().toISOString()
+  );
+
+  return new NextResponse(JSON.stringify(payload, null, 2), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Content-Disposition": 'attachment; filename="ccp-data-export.json"',
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/lib/__tests__/account-export.test.ts
+++ b/lib/__tests__/account-export.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { buildAccountExport, escapeIlikePattern } from "@/lib/account-export";
+
+describe("escapeIlikePattern", () => {
+  it("escapes ILIKE wildcards so an email matches literally", () => {
+    expect(escapeIlikePattern("a_b%c@x.com")).toBe("a\\_b\\%c@x.com");
+    expect(escapeIlikePattern("a\\b@x.com")).toBe("a\\\\b@x.com");
+  });
+  it("leaves an ordinary email unchanged", () => {
+    expect(escapeIlikePattern("foo.bar@example.com")).toBe("foo.bar@example.com");
+  });
+});
+
+describe("buildAccountExport", () => {
+  const base = {
+    user: { id: "u1", email: "x@y.com" },
+    profile: { id: "u1", display_name: "X" },
+    savedPlans: [{ id: "p1" }],
+    savedSchedules: [],
+    savedCourses: [],
+    savedTransfers: [],
+    seatNotifications: [],
+    emailSubscriptions: [{ email: "x@y.com" }],
+  };
+
+  it("assembles every section with a stable shape and the passed-in timestamp", () => {
+    const out = buildAccountExport(base, "2026-06-04T00:00:00.000Z");
+    expect(out.format).toBe("ccp-account-export");
+    expect(out.version).toBe(1);
+    expect(out.exportedAt).toBe("2026-06-04T00:00:00.000Z");
+    expect(out.account).toEqual({ id: "u1", email: "x@y.com" });
+    expect(out.profile).toEqual({ id: "u1", display_name: "X" });
+    expect(out.savedPlans).toEqual([{ id: "p1" }]);
+    expect(out.emailSubscriptions).toEqual([{ email: "x@y.com" }]);
+  });
+
+  it("is deterministic for the same input and timestamp", () => {
+    const a = buildAccountExport(base, "2026-06-04T00:00:00.000Z");
+    const b = buildAccountExport(base, "2026-06-04T00:00:00.000Z");
+    expect(a).toEqual(b);
+  });
+
+  it("coerces a null profile and missing arrays to safe defaults", () => {
+    const out = buildAccountExport(
+      {
+        user: { id: "u2", email: null },
+        profile: null,
+        savedPlans: [],
+        savedSchedules: [],
+        savedCourses: [],
+        savedTransfers: [],
+        seatNotifications: [],
+        emailSubscriptions: [],
+      },
+      "2026-06-04T00:00:00.000Z"
+    );
+    expect(out.profile).toBeNull();
+    expect(out.account.email).toBeNull();
+    expect(out.savedCourses).toEqual([]);
+  });
+});

--- a/lib/account-export.ts
+++ b/lib/account-export.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure helpers for the account data-export + account-deletion endpoints.
+ * Kept separate from the route handlers so they can be unit-tested without a
+ * Supabase client or a request.
+ */
+
+/**
+ * Escape a literal string for safe use in a Postgres ILIKE pattern, so that
+ * `%`, `_`, and `\` inside (e.g.) an email address are matched literally rather
+ * than as wildcards. Used to match the email-keyed `subscribers` rows
+ * case-insensitively for both export and account-deletion cleanup.
+ */
+export function escapeIlikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+export interface AccountExportInput {
+  user: { id: string; email: string | null };
+  profile: unknown;
+  savedPlans: unknown[];
+  savedSchedules: unknown[];
+  savedCourses: unknown[];
+  savedTransfers: unknown[];
+  seatNotifications: unknown[];
+  emailSubscriptions: unknown[];
+}
+
+/**
+ * Assemble a user's data into a single, stable, downloadable object. Pure: the
+ * timestamp is passed in so the result is deterministic and unit-testable.
+ */
+export function buildAccountExport(input: AccountExportInput, exportedAt: string) {
+  return {
+    format: "ccp-account-export",
+    version: 1,
+    exportedAt,
+    account: input.user,
+    profile: input.profile ?? null,
+    savedPlans: input.savedPlans ?? [],
+    savedSchedules: input.savedSchedules ?? [],
+    savedCourses: input.savedCourses ?? [],
+    savedTransfers: input.savedTransfers ?? [],
+    seatNotifications: input.seatNotifications ?? [],
+    emailSubscriptions: input.emailSubscriptions ?? [],
+  };
+}


### PR DESCRIPTION
## What changes for someone using the site

- **Deleting your account now also stops the notification emails.** Before, a "deleted" account kept getting new-term / seat-open emails, because the email subscription lived in a separate email-keyed table that the delete didn't touch.
- **New "Download my data" button** on the account page (a new "Your data" section just above the Danger Zone). It downloads a JSON file with everything saved to your account: profile, plans, schedules, bookmarks, transfer tracking, seat-watch history, and email subscriptions.

## Why

The privacy rewrite (#1172) honestly disclosed two gaps: account deletion didn't stop emails, and there was no self-serve data export (it said "contact us for a copy"). This closes both — the **last item in Milestone A**.

## How it works

- **Delete fix** (`app/api/account/delete/route.ts`): before `admin.deleteUser`, delete `subscribers` rows matching the account's verified email (service client, case-insensitive escaped `ILIKE`). `profiles` + `saved_*` + `plan_seat_notifications` already cascade on the auth-user delete; `subscribers` (email-keyed, FK `SET NULL`) was the one orphan. The existing Origin/CSRF check + rate limit are preserved, and a subscriber-cleanup error is non-fatal (logged) so a delete never half-fails.
- **Export** (new `GET /api/account/export`): `getUser()`-gated (401 logged out) + rate-limited. Identity comes **only** from the session — never a request parameter — so it can't dump another user's data. `saved_*` / profile / seat-watch read via the user's own RLS; the email-keyed `subscribers` via the service client scoped to the verified email. Returns `application/json` as an attachment download.
- Pure helpers in `lib/account-export.ts` (`escapeIlikePattern`, `buildAccountExport`), unit-tested. **No schema change.**

## Test plan

- **Unit test** (`lib/__tests__/account-export.test.ts`, 5 cases): ILIKE wildcard escaping + export assembly shape / determinism / null-coercion.
- `tsc --noEmit` clean; `npm run build` passes (export route compiles, `ƒ Dynamic`).
- Dev: `GET /api/account/export` while logged out → **401 "Not authenticated."** (Full delete/export with a real session isn't exercised here; the auth gate and the cascade/cleanup paths are covered by code review + the existing delete flow.)

> With this PR, **Milestone A — "safe & legal to grow" — is complete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)