### PR TITLE
ci: add migration-drift guard (catch never-applied migrations)

### DIFF
--- a/.github/workflows/migration-drift.yml
+++ b/.github/workflows/migration-drift.yml
@@ -1,0 +1,32 @@
+name: Migration drift
+
+# Fails when a table defined in supabase/migrations/ was never applied to prod
+# (migrations here are applied by hand, so the repo files are not a reliable
+# record of what's deployed). The check SKIPS gracefully when the Supabase
+# secrets are not configured, so it never blocks forks / unconfigured CI — add
+# NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY as repo secrets to enforce.
+
+on:
+  pull_request:
+    paths:
+      - "supabase/migrations/**"
+      - "scripts/check-migration-drift.ts"
+      - "scripts/lib/migration-tables.ts"
+      - ".github/workflows/migration-drift.yml"
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run check:migration-drift
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "check:data": "tsx scripts/check-data-integrity.ts",
     "check:blog-mdx": "tsx scripts/check-blog-mdx.ts",
     "check:scorecard": "tsx scripts/check-scorecard-freshness.ts",
+    "check:migration-drift": "tsx scripts/check-migration-drift.ts",
     "eval:search": "tsx scripts/eval-search-intent.ts",
     "scrape": "tsx scripts/scrape-vccs.ts",
     "scrape:college": "tsx scripts/scrape-vccs.ts --college",

--- a/scripts/check-migration-drift.ts
+++ b/scripts/check-migration-drift.ts
@@ -1,0 +1,96 @@
+/**
+ * check-migration-drift.ts — fail CI when a table defined in
+ * supabase/migrations/ was never applied to the prod database.
+ *
+ * Background: migrations here are applied BY HAND (Supabase Dashboard / MCP) —
+ * there is no automated migration-on-deploy, so the committed migration files
+ * are NOT a reliable record of what's actually live. On 2026-06-04 we found 4
+ * migrations authored-but-never-applied, which silently broke "Save plan"
+ * (saved_plans didn't exist), seat-watch, and the /ask cache. This check parses
+ * the tables the migrations CREATE and probes prod (service-role REST client)
+ * to confirm each one exists. Read-only; never writes.
+ *
+ * Creds: NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (from .env.local
+ * locally, or CI secrets). If either is missing it SKIPS (exit 0) with a clear
+ * message, so it never blocks forks or unconfigured CI — the owner must add the
+ * secrets to make it enforce.
+ */
+import fs from "fs";
+import path from "path";
+import { createClient } from "@supabase/supabase-js";
+import { loadEnv } from "./lib/load-env";
+import { expectedTables } from "./lib/migration-tables";
+
+loadEnv();
+
+async function main() {
+  const dir = path.join(process.cwd(), "supabase", "migrations");
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith(".sql")).sort();
+  const sqls = files.map((f) => fs.readFileSync(path.join(dir, f), "utf-8"));
+  const expected = expectedTables(sqls);
+  console.log(
+    `Parsed ${expected.length} expected public table(s) from ${files.length} migration file(s).`
+  );
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.log(
+      "⏭  SKIP: NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set — " +
+        "cannot probe prod.\n   Add them as CI secrets to enforce the drift check."
+    );
+    process.exit(0);
+  }
+
+  // Service-role REST client (bypasses RLS; mirrors lib/supabase getServiceClient).
+  const sb = createClient(url, key);
+  const missing: string[] = [];
+  const errored: string[] = [];
+
+  for (const table of expected) {
+    // A 0-row select resolves the relation without transferring data. An
+    // existing table → { error: null }; a missing one → a PostgREST error.
+    const { error } = await sb.from(table).select("*").limit(0);
+    if (!error) continue;
+    const blob = `${error.code ?? ""} ${error.message ?? ""}`.toLowerCase();
+    if (
+      error.code === "PGRST205" ||
+      blob.includes("could not find the table") ||
+      blob.includes("does not exist")
+    ) {
+      missing.push(table);
+    } else {
+      errored.push(`${table}: ${error.code ?? ""} ${error.message ?? ""}`.trim());
+    }
+  }
+
+  if (errored.length) {
+    console.error(
+      `\n⚠  ${errored.length} table(s) could not be checked (unexpected error — failing):`
+    );
+    for (const e of errored) console.error(`   - ${e}`);
+    process.exit(1);
+  }
+
+  if (missing.length) {
+    console.error(
+      `\n❌ MIGRATION DRIFT — ${missing.length} table(s) defined in supabase/migrations/ ` +
+        "are MISSING from prod:"
+    );
+    for (const t of missing) console.error(`   - ${t}`);
+    console.error(
+      "\nThese migrations were authored but never applied. Apply them to prod " +
+        "(Supabase Dashboard SQL editor or scripts/lib/run-migration.ts) before merging " +
+        "anything that depends on them. See memory feedback_verify_prod_schema_before_assuming."
+    );
+    process.exit(1);
+  }
+
+  console.log(`✅ No drift — all ${expected.length} migration-defined table(s) exist in prod.`);
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error("check-migration-drift crashed:", e);
+  process.exit(1);
+});

--- a/scripts/lib/__tests__/migration-tables.test.ts
+++ b/scripts/lib/__tests__/migration-tables.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { parseTableOps, expectedTables } from "../migration-tables";
+
+describe("parseTableOps", () => {
+  it("extracts CREATE TABLE names (plain, IF NOT EXISTS, public., quoted)", () => {
+    const sql = `
+      CREATE TABLE profiles ( id uuid );
+      CREATE TABLE IF NOT EXISTS saved_plans ( id uuid );
+      CREATE TABLE public.seat_snapshots ( state text );
+      CREATE TABLE "plan_seat_notifications" ( id uuid );
+    `;
+    expect(parseTableOps(sql).created.sort()).toEqual([
+      "plan_seat_notifications",
+      "profiles",
+      "saved_plans",
+      "seat_snapshots",
+    ]);
+  });
+
+  it("ignores CREATE TABLE inside line and block comments", () => {
+    const sql = `
+      -- CREATE TABLE commented_out_line ( x int );
+      /* CREATE TABLE commented_out_block ( x int ); */
+      CREATE TABLE real_table ( x int );
+    `;
+    expect(parseTableOps(sql).created).toEqual(["real_table"]);
+  });
+
+  it("captures DROP TABLE (incl. IF EXISTS)", () => {
+    expect(parseTableOps("DROP TABLE IF EXISTS old_thing;").dropped).toEqual(["old_thing"]);
+  });
+
+  it("does not match CREATE INDEX / CREATE POLICY / ALTER TABLE", () => {
+    const sql = `
+      CREATE INDEX idx ON foo(x);
+      CREATE POLICY p ON foo FOR SELECT USING (true);
+      ALTER TABLE foo ADD COLUMN y int;
+    `;
+    expect(parseTableOps(sql).created).toEqual([]);
+  });
+});
+
+describe("expectedTables", () => {
+  it("computes the net set across migrations, honoring later drops", () => {
+    const m1 = "CREATE TABLE a (x int); CREATE TABLE b (x int);";
+    const m2 = "DROP TABLE a; CREATE TABLE c (x int);";
+    expect(expectedTables([m1, m2])).toEqual(["b", "c"]);
+  });
+
+  it("dedupes a table created with IF NOT EXISTS across two migrations", () => {
+    const m1 = "CREATE TABLE t (x int);";
+    const m2 = "CREATE TABLE IF NOT EXISTS t (x int);";
+    expect(expectedTables([m1, m2])).toEqual(["t"]);
+  });
+});

--- a/scripts/lib/migration-tables.ts
+++ b/scripts/lib/migration-tables.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure helpers for the migration-drift check (scripts/check-migration-drift.ts).
+ *
+ * Extracts the public tables a migration SQL file CREATEs or DROPs, so the check
+ * can compute the net set of tables the repo expects to exist and compare it
+ * against what's actually deployed to prod. Kept dependency-free so it can be
+ * unit-tested without a database.
+ */
+
+export interface TableOps {
+  created: string[];
+  dropped: string[];
+}
+
+/**
+ * Strip `--` line comments and block comments so a commented-out CREATE TABLE
+ * in a header (every migration here has a big comment block) doesn't count.
+ */
+function stripSqlComments(sql: string): string {
+  return sql
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .split("\n")
+    .map((line) => line.replace(/--.*$/, ""))
+    .join("\n");
+}
+
+// Matches `CREATE TABLE [IF NOT EXISTS] [public.]<name>` with optional quoting.
+const CREATE_SRC =
+  'CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?(?:"?public"?\\.)?"?([a-zA-Z_][a-zA-Z0-9_]*)"?';
+// Matches `DROP TABLE [IF EXISTS] [public.]<name>`.
+const DROP_SRC =
+  'DROP\\s+TABLE\\s+(?:IF\\s+EXISTS\\s+)?(?:"?public"?\\.)?"?([a-zA-Z_][a-zA-Z0-9_]*)"?';
+
+function matchNames(sql: string, source: string): string[] {
+  // Fresh regex per call so the stateful `lastIndex` of a global regex can't
+  // leak between invocations.
+  const re = new RegExp("\\b" + source, "gi");
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(sql)) !== null) out.push(m[1]);
+  return [...new Set(out)];
+}
+
+export function parseTableOps(sql: string): TableOps {
+  const clean = stripSqlComments(sql);
+  return {
+    created: matchNames(clean, CREATE_SRC),
+    dropped: matchNames(clean, DROP_SRC),
+  };
+}
+
+/**
+ * Net set of public tables the repo expects to exist, given migration SQL
+ * strings IN ORDER. A later DROP removes an earlier CREATE so renamed/removed
+ * tables don't produce false positives.
+ */
+export function expectedTables(migrationSqls: string[]): string[] {
+  const set = new Set<string>();
+  for (const sql of migrationSqls) {
+    const { created, dropped } = parseTableOps(sql);
+    for (const t of created) set.add(t);
+    for (const t of dropped) set.delete(t);
+  }
+  return [...set].sort();
+}


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — this adds an automated safety net in CI. It exists because of the bug we just hit: a database change (the `saved_plans` table) had been written but **never actually applied to the production database**, so "Save plan" silently did nothing. This check makes CI **fail** if a future migration is committed but not deployed, so that class of bug gets caught before it can break a feature.

## Why

Migrations here are applied **by hand** (no automated migration-on-deploy), and the repo's migration files aren't a reliable record of what's actually live. On 2026-06-04, four migrations were found authored-but-never-applied (fixed in #1174). This is the guardrail so it's caught automatically next time.

## How it works

- **`scripts/lib/migration-tables.ts`** — a pure parser that reads every `supabase/migrations/*.sql` and extracts the tables they create (handles `IF NOT EXISTS`, `public.` prefixes, quoting, comments; nets out later `DROP`s). Unit-tested.
- **`scripts/check-migration-drift.ts`** — builds the expected table set, then probes prod via the service-role REST client (a 0-row select per table; a "relation does not exist" / `PGRST205` error = the table was never deployed). Reports any missing table and exits non-zero. **Read-only.** **Skips gracefully** (passes) when the Supabase secrets aren't set, so it never blocks forks / unconfigured CI.
- **`npm run check:migration-drift`** + **`.github/workflows/migration-drift.yml`** (runs on PRs touching `supabase/migrations/**` and on push to `main`).

## ⚠️ Owner action to enforce

The check only *enforces* once you add **`NEXT_PUBLIC_SUPABASE_URL`** and **`SUPABASE_SERVICE_ROLE_KEY`** as repo Actions secrets (Settings → Secrets and variables → Actions). Without them the job runs but skips with a clear log. I can't add secrets for you.

## Test plan

- Parser unit test — **6 cases**.
- **Live run against prod:** parsed 17 tables from 25 migrations → "No drift", exit 0 (prod was synced in #1174).
- **Negative test:** a throwaway migration referencing a nonexistent table was correctly flagged as **MISSING** and the check exited non-zero (file removed).
- `tsc --noEmit` + `npm run build` pass.

Future extension (not here): column-level drift; auto-applying migrations on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)