### PR TITLE
feat: anonymous→account plan drain — a plan built logged-out survives sign-in

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import ThemeProvider from "@/components/ThemeProvider";
 import AuthProvider from "@/components/AuthProvider";
 import LoginModal from "@/components/auth/LoginModal";
 import ConsentPrompt from "@/components/auth/ConsentPrompt";
+import DraftDrainPrompt from "@/components/auth/DraftDrainPrompt";
 import JsonLd from "@/components/JsonLd";
 import Footer from "@/components/Footer";
 import { getAllStates } from "@/lib/states/registry";
@@ -125,6 +126,7 @@ export default function RootLayout({
             <Footer />
             <LoginModal />
             <ConsentPrompt />
+            <DraftDrainPrompt />
           </AuthProvider>
         </ThemeProvider>
         <Analytics />

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -14,6 +14,7 @@ import {
   TOS_VERSION,
   decideConsentAction,
 } from "@/lib/consent";
+import { readAnonDraft, clearAnonDraft, type AnonDraft } from "@/lib/anon-draft";
 
 // Type-only imports above don't add bundle weight. The runtime
 // `@supabase/supabase-js` code is behind a dynamic import in
@@ -57,6 +58,13 @@ export interface AuthContextValue {
   needsConsent: boolean;
   /** Record Terms/Privacy + 13+ acceptance for the current user */
   acceptConsent: () => Promise<void>;
+  /** A plan draft found in sessionStorage on first authed load, awaiting the
+   *  shared-computer confirm (null = nothing to drain). */
+  pendingDraft: AnonDraft | null;
+  /** Drain the pending draft into the account (idempotent RPC). Returns success. */
+  drainDraft: () => Promise<boolean>;
+  /** Discard the pending draft without saving it. */
+  discardDraft: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -96,6 +104,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const [needsConsent, setNeedsConsent] = useState(false);
+  const [pendingDraft, setPendingDraft] = useState<AnonDraft | null>(null);
 
   // Cached Supabase client. Null until first call to `getSupabase()`.
   const supabaseRef = useRef<SupabaseClient | null>(null);
@@ -181,6 +190,12 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     [reconcileConsent]
   );
 
+  // Surface any sessionStorage plan draft for the shared-computer confirm on
+  // first authed load. NEVER auto-flush — see DraftDrainPrompt + lib/anon-draft.
+  const reconcileDraft = useCallback(() => {
+    setPendingDraft(readAnonDraft());
+  }, []);
+
   /**
    * Dynamic-import + instantiate the Supabase client on first call. Wires
    * up the `onAuthStateChange` subscription exactly once per mount so that
@@ -202,6 +217,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
               setUser(newUser);
               if (newUser) {
                 await fetchProfile(newUser.id);
+                reconcileDraft();
                 setLoginModalOpen(false);
               } else {
                 setProfile(null);
@@ -216,7 +232,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       );
     }
     return loaderRef.current;
-  }, [fetchProfile]);
+  }, [fetchProfile, reconcileDraft]);
 
   // Initialize auth state on mount.
   useEffect(() => {
@@ -247,6 +263,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
         setUser(currentUser);
         if (currentUser) {
           await fetchProfile(currentUser.id);
+          reconcileDraft();
         }
       } catch {
         // No session, timeout, or error — user stays null.
@@ -261,7 +278,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       subscriptionRef.current?.unsubscribe();
       subscriptionRef.current = null;
     };
-  }, [fetchProfile, getSupabase]);
+  }, [fetchProfile, getSupabase, reconcileDraft]);
 
   // ---------------------------------------------------------------------------
   // Auth actions — each triggers the dynamic Supabase load on first use
@@ -321,6 +338,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null);
     setProfile(null);
     setNeedsConsent(false);
+    setPendingDraft(null);
   }, []);
 
   // Accept the current Terms/Privacy + 13+ attestation (used by the
@@ -337,6 +355,30 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       setNeedsConsent(false);
     }
   }, [user, writeConsent]);
+
+  // Drain the pending sessionStorage plan draft into the account via a single
+  // transactional, idempotent RPC (ON CONFLICT DO NOTHING on client_dedup_key).
+  // Clears the draft only after a confirmed commit. Triggered by DraftDrainPrompt.
+  const drainDraft = useCallback(async (): Promise<boolean> => {
+    const supabase = supabaseRef.current;
+    if (!supabase || !user || !pendingDraft) return false;
+    try {
+      const { error } = await supabase.rpc("drain_anonymous_plans", {
+        payload: pendingDraft,
+      });
+      if (error) return false;
+      clearAnonDraft();
+      setPendingDraft(null);
+      return true;
+    } catch {
+      return false;
+    }
+  }, [user, pendingDraft]);
+
+  const discardDraft = useCallback(() => {
+    clearAnonDraft();
+    setPendingDraft(null);
+  }, []);
 
   const openLoginModal = useCallback(() => setLoginModalOpen(true), []);
   const closeLoginModal = useCallback(() => setLoginModalOpen(false), []);
@@ -359,6 +401,9 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
         loginModalOpen,
         needsConsent,
         acceptConsent,
+        pendingDraft,
+        drainDraft,
+        discardDraft,
       }}
     >
       {children}

--- a/components/SemesterPlanner.tsx
+++ b/components/SemesterPlanner.tsx
@@ -4,6 +4,7 @@ import { Fragment, useState, useCallback, useMemo, useEffect, useRef } from "rea
 import { createClient } from "@/lib/supabase/client";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { track } from "@/lib/analytics";
+import { stashPlanDraft, planDedupKey } from "@/lib/anon-draft";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -751,7 +752,23 @@ export default function SemesterPlanner({
             <button
               type="button"
               onClick={async () => {
-                if (!user) { openLoginModal(); return; }
+                if (!user) {
+                  // Stash the plan to sessionStorage BEFORE the login modal /
+                  // OAuth redirect destroys React state, so it survives sign-in
+                  // and can be drained into the new account. See lib/anon-draft.
+                  const draftName =
+                    initialName?.trim() ||
+                    (targets.length > 0 ? targets.join(", ") : "My Plan");
+                  stashPlanDraft({
+                    state,
+                    name: draftName,
+                    targetCourses: targets,
+                    kind: "semester",
+                    dedupKey: planDedupKey(state, targets),
+                  });
+                  openLoginModal();
+                  return;
+                }
                 setSaveStatus("saving");
                 try {
                   const supabase = createClient();

--- a/components/auth/DraftDrainPrompt.tsx
+++ b/components/auth/DraftDrainPrompt.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/hooks/useAuth";
+
+/**
+ * Shared-computer guard for the anonymous→account plan drain. When AuthProvider
+ * detects a sessionStorage draft on the first authed load, it surfaces THIS
+ * confirmation — we NEVER auto-flush a draft into whoever happens to be signed
+ * in (person A's draft must not silently land in person B's account on a shared
+ * machine). Mounted in the root layout next to LoginModal / ConsentPrompt.
+ */
+export default function DraftDrainPrompt() {
+  const { user, pendingDraft, drainDraft, discardDraft } = useAuth();
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  if (!user || !pendingDraft || pendingDraft.plans.length === 0) return null;
+
+  const n = pendingDraft.plans.length;
+  const who = user.email ?? "your account";
+
+  return (
+    <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/50 p-4">
+      <div className="w-full max-w-sm rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-xl">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100">
+          Add your unsaved {n === 1 ? "plan" : "plans"}?
+        </h2>
+        <p className="mt-2 text-sm text-gray-600 dark:text-slate-400">
+          We found {n === 1 ? "a plan" : `${n} plans`} you built on this device before
+          signing in. Add {n === 1 ? "it" : "them"} to{" "}
+          <strong>{who}</strong>&apos;s account?
+        </p>
+        <div className="mt-4 flex gap-3">
+          <button
+            type="button"
+            onClick={async () => {
+              setBusy(true);
+              const ok = await drainDraft();
+              setBusy(false);
+              if (ok) router.push("/account");
+            }}
+            disabled={busy}
+            className="flex-1 rounded-lg bg-teal-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          >
+            {busy ? "Adding..." : "Add to my account"}
+          </button>
+          <button
+            type="button"
+            onClick={() => discardDraft()}
+            disabled={busy}
+            className="rounded-lg border border-gray-300 dark:border-slate-600 px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 disabled:opacity-50 transition"
+          >
+            Discard
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/auth/LoginModal.tsx
+++ b/components/auth/LoginModal.tsx
@@ -106,7 +106,7 @@ export default function LoginModal() {
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100">
-            Sign in to save your work
+            Save your work — free, in seconds
           </h2>
           <button
             onClick={closeLoginModal}

--- a/lib/__tests__/anon-draft.test.ts
+++ b/lib/__tests__/anon-draft.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseAndValidateDraft,
+  upsertPlan,
+  planDedupKey,
+  ANON_DRAFT_VERSION,
+  ANON_DRAFT_MAX_AGE_MS,
+  type AnonDraft,
+  type AnonPlanDraft,
+} from "@/lib/anon-draft";
+
+const NOW = 1_750_000_000_000;
+const plan = (over: Partial<AnonPlanDraft> = {}): AnonPlanDraft => ({
+  state: "va",
+  name: "My Plan",
+  targetCourses: ["BIO 101"],
+  kind: "semester",
+  dedupKey: "va::BIO 101",
+  ...over,
+});
+const draft = (over: Partial<AnonDraft> = {}): AnonDraft => ({
+  v: ANON_DRAFT_VERSION,
+  plans: [plan()],
+  savedAt: NOW,
+  ...over,
+});
+
+describe("parseAndValidateDraft", () => {
+  it("returns a valid, current-version, fresh draft", () => {
+    expect(parseAndValidateDraft(JSON.stringify(draft()), NOW)).toEqual(draft());
+  });
+
+  it("rejects a wrong-version payload", () => {
+    expect(parseAndValidateDraft(JSON.stringify(draft({ v: 99 })), NOW)).toBeNull();
+  });
+
+  it("rejects a stale payload (> 30 days old)", () => {
+    const old = draft({ savedAt: NOW - ANON_DRAFT_MAX_AGE_MS - 1 });
+    expect(parseAndValidateDraft(JSON.stringify(old), NOW)).toBeNull();
+  });
+
+  it("accepts a payload exactly at the age boundary", () => {
+    const edge = draft({ savedAt: NOW - ANON_DRAFT_MAX_AGE_MS });
+    expect(parseAndValidateDraft(JSON.stringify(edge), NOW)).not.toBeNull();
+  });
+
+  it("rejects null / malformed / empty-plans", () => {
+    expect(parseAndValidateDraft(null, NOW)).toBeNull();
+    expect(parseAndValidateDraft("{not json", NOW)).toBeNull();
+    expect(parseAndValidateDraft(JSON.stringify(draft({ plans: [] })), NOW)).toBeNull();
+  });
+});
+
+describe("upsertPlan", () => {
+  it("replaces an entry with the same dedupKey and keeps each entry's own state", () => {
+    const a = plan({ dedupKey: "k1", state: "va" });
+    const b = plan({ dedupKey: "k2", state: "tx" });
+    const aPrime = plan({ dedupKey: "k1", state: "va", name: "Renamed" });
+    const out = upsertPlan(upsertPlan([a], b), aPrime);
+    expect(out).toHaveLength(2);
+    expect(out.find((p) => p.dedupKey === "k1")?.name).toBe("Renamed");
+    expect(out.find((p) => p.dedupKey === "k2")?.state).toBe("tx");
+  });
+});
+
+describe("planDedupKey", () => {
+  it("is stable regardless of target order", () => {
+    expect(planDedupKey("va", ["B", "A"])).toBe(planDedupKey("va", ["A", "B"]));
+  });
+  it("differs by state and by target set", () => {
+    expect(planDedupKey("va", ["A"])).not.toBe(planDedupKey("tx", ["A"]));
+    expect(planDedupKey("va", ["A"])).not.toBe(planDedupKey("va", ["A", "B"]));
+  });
+});

--- a/lib/anon-draft.ts
+++ b/lib/anon-draft.ts
@@ -1,0 +1,106 @@
+/**
+ * Versioned sessionStorage draft for the anonymous→account hand-off.
+ *
+ * A logged-out student who builds a plan and clicks "Sign in to save" has the
+ * plan stashed here so it survives the full-page OAuth redirect; on first authed
+ * load AuthProvider offers to drain it into the new account (DraftDrainPrompt).
+ *
+ * Why sessionStorage (tab-scoped): safer on shared computers, cleared when the
+ * tab closes. NOT localStorage, and NOT a Supabase anonymous session — an anon
+ * session sets the `sb-` cookie and would defeat AuthProvider's logged-out SEO
+ * fast-path.
+ *
+ * Store only INPUT (state + course codes + kind), never computed plan_data —
+ * the plan is recomputed from target_courses after sign-in. The pure helpers
+ * (parseAndValidateDraft / upsertPlan / planDedupKey) are split from the I/O so
+ * they can be unit-tested without a DOM.
+ */
+export const ANON_DRAFT_KEY = "ccp:anon-draft";
+export const ANON_DRAFT_VERSION = 1;
+export const ANON_DRAFT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+export type PlanKind = "semester" | "program";
+
+export interface AnonPlanDraft {
+  state: string;
+  name: string;
+  targetCourses: string[];
+  kind: PlanKind;
+  dedupKey: string;
+}
+
+export interface AnonDraft {
+  v: number;
+  plans: AnonPlanDraft[];
+  savedAt: number; // epoch ms
+}
+
+/**
+ * Stable, content-derived idempotency key: re-saving the same plan (same state +
+ * same targets) reuses one entry, and the drain RPC is a no-op on retry.
+ */
+export function planDedupKey(state: string, targetCourses: string[]): string {
+  return `${state}::${[...targetCourses].sort().join("|")}`;
+}
+
+/**
+ * PURE: validate a raw JSON string into a draft, or null if missing / wrong
+ * version / malformed / stale (older than MAX_AGE) / empty. `now` is injected so
+ * staleness is testable.
+ */
+export function parseAndValidateDraft(raw: string | null, now: number): AnonDraft | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const d = parsed as Partial<AnonDraft> | null;
+  if (!d || d.v !== ANON_DRAFT_VERSION || !Array.isArray(d.plans)) return null;
+  if (typeof d.savedAt !== "number" || now - d.savedAt > ANON_DRAFT_MAX_AGE_MS) return null;
+  if (d.plans.length === 0) return null;
+  return d as AnonDraft;
+}
+
+/** PURE: add or replace a plan by its dedupKey (each entry keeps its own state). */
+export function upsertPlan(plans: AnonPlanDraft[], plan: AnonPlanDraft): AnonPlanDraft[] {
+  return [...plans.filter((p) => p.dedupKey !== plan.dedupKey), plan];
+}
+
+// ── sessionStorage I/O (client-only; no-ops during SSR) ─────────────────────
+
+export function stashPlanDraft(plan: AnonPlanDraft): void {
+  if (typeof window === "undefined") return;
+  try {
+    const existing = readAnonDraft();
+    const plans = upsertPlan(existing?.plans ?? [], plan);
+    const draft: AnonDraft = { v: ANON_DRAFT_VERSION, plans, savedAt: Date.now() };
+    window.sessionStorage.setItem(ANON_DRAFT_KEY, JSON.stringify(draft));
+  } catch {
+    // QuotaExceededError / serialization — drop silently; worst case the user
+    // re-saves after signing in.
+  }
+}
+
+export function readAnonDraft(): AnonDraft | null {
+  if (typeof window === "undefined") return null;
+  let raw: string | null = null;
+  try {
+    raw = window.sessionStorage.getItem(ANON_DRAFT_KEY);
+  } catch {
+    return null;
+  }
+  const draft = parseAndValidateDraft(raw, Date.now());
+  if (!draft && raw) clearAnonDraft(); // purge invalid / stale
+  return draft;
+}
+
+export function clearAnonDraft(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(ANON_DRAFT_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/supabase/migrations/025_drain_anonymous_plans.sql
+++ b/supabase/migrations/025_drain_anonymous_plans.sql
@@ -1,0 +1,77 @@
+-- ============================================================================
+-- 025: drain_anonymous_plans — idempotent anonymous→account plan drain
+-- ============================================================================
+-- WHAT: A function the client calls after sign-in to move the degree plans a
+--       user built while logged out (stashed in sessionStorage — see
+--       lib/anon-draft.ts) into their account. Inserts one saved_plans row per
+--       draft plan FOR THE CALLER (auth.uid()), idempotent via the
+--       client_dedup_key partial unique index from migration 024 — a retried
+--       drain is a no-op. Returns the number of rows actually inserted.
+-- WHY:  "Sign in to save" on the planner triggers a full-page OAuth redirect
+--       that destroys the in-memory plan; this is how it survives and lands.
+-- SECURITY: SECURITY DEFINER + pinned search_path (privilege-escalation guard,
+--       same as migration 022). Writes ONLY the caller's rows — user_id is
+--       auth.uid(), never trusted from the payload. EXECUTE granted to the
+--       `authenticated` role only.
+-- CAVEATS: Additive; idempotent (CREATE OR REPLACE). plan_data is a minimal
+--       placeholder by kind — /plan/[id] recomputes from target_courses, so the
+--       cached snapshot isn't needed for a drained plan.
+-- EXECUTION: Supabase Dashboard SQL Editor (or scripts/lib/run-migration.ts).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION drain_anonymous_plans(payload jsonb)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  uid uuid := auth.uid();
+  rec jsonb;
+  inserted integer := 0;
+BEGIN
+  IF uid IS NULL THEN
+    RAISE EXCEPTION 'drain_anonymous_plans: not authenticated';
+  END IF;
+
+  FOR rec IN
+    SELECT value FROM jsonb_array_elements(COALESCE(payload->'plans', '[]'::jsonb))
+  LOOP
+    -- Skip entries with no dedup key: the partial unique index can't dedup them,
+    -- so they'd risk duplicates on retry.
+    CONTINUE WHEN COALESCE(rec->>'dedupKey', '') = '';
+
+    INSERT INTO saved_plans
+      (user_id, state, name, target_courses, plan_data, kind, client_dedup_key)
+    VALUES (
+      uid,
+      rec->>'state',
+      COALESCE(NULLIF(rec->>'name', ''), 'My Plan'),
+      COALESCE(
+        (SELECT array_agg(value) FROM jsonb_array_elements_text(rec->'targetCourses')),
+        '{}'::text[]
+      ),
+      CASE WHEN rec->>'kind' = 'program'
+           THEN '{"groups": []}'::jsonb
+           ELSE '{"semesters": []}'::jsonb END,
+      COALESCE(NULLIF(rec->>'kind', ''), 'semester'),
+      rec->>'dedupKey'
+    )
+    ON CONFLICT (user_id, client_dedup_key) WHERE client_dedup_key IS NOT NULL
+    DO NOTHING;
+
+    IF FOUND THEN
+      inserted := inserted + 1;
+    END IF;
+  END LOOP;
+
+  RETURN inserted;
+END;
+$$;
+
+-- Supabase's default privileges grant EXECUTE to anon + authenticated directly
+-- (not via PUBLIC), so revoke from both PUBLIC and anon, then grant only to
+-- authenticated. (The function also self-protects via auth.uid() IS NULL.)
+REVOKE ALL ON FUNCTION drain_anonymous_plans(jsonb) FROM public;
+REVOKE ALL ON FUNCTION drain_anonymous_plans(jsonb) FROM anon;
+GRANT EXECUTE ON FUNCTION drain_anonymous_plans(jsonb) TO authenticated;


### PR DESCRIPTION
## What changes for someone using the site

A degree plan you build **before** signing in no longer vanishes when you log in. Today, building a plan and clicking "Sign in to save" opens the sign-in box — but the plan only lived in the page's memory, so the sign-in redirect wiped it and you'd land in an empty account. Now the plan is stashed safely, and right after you sign in a prompt asks **"Add your unsaved plan to &lt;your email&gt;'s account?"** (Add / Discard). The sign-in box also now leads with the benefit — **"Save your work — free, in seconds."**

## Why

First slice of "make login-required-to-save actually convert." Without it, the save-gate loses the user's work at the exact moment they convert — the worst possible time.

## How it works

- **`lib/anon-draft.ts`** — a versioned `sessionStorage` draft. `sessionStorage` (tab-scoped, safer on shared computers) — deliberately **not** a Supabase anonymous session, which would set the `sb-` cookie and defeat the logged-out SEO fast-path. Stores only the **inputs** (state + course codes + kind), not the computed plan; the plan is recomputed from the saved codes after sign-in. Drops wrong-version / >30-day drafts; survives storage-quota errors. Pure helpers unit-tested.
- The planner stashes the plan **before** opening the sign-in box.
- **Migration 025** — `drain_anonymous_plans()`: inserts the plans for the signed-in user **only**, **idempotently** (a retry can't duplicate — the `client_dedup_key` partial index from #1174). `SECURITY DEFINER` + pinned `search_path` + EXECUTE restricted to `authenticated` (anon revoked; also self-guards on `auth.uid()`).
- **AuthProvider** detects the draft on first authed load but **never auto-adds it** — the shared-computer confirmation (`DraftDrainPrompt`) is mandatory, so person A's draft can't silently land in person B's account on a shared machine.

## ⚠️ Migration already applied to prod

Migration `025` (the drain function) is **already applied** to Project CC and verified (SECURITY DEFINER, pinned search_path, `authenticated` yes / `anon` no). Merging just records the file.

## Test plan

- **Unit tests 8/8** (version mismatch, 30-day staleness + boundary, malformed/empty, upsert-by-key keeping each entry's state, stable content-based key).
- **Playwright (logged-out):** seed `/va/plan?targets=ENG+111`, click "Sign in to save" → the draft lands in `sessionStorage` with the right shape; the modal shows the new copy. **11/11.**
- `check:migration-drift` still green; `tsc` + `npm run build` pass.
- **Honest gap:** the full *login → drain → saved* path needs a real signed-in session I can't automate — covered by the RPC's by-construction idempotency (applied + verified) + code review. **Worth a manual check after merge:** sign in with a stashed plan and confirm the "Add your unsaved plan?" prompt → Add → it appears on `/account`.

## Out of scope (1b-ii)

Draining favorites + schedules into the same machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)