### PR TITLE
feat: drain favorited courses too (anon→account, 1b-ii)

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -20,6 +20,7 @@ import { useAuth } from "@/lib/hooks/useAuth";
 import { createClient } from "@/lib/supabase/client";
 import { track } from "@/lib/analytics";
 import AdUnit from "@/components/AdUnit";
+import { stashFavoriteDraft, favoriteDedupKey } from "@/lib/anon-draft";
 
 // ---------------------------------------------------------------------------
 // Types matching the API response
@@ -196,7 +197,20 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
   const [bookmarkError, setBookmarkError] = useState<string | null>(null);
 
   const toggleBookmark = useCallback(async (course: CourseGroup) => {
-    if (!user) { openLoginModal(); return; }
+    if (!user) {
+      // Stash the favorite BEFORE the login modal / OAuth redirect so it
+      // survives sign-in and can be drained into the new account. (Logged-out,
+      // bookmarkedCourses is always empty, so a click here is always an ADD.)
+      stashFavoriteDraft({
+        state,
+        coursePrefix: course.prefix,
+        courseNumber: course.number,
+        courseTitle: course.title,
+        dedupKey: favoriteDedupKey(state, course.prefix, course.number),
+      });
+      openLoginModal();
+      return;
+    }
     const key = `${course.prefix}-${course.number}`;
     setBookmarkLoading((prev) => new Set(prev).add(key));
     setBookmarkError(null);

--- a/components/auth/DraftDrainPrompt.tsx
+++ b/components/auth/DraftDrainPrompt.tsx
@@ -5,32 +5,40 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/hooks/useAuth";
 
 /**
- * Shared-computer guard for the anonymous→account plan drain. When AuthProvider
- * detects a sessionStorage draft on the first authed load, it surfaces THIS
- * confirmation — we NEVER auto-flush a draft into whoever happens to be signed
- * in (person A's draft must not silently land in person B's account on a shared
- * machine). Mounted in the root layout next to LoginModal / ConsentPrompt.
+ * Shared-computer guard for the anonymous→account drain. When AuthProvider
+ * detects a sessionStorage draft (plans and/or favorited courses) on the first
+ * authed load, it surfaces THIS confirmation — we NEVER auto-flush a draft into
+ * whoever happens to be signed in (person A's draft must not silently land in
+ * person B's account on a shared machine). Mounted in the root layout next to
+ * LoginModal / ConsentPrompt.
  */
 export default function DraftDrainPrompt() {
   const { user, pendingDraft, drainDraft, discardDraft } = useAuth();
   const router = useRouter();
   const [busy, setBusy] = useState(false);
 
-  if (!user || !pendingDraft || pendingDraft.plans.length === 0) return null;
+  if (!user || !pendingDraft) return null;
+  const planCount = pendingDraft.plans.length;
+  const favCount = pendingDraft.favorites.length;
+  if (planCount === 0 && favCount === 0) return null;
 
-  const n = pendingDraft.plans.length;
   const who = user.email ?? "your account";
+  const parts: string[] = [];
+  if (planCount > 0) parts.push(`${planCount} ${planCount === 1 ? "plan" : "plans"}`);
+  if (favCount > 0)
+    parts.push(`${favCount} saved ${favCount === 1 ? "course" : "courses"}`);
+  const summary = parts.join(" and ");
+  const isPlural = planCount + favCount > 1;
 
   return (
     <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/50 p-4">
       <div className="w-full max-w-sm rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-xl">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100">
-          Add your unsaved {n === 1 ? "plan" : "plans"}?
+          Add your unsaved work?
         </h2>
         <p className="mt-2 text-sm text-gray-600 dark:text-slate-400">
-          We found {n === 1 ? "a plan" : `${n} plans`} you built on this device before
-          signing in. Add {n === 1 ? "it" : "them"} to{" "}
-          <strong>{who}</strong>&apos;s account?
+          We found {summary} you saved on this device before signing in. Add{" "}
+          {isPlural ? "them" : "it"} to <strong>{who}</strong>&apos;s account?
         </p>
         <div className="mt-4 flex gap-3">
           <button

--- a/lib/__tests__/anon-draft.test.ts
+++ b/lib/__tests__/anon-draft.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from "vitest";
 import {
   parseAndValidateDraft,
   upsertPlan,
+  upsertFavorite,
   planDedupKey,
+  favoriteDedupKey,
   ANON_DRAFT_VERSION,
   ANON_DRAFT_MAX_AGE_MS,
   type AnonDraft,
   type AnonPlanDraft,
+  type AnonFavoriteDraft,
 } from "@/lib/anon-draft";
 
 const NOW = 1_750_000_000_000;
@@ -18,9 +21,18 @@ const plan = (over: Partial<AnonPlanDraft> = {}): AnonPlanDraft => ({
   dedupKey: "va::BIO 101",
   ...over,
 });
+const fav = (over: Partial<AnonFavoriteDraft> = {}): AnonFavoriteDraft => ({
+  state: "va",
+  coursePrefix: "BIO",
+  courseNumber: "101",
+  courseTitle: "Biology I",
+  dedupKey: "va::BIO::101",
+  ...over,
+});
 const draft = (over: Partial<AnonDraft> = {}): AnonDraft => ({
   v: ANON_DRAFT_VERSION,
   plans: [plan()],
+  favorites: [],
   savedAt: NOW,
   ...over,
 });
@@ -49,6 +61,18 @@ describe("parseAndValidateDraft", () => {
     expect(parseAndValidateDraft("{not json", NOW)).toBeNull();
     expect(parseAndValidateDraft(JSON.stringify(draft({ plans: [] })), NOW)).toBeNull();
   });
+
+  it("defaults a missing favorites array (back-compat with v1 plans-only drafts)", () => {
+    const legacy = JSON.stringify({ v: ANON_DRAFT_VERSION, plans: [plan()], savedAt: NOW });
+    const parsed = parseAndValidateDraft(legacy, NOW);
+    expect(parsed?.favorites).toEqual([]);
+    expect(parsed?.plans).toHaveLength(1);
+  });
+
+  it("accepts a favorites-only draft (no plans)", () => {
+    const favOnly = draft({ plans: [], favorites: [fav()] });
+    expect(parseAndValidateDraft(JSON.stringify(favOnly), NOW)).toEqual(favOnly);
+  });
 });
 
 describe("upsertPlan", () => {
@@ -70,5 +94,20 @@ describe("planDedupKey", () => {
   it("differs by state and by target set", () => {
     expect(planDedupKey("va", ["A"])).not.toBe(planDedupKey("tx", ["A"]));
     expect(planDedupKey("va", ["A"])).not.toBe(planDedupKey("va", ["A", "B"]));
+  });
+});
+
+describe("upsertFavorite / favoriteDedupKey", () => {
+  it("replaces a favorite with the same dedupKey", () => {
+    const a = fav({ dedupKey: "k1", courseTitle: "Old" });
+    const b = fav({ dedupKey: "k2" });
+    const aPrime = fav({ dedupKey: "k1", courseTitle: "New" });
+    const out = upsertFavorite(upsertFavorite([a], b), aPrime);
+    expect(out).toHaveLength(2);
+    expect(out.find((f) => f.dedupKey === "k1")?.courseTitle).toBe("New");
+  });
+  it("favoriteDedupKey is content-based (state + prefix + number)", () => {
+    expect(favoriteDedupKey("va", "BIO", "101")).toBe("va::BIO::101");
+    expect(favoriteDedupKey("va", "BIO", "101")).not.toBe(favoriteDedupKey("tx", "BIO", "101"));
   });
 });

--- a/lib/anon-draft.ts
+++ b/lib/anon-draft.ts
@@ -29,9 +29,18 @@ export interface AnonPlanDraft {
   dedupKey: string;
 }
 
+export interface AnonFavoriteDraft {
+  state: string;
+  coursePrefix: string;
+  courseNumber: string;
+  courseTitle: string;
+  dedupKey: string;
+}
+
 export interface AnonDraft {
   v: number;
   plans: AnonPlanDraft[];
+  favorites: AnonFavoriteDraft[];
   savedAt: number; // epoch ms
 }
 
@@ -59,13 +68,30 @@ export function parseAndValidateDraft(raw: string | null, now: number): AnonDraf
   const d = parsed as Partial<AnonDraft> | null;
   if (!d || d.v !== ANON_DRAFT_VERSION || !Array.isArray(d.plans)) return null;
   if (typeof d.savedAt !== "number" || now - d.savedAt > ANON_DRAFT_MAX_AGE_MS) return null;
-  if (d.plans.length === 0) return null;
-  return d as AnonDraft;
+  // favorites was added after v1 shipped — default a missing array so older
+  // #1176 drafts (plans only) stay valid.
+  const favorites = Array.isArray(d.favorites) ? d.favorites : [];
+  if (d.plans.length === 0 && favorites.length === 0) return null;
+  return { v: d.v, plans: d.plans, favorites, savedAt: d.savedAt } as AnonDraft;
 }
 
 /** PURE: add or replace a plan by its dedupKey (each entry keeps its own state). */
 export function upsertPlan(plans: AnonPlanDraft[], plan: AnonPlanDraft): AnonPlanDraft[] {
   return [...plans.filter((p) => p.dedupKey !== plan.dedupKey), plan];
+}
+
+/** Stable content key for a favorited course — matches the saved_courses unique
+ *  index granularity (state + prefix + number). */
+export function favoriteDedupKey(state: string, prefix: string, number: string): string {
+  return `${state}::${prefix}::${number}`;
+}
+
+/** PURE: add or replace a favorite by its dedupKey. */
+export function upsertFavorite(
+  favorites: AnonFavoriteDraft[],
+  fav: AnonFavoriteDraft
+): AnonFavoriteDraft[] {
+  return [...favorites.filter((f) => f.dedupKey !== fav.dedupKey), fav];
 }
 
 // ── sessionStorage I/O (client-only; no-ops during SSR) ─────────────────────
@@ -75,11 +101,33 @@ export function stashPlanDraft(plan: AnonPlanDraft): void {
   try {
     const existing = readAnonDraft();
     const plans = upsertPlan(existing?.plans ?? [], plan);
-    const draft: AnonDraft = { v: ANON_DRAFT_VERSION, plans, savedAt: Date.now() };
+    const draft: AnonDraft = {
+      v: ANON_DRAFT_VERSION,
+      plans,
+      favorites: existing?.favorites ?? [],
+      savedAt: Date.now(),
+    };
     window.sessionStorage.setItem(ANON_DRAFT_KEY, JSON.stringify(draft));
   } catch {
     // QuotaExceededError / serialization — drop silently; worst case the user
     // re-saves after signing in.
+  }
+}
+
+export function stashFavoriteDraft(fav: AnonFavoriteDraft): void {
+  if (typeof window === "undefined") return;
+  try {
+    const existing = readAnonDraft();
+    const favorites = upsertFavorite(existing?.favorites ?? [], fav);
+    const draft: AnonDraft = {
+      v: ANON_DRAFT_VERSION,
+      plans: existing?.plans ?? [],
+      favorites,
+      savedAt: Date.now(),
+    };
+    window.sessionStorage.setItem(ANON_DRAFT_KEY, JSON.stringify(draft));
+  } catch {
+    // QuotaExceededError / serialization — drop silently.
   }
 }
 

--- a/supabase/migrations/026_drain_anonymous_favorites.sql
+++ b/supabase/migrations/026_drain_anonymous_favorites.sql
@@ -1,0 +1,96 @@
+-- ============================================================================
+-- 026: drain_anonymous_plans — also drain favorited courses
+-- ============================================================================
+-- WHAT: Extends the 025 drain function (SAME NAME — the live 1b-i client calls
+--       drain_anonymous_plans; renaming/dropping would break the live plan
+--       drain) to ALSO insert favorited courses from payload->'favorites' into
+--       saved_courses, idempotent via the existing saved_courses UNIQUE index
+--       (which actually fires after migration 024's college_code/crn NOT NULL
+--       backfill). The old plans-only client sends no 'favorites' key →
+--       COALESCE to [] → harmless no-op.
+-- WHY:  1b-ii — a course favorited while logged out should also survive sign-in.
+-- SECURITY: unchanged from 025 — SECURITY DEFINER + pinned search_path, writes
+--       only the caller's rows (auth.uid()), EXECUTE for `authenticated` only
+--       (anon revoked; also self-guards on auth.uid() IS NULL).
+-- CAVEATS: Idempotent (CREATE OR REPLACE). Additive.
+-- EXECUTION: Supabase Dashboard SQL Editor (or scripts/lib/run-migration.ts).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION drain_anonymous_plans(payload jsonb)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  uid uuid := auth.uid();
+  rec jsonb;
+  inserted integer := 0;
+BEGIN
+  IF uid IS NULL THEN
+    RAISE EXCEPTION 'drain_anonymous_plans: not authenticated';
+  END IF;
+
+  -- Plans (unchanged from 025).
+  FOR rec IN
+    SELECT value FROM jsonb_array_elements(COALESCE(payload->'plans', '[]'::jsonb))
+  LOOP
+    CONTINUE WHEN COALESCE(rec->>'dedupKey', '') = '';
+
+    INSERT INTO saved_plans
+      (user_id, state, name, target_courses, plan_data, kind, client_dedup_key)
+    VALUES (
+      uid,
+      rec->>'state',
+      COALESCE(NULLIF(rec->>'name', ''), 'My Plan'),
+      COALESCE(
+        (SELECT array_agg(value) FROM jsonb_array_elements_text(rec->'targetCourses')),
+        '{}'::text[]
+      ),
+      CASE WHEN rec->>'kind' = 'program'
+           THEN '{"groups": []}'::jsonb
+           ELSE '{"semesters": []}'::jsonb END,
+      COALESCE(NULLIF(rec->>'kind', ''), 'semester'),
+      rec->>'dedupKey'
+    )
+    ON CONFLICT (user_id, client_dedup_key) WHERE client_dedup_key IS NOT NULL
+    DO NOTHING;
+
+    IF FOUND THEN
+      inserted := inserted + 1;
+    END IF;
+  END LOOP;
+
+  -- Favorites (new in 026). Idempotent via the saved_courses unique index
+  -- (user_id, state, course_prefix, course_number, college_code, crn);
+  -- college_code/crn default '' (NOT NULL after migration 024).
+  FOR rec IN
+    SELECT value FROM jsonb_array_elements(COALESCE(payload->'favorites', '[]'::jsonb))
+  LOOP
+    CONTINUE WHEN COALESCE(rec->>'coursePrefix', '') = ''
+               OR COALESCE(rec->>'courseNumber', '') = '';
+
+    INSERT INTO saved_courses
+      (user_id, state, course_prefix, course_number, course_title)
+    VALUES (
+      uid,
+      rec->>'state',
+      rec->>'coursePrefix',
+      rec->>'courseNumber',
+      COALESCE(rec->>'courseTitle', '')
+    )
+    ON CONFLICT (user_id, state, course_prefix, course_number, college_code, crn)
+    DO NOTHING;
+
+    IF FOUND THEN
+      inserted := inserted + 1;
+    END IF;
+  END LOOP;
+
+  RETURN inserted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION drain_anonymous_plans(jsonb) FROM public;
+REVOKE ALL ON FUNCTION drain_anonymous_plans(jsonb) FROM anon;
+GRANT EXECUTE ON FUNCTION drain_anonymous_plans(jsonb) TO authenticated;


### PR DESCRIPTION
## What changes for someone using the site

Extends #1176: a course you **favorite while logged out** now also survives signing in, not just degree plans. Favorite a course before logging in → after you sign in, the same prompt offers to add your unsaved **plans and saved courses** to your account.

## How it works

- **`lib/anon-draft.ts`**: the sessionStorage draft gains a `favorites` array (kept `v:1` — a missing array defaults to `[]` on read, so #1176 plans-only drafts stay valid). New pure helpers + `stashFavoriteDraft`; `stashPlanDraft` now preserves favorites and vice-versa. Unit tests 8 → 12.
- **`CourseSearchClient.toggleBookmark`** stashes the favorite **before** `openLoginModal` when logged out (a logged-out click is always an ADD).
- **Migration 026** `CREATE OR REPLACE`s `drain_anonymous_plans` — **same name on purpose**: #1176's client is live in prod and calls it, so renaming/dropping would break the live plan drain. It now also inserts `payload->'favorites'` into `saved_courses`, idempotent via the `saved_courses` unique index (which fires after #1174's NOT NULL backfill). The old plans-only client sends no favorites → `COALESCE []` → no-op. Same `SECURITY DEFINER` + pinned `search_path` + `authenticated`-only (anon revoked).
- **`DraftDrainPrompt`** generalized to plans **and** favorites — and its gate is fixed so a favorites-only draft still prompts (the #1176 version returned early on `plans.length === 0`).
- **AuthProvider unchanged** — `drainDraft` already sends the whole draft.

## ⚠️ Migration already applied to prod

Migration `026` is **already applied** to Project CC + verified (`authenticated` yes / `anon` no, SECURITY DEFINER). Merging records the file.

## Test plan

- **Unit tests 12/12** — favorites add/upsert, content key, missing-favorites back-compat, favorites-only validity, plans unchanged.
- **Playwright (logged-out):** `/va/courses?q=english`, click a course's bookmark → the favorite lands in the sessionStorage draft with the right shape (favorites-only, `plans:[]`); modal opens. **10/10.**
- `check:migration-drift` green; `tsc` + `npm run build` pass.
- **Not e2e'd:** full *login → drain → saved* (needs a real session) — covered by the RPC's ON CONFLICT idempotency + applied function + code review. **Manual check after merge:** sign in with a stashed favorite → "Add your unsaved work?" → Add → it appears in your account's saved courses.

## Out of scope (1b-iii)

Draining saved **schedules** (needs a new dedup-key migration on `saved_schedules`, which has none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)