### PR TITLE
feat: drain anonymous schedules too (anon→account, 1b-iii)

### DIFF
--- a/components/auth/DraftDrainPrompt.tsx
+++ b/components/auth/DraftDrainPrompt.tsx
@@ -6,8 +6,9 @@ import { useAuth } from "@/lib/hooks/useAuth";
 
 /**
  * Shared-computer guard for the anonymous→account drain. When AuthProvider
- * detects a sessionStorage draft (plans and/or favorited courses) on the first
- * authed load, it surfaces THIS confirmation — we NEVER auto-flush a draft into
+ * detects a sessionStorage draft (plans, favorited courses, and/or schedules)
+ * on the first authed load, it surfaces THIS confirmation — we NEVER auto-flush
+ * a draft into
  * whoever happens to be signed in (person A's draft must not silently land in
  * person B's account on a shared machine). Mounted in the root layout next to
  * LoginModal / ConsentPrompt.
@@ -20,15 +21,18 @@ export default function DraftDrainPrompt() {
   if (!user || !pendingDraft) return null;
   const planCount = pendingDraft.plans.length;
   const favCount = pendingDraft.favorites.length;
-  if (planCount === 0 && favCount === 0) return null;
+  const schedCount = pendingDraft.schedules.length;
+  if (planCount === 0 && favCount === 0 && schedCount === 0) return null;
 
   const who = user.email ?? "your account";
   const parts: string[] = [];
   if (planCount > 0) parts.push(`${planCount} ${planCount === 1 ? "plan" : "plans"}`);
   if (favCount > 0)
     parts.push(`${favCount} saved ${favCount === 1 ? "course" : "courses"}`);
+  if (schedCount > 0)
+    parts.push(`${schedCount} ${schedCount === 1 ? "schedule" : "schedules"}`);
   const summary = parts.join(" and ");
-  const isPlural = planCount + favCount > 1;
+  const isPlural = planCount + favCount + schedCount > 1;
 
   return (
     <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/50 p-4">

--- a/components/schedule/ScheduleResults.tsx
+++ b/components/schedule/ScheduleResults.tsx
@@ -10,6 +10,7 @@ import SectionSeats from "@/components/SectionSeats";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { createClient } from "@/lib/supabase/client";
 import { track } from "@/lib/analytics";
+import { stashScheduleDraft, scheduleDedupKey } from "@/lib/anon-draft";
 
 interface Props {
   response: ScheduleResponse;
@@ -511,15 +512,30 @@ function ScheduleCard({
             <button
               type="button"
               onClick={async () => {
-                if (!user) { openLoginModal(); return; }
+                // Build a descriptive name from course codes — shared by the
+                // logged-out stash and the authed insert below.
+                const courseLabels = [...new Set(sections.map((s) => `${s.course_prefix} ${s.course_number}`))];
+                const name = courseLabels.length > 0
+                  ? courseLabels.join(", ")
+                  : `Schedule #${rank}`;
+                if (!user) {
+                  // Stash the chosen schedule so it survives the OAuth redirect;
+                  // AuthProvider offers to drain it on first authed load.
+                  stashScheduleDraft({
+                    state,
+                    name,
+                    sections,
+                    score: score ?? null,
+                    scoreBreakdown: scoreBreakdown ?? null,
+                    formData: formData && Object.keys(formData).length > 0 ? formData : null,
+                    dedupKey: scheduleDedupKey(state, sections),
+                  });
+                  openLoginModal();
+                  return;
+                }
                 setSaveStatus("saving");
                 try {
                   const supabase = createClient();
-                  // Build a descriptive name from course codes
-                  const courseLabels = [...new Set(sections.map((s) => `${s.course_prefix} ${s.course_number}`))];
-                  const name = courseLabels.length > 0
-                    ? courseLabels.join(", ")
-                    : `Schedule #${rank}`;
                   const { error } = await supabase.from("saved_schedules").insert({
                     user_id: user.id,
                     state,

--- a/lib/__tests__/anon-draft.test.ts
+++ b/lib/__tests__/anon-draft.test.ts
@@ -1,15 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import {
   parseAndValidateDraft,
   upsertPlan,
   upsertFavorite,
+  upsertSchedule,
   planDedupKey,
   favoriteDedupKey,
+  scheduleDedupKey,
+  stashPlanDraft,
+  stashFavoriteDraft,
+  stashScheduleDraft,
+  readAnonDraft,
   ANON_DRAFT_VERSION,
   ANON_DRAFT_MAX_AGE_MS,
   type AnonDraft,
   type AnonPlanDraft,
   type AnonFavoriteDraft,
+  type AnonScheduleDraft,
 } from "@/lib/anon-draft";
 
 const NOW = 1_750_000_000_000;
@@ -29,10 +36,21 @@ const fav = (over: Partial<AnonFavoriteDraft> = {}): AnonFavoriteDraft => ({
   dedupKey: "va::BIO::101",
   ...over,
 });
+const sched = (over: Partial<AnonScheduleDraft> = {}): AnonScheduleDraft => ({
+  state: "va",
+  name: "BIO 101",
+  sections: [{ college_code: "nv", crn: "12345" }],
+  score: 87,
+  scoreBreakdown: null,
+  formData: { zip: "20109" },
+  dedupKey: "va::nv:12345",
+  ...over,
+});
 const draft = (over: Partial<AnonDraft> = {}): AnonDraft => ({
   v: ANON_DRAFT_VERSION,
   plans: [plan()],
   favorites: [],
+  schedules: [],
   savedAt: NOW,
   ...over,
 });
@@ -62,16 +80,27 @@ describe("parseAndValidateDraft", () => {
     expect(parseAndValidateDraft(JSON.stringify(draft({ plans: [] })), NOW)).toBeNull();
   });
 
-  it("defaults a missing favorites array (back-compat with v1 plans-only drafts)", () => {
+  it("defaults missing favorites + schedules arrays (back-compat with older drafts)", () => {
     const legacy = JSON.stringify({ v: ANON_DRAFT_VERSION, plans: [plan()], savedAt: NOW });
     const parsed = parseAndValidateDraft(legacy, NOW);
     expect(parsed?.favorites).toEqual([]);
+    expect(parsed?.schedules).toEqual([]);
     expect(parsed?.plans).toHaveLength(1);
   });
 
   it("accepts a favorites-only draft (no plans)", () => {
     const favOnly = draft({ plans: [], favorites: [fav()] });
     expect(parseAndValidateDraft(JSON.stringify(favOnly), NOW)).toEqual(favOnly);
+  });
+
+  it("accepts a schedules-only draft (no plans or favorites)", () => {
+    const schedOnly = draft({ plans: [], favorites: [], schedules: [sched()] });
+    expect(parseAndValidateDraft(JSON.stringify(schedOnly), NOW)).toEqual(schedOnly);
+  });
+
+  it("rejects an all-empty draft (no plans, favorites, or schedules)", () => {
+    const empty = draft({ plans: [], favorites: [], schedules: [] });
+    expect(parseAndValidateDraft(JSON.stringify(empty), NOW)).toBeNull();
   });
 });
 
@@ -109,5 +138,78 @@ describe("upsertFavorite / favoriteDedupKey", () => {
   it("favoriteDedupKey is content-based (state + prefix + number)", () => {
     expect(favoriteDedupKey("va", "BIO", "101")).toBe("va::BIO::101");
     expect(favoriteDedupKey("va", "BIO", "101")).not.toBe(favoriteDedupKey("tx", "BIO", "101"));
+  });
+});
+
+describe("scheduleDedupKey", () => {
+  it("is stable regardless of section order", () => {
+    const a = [
+      { college_code: "nv", crn: "111" },
+      { college_code: "tcc", crn: "222" },
+    ];
+    const b = [
+      { college_code: "tcc", crn: "222" },
+      { college_code: "nv", crn: "111" },
+    ];
+    expect(scheduleDedupKey("va", a)).toBe(scheduleDedupKey("va", b));
+  });
+  it("differs by state and by section set", () => {
+    const s = [{ college_code: "nv", crn: "111" }];
+    expect(scheduleDedupKey("va", s)).not.toBe(scheduleDedupKey("tx", s));
+    expect(scheduleDedupKey("va", s)).not.toBe(
+      scheduleDedupKey("va", [...s, { college_code: "nv", crn: "222" }])
+    );
+  });
+});
+
+describe("upsertSchedule", () => {
+  it("replaces a schedule with the same dedupKey", () => {
+    const a = sched({ dedupKey: "k1", name: "Old" });
+    const b = sched({ dedupKey: "k2" });
+    const aPrime = sched({ dedupKey: "k1", name: "New" });
+    const out = upsertSchedule(upsertSchedule([a], b), aPrime);
+    expect(out).toHaveLength(2);
+    expect(out.find((s) => s.dedupKey === "k1")?.name).toBe("New");
+  });
+});
+
+describe("stash* sessionStorage I/O", () => {
+  // The vitest env is "node" (no DOM); install a minimal sessionStorage stub so
+  // the I/O helpers run, then tear it down so the pure tests stay unaffected.
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    (globalThis as { window?: unknown }).window = {
+      sessionStorage: {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => {
+          store.set(k, v);
+        },
+        removeItem: (k: string) => {
+          store.delete(k);
+        },
+      },
+    };
+  });
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  it("stashScheduleDraft preserves existing plans and favorites", () => {
+    stashPlanDraft(plan());
+    stashFavoriteDraft(fav());
+    stashScheduleDraft(sched());
+    const out = readAnonDraft();
+    expect(out?.plans).toHaveLength(1);
+    expect(out?.favorites).toHaveLength(1);
+    expect(out?.schedules).toHaveLength(1);
+    expect(out?.schedules?.[0]?.dedupKey).toBe("va::nv:12345");
+  });
+
+  it("stashScheduleDraft de-dupes by dedupKey on re-save", () => {
+    stashScheduleDraft(sched());
+    stashScheduleDraft(sched({ name: "Renamed" }));
+    const out = readAnonDraft();
+    expect(out?.schedules).toHaveLength(1);
+    expect(out?.schedules?.[0]?.name).toBe("Renamed");
   });
 });

--- a/lib/anon-draft.ts
+++ b/lib/anon-draft.ts
@@ -11,9 +11,12 @@
  * fast-path.
  *
  * Store only INPUT (state + course codes + kind), never computed plan_data —
- * the plan is recomputed from target_courses after sign-in. The pure helpers
- * (parseAndValidateDraft / upsertPlan / planDedupKey) are split from the I/O so
- * they can be unit-tested without a DOM.
+ * plans/favorites are recomputed from their input after sign-in. EXCEPTION: a
+ * saved SCHEDULE is one chosen GeneratedSchedule (one of many ranked options),
+ * so there is nothing to recompute — its draft carries the full sections array
+ * + score + scoreBreakdown + form_data, inserted verbatim by the drain. The
+ * pure helpers (parseAndValidateDraft / upsert* / *DedupKey) are split from the
+ * I/O so they can be unit-tested without a DOM.
  */
 export const ANON_DRAFT_KEY = "ccp:anon-draft";
 export const ANON_DRAFT_VERSION = 1;
@@ -37,10 +40,27 @@ export interface AnonFavoriteDraft {
   dedupKey: string;
 }
 
+/**
+ * A chosen schedule. Unlike plans/favorites this stores COMPUTED output (the
+ * picked sections + score), because the saved artifact IS one specific ranked
+ * option — there is no input to recompute it from. `sections` is the serialized
+ * ScheduleSection[]; score / scoreBreakdown / formData may be null.
+ */
+export interface AnonScheduleDraft {
+  state: string;
+  name: string;
+  sections: unknown[];
+  score: number | null;
+  scoreBreakdown: unknown | null;
+  formData: Record<string, unknown> | null;
+  dedupKey: string;
+}
+
 export interface AnonDraft {
   v: number;
   plans: AnonPlanDraft[];
   favorites: AnonFavoriteDraft[];
+  schedules: AnonScheduleDraft[];
   savedAt: number; // epoch ms
 }
 
@@ -68,11 +88,13 @@ export function parseAndValidateDraft(raw: string | null, now: number): AnonDraf
   const d = parsed as Partial<AnonDraft> | null;
   if (!d || d.v !== ANON_DRAFT_VERSION || !Array.isArray(d.plans)) return null;
   if (typeof d.savedAt !== "number" || now - d.savedAt > ANON_DRAFT_MAX_AGE_MS) return null;
-  // favorites was added after v1 shipped — default a missing array so older
-  // #1176 drafts (plans only) stay valid.
+  // favorites and schedules were added after the v1 plans-only draft shipped —
+  // default missing arrays so older drafts (plans-only / plans+favorites) stay
+  // valid.
   const favorites = Array.isArray(d.favorites) ? d.favorites : [];
-  if (d.plans.length === 0 && favorites.length === 0) return null;
-  return { v: d.v, plans: d.plans, favorites, savedAt: d.savedAt } as AnonDraft;
+  const schedules = Array.isArray(d.schedules) ? d.schedules : [];
+  if (d.plans.length === 0 && favorites.length === 0 && schedules.length === 0) return null;
+  return { v: d.v, plans: d.plans, favorites, schedules, savedAt: d.savedAt } as AnonDraft;
 }
 
 /** PURE: add or replace a plan by its dedupKey (each entry keeps its own state). */
@@ -94,6 +116,27 @@ export function upsertFavorite(
   return [...favorites.filter((f) => f.dedupKey !== fav.dedupKey), fav];
 }
 
+/**
+ * Stable content key for a chosen schedule: state + the sorted set of section
+ * identifiers (college_code:crn). Re-saving the same set of sections reuses one
+ * entry; a different combination is a distinct schedule. Order-independent.
+ */
+export function scheduleDedupKey(
+  state: string,
+  sections: ReadonlyArray<{ college_code: string; crn: string }>
+): string {
+  const ids = sections.map((s) => `${s.college_code}:${s.crn}`).sort();
+  return `${state}::${ids.join("|")}`;
+}
+
+/** PURE: add or replace a schedule by its dedupKey. */
+export function upsertSchedule(
+  schedules: AnonScheduleDraft[],
+  sched: AnonScheduleDraft
+): AnonScheduleDraft[] {
+  return [...schedules.filter((s) => s.dedupKey !== sched.dedupKey), sched];
+}
+
 // ── sessionStorage I/O (client-only; no-ops during SSR) ─────────────────────
 
 export function stashPlanDraft(plan: AnonPlanDraft): void {
@@ -105,6 +148,7 @@ export function stashPlanDraft(plan: AnonPlanDraft): void {
       v: ANON_DRAFT_VERSION,
       plans,
       favorites: existing?.favorites ?? [],
+      schedules: existing?.schedules ?? [],
       savedAt: Date.now(),
     };
     window.sessionStorage.setItem(ANON_DRAFT_KEY, JSON.stringify(draft));
@@ -123,6 +167,25 @@ export function stashFavoriteDraft(fav: AnonFavoriteDraft): void {
       v: ANON_DRAFT_VERSION,
       plans: existing?.plans ?? [],
       favorites,
+      schedules: existing?.schedules ?? [],
+      savedAt: Date.now(),
+    };
+    window.sessionStorage.setItem(ANON_DRAFT_KEY, JSON.stringify(draft));
+  } catch {
+    // QuotaExceededError / serialization — drop silently.
+  }
+}
+
+export function stashScheduleDraft(sched: AnonScheduleDraft): void {
+  if (typeof window === "undefined") return;
+  try {
+    const existing = readAnonDraft();
+    const schedules = upsertSchedule(existing?.schedules ?? [], sched);
+    const draft: AnonDraft = {
+      v: ANON_DRAFT_VERSION,
+      plans: existing?.plans ?? [],
+      favorites: existing?.favorites ?? [],
+      schedules,
       savedAt: Date.now(),
     };
     window.sessionStorage.setItem(ANON_DRAFT_KEY, JSON.stringify(draft));

--- a/supabase/migrations/027_saved_schedules_dedup.sql
+++ b/supabase/migrations/027_saved_schedules_dedup.sql
@@ -1,0 +1,24 @@
+-- ============================================================================
+-- 027: saved_schedules.client_dedup_key — idempotency for the schedule drain
+-- ============================================================================
+-- WHAT: Adds a nullable client_dedup_key to saved_schedules + a PARTIAL unique
+--       index on (user_id, client_dedup_key) so the 028 drain RPC can insert a
+--       logged-out-built schedule exactly once via ON CONFLICT DO NOTHING.
+-- WHY:  1b-iii — a schedule built while logged out should survive sign-in. Like
+--       024 did for saved_plans, the dedup key lives in its own additive
+--       migration so the structural change is separate from the function change.
+-- NOTE: The index is PARTIAL (WHERE client_dedup_key IS NOT NULL) so existing
+--       rows + any future direct inserts that omit the key stay unconstrained —
+--       only drained rows (which always carry a key) are de-duplicated. The key
+--       is a TEXT content hash of (state + sorted section college_code:crn),
+--       computed client-side in lib/anon-draft.ts (scheduleDedupKey).
+-- CAVEATS: Additive + idempotent (IF NOT EXISTS). No backfill of old rows.
+-- EXECUTION: Supabase Dashboard SQL Editor (or scripts/lib/run-migration.ts).
+-- ============================================================================
+
+ALTER TABLE saved_schedules
+  ADD COLUMN IF NOT EXISTS client_dedup_key TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_schedules_user_dedup
+  ON saved_schedules (user_id, client_dedup_key)
+  WHERE client_dedup_key IS NOT NULL;

--- a/supabase/migrations/028_drain_anonymous_schedules.sql
+++ b/supabase/migrations/028_drain_anonymous_schedules.sql
@@ -1,0 +1,134 @@
+-- ============================================================================
+-- 028: drain_anonymous_plans — also drain saved schedules
+-- ============================================================================
+-- WHAT: Extends the 026 drain function (SAME NAME/SIGNATURE — the live client
+--       calls drain_anonymous_plans; renaming/dropping would break the live
+--       plan + favorite drain) to ALSO insert chosen schedules from
+--       payload->'schedules' into saved_schedules, idempotent via 027's partial
+--       unique index (user_id, client_dedup_key). Old clients (1b-i/1b-ii) send
+--       no 'schedules' key → COALESCE to [] → harmless no-op.
+-- WHY:  1b-iii — a schedule built while logged out should survive sign-in.
+-- KEY DIFFERENCE vs plans/favorites: a saved schedule stores COMPUTED data — it
+--       is ONE chosen GeneratedSchedule, not a recomputed-from-input artifact —
+--       so the draft carries the full sections array + score + scoreBreakdown +
+--       form_data, and we insert them verbatim. form_data & sections are NOT
+--       NULL in saved_schedules, so we COALESCE form_data to '{}' and skip any
+--       schedule whose sections array is empty.
+-- SECURITY: unchanged from 026 — SECURITY DEFINER + pinned search_path, writes
+--       only the caller's rows (auth.uid()), EXECUTE for `authenticated` only
+--       (anon revoked; also self-guards on auth.uid() IS NULL).
+-- CAVEATS: Idempotent (CREATE OR REPLACE). Additive. Requires 027 applied first.
+-- EXECUTION: Supabase Dashboard SQL Editor (or scripts/lib/run-migration.ts).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION drain_anonymous_plans(payload jsonb)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  uid uuid := auth.uid();
+  rec jsonb;
+  inserted integer := 0;
+BEGIN
+  IF uid IS NULL THEN
+    RAISE EXCEPTION 'drain_anonymous_plans: not authenticated';
+  END IF;
+
+  -- Plans (unchanged from 025/026).
+  FOR rec IN
+    SELECT value FROM jsonb_array_elements(COALESCE(payload->'plans', '[]'::jsonb))
+  LOOP
+    CONTINUE WHEN COALESCE(rec->>'dedupKey', '') = '';
+
+    INSERT INTO saved_plans
+      (user_id, state, name, target_courses, plan_data, kind, client_dedup_key)
+    VALUES (
+      uid,
+      rec->>'state',
+      COALESCE(NULLIF(rec->>'name', ''), 'My Plan'),
+      COALESCE(
+        (SELECT array_agg(value) FROM jsonb_array_elements_text(rec->'targetCourses')),
+        '{}'::text[]
+      ),
+      CASE WHEN rec->>'kind' = 'program'
+           THEN '{"groups": []}'::jsonb
+           ELSE '{"semesters": []}'::jsonb END,
+      COALESCE(NULLIF(rec->>'kind', ''), 'semester'),
+      rec->>'dedupKey'
+    )
+    ON CONFLICT (user_id, client_dedup_key) WHERE client_dedup_key IS NOT NULL
+    DO NOTHING;
+
+    IF FOUND THEN
+      inserted := inserted + 1;
+    END IF;
+  END LOOP;
+
+  -- Favorites (unchanged from 026). Idempotent via the saved_courses unique
+  -- index (user_id, state, course_prefix, course_number, college_code, crn);
+  -- college_code/crn default '' (NOT NULL after migration 024).
+  FOR rec IN
+    SELECT value FROM jsonb_array_elements(COALESCE(payload->'favorites', '[]'::jsonb))
+  LOOP
+    CONTINUE WHEN COALESCE(rec->>'coursePrefix', '') = ''
+               OR COALESCE(rec->>'courseNumber', '') = '';
+
+    INSERT INTO saved_courses
+      (user_id, state, course_prefix, course_number, course_title)
+    VALUES (
+      uid,
+      rec->>'state',
+      rec->>'coursePrefix',
+      rec->>'courseNumber',
+      COALESCE(rec->>'courseTitle', '')
+    )
+    ON CONFLICT (user_id, state, course_prefix, course_number, college_code, crn)
+    DO NOTHING;
+
+    IF FOUND THEN
+      inserted := inserted + 1;
+    END IF;
+  END LOOP;
+
+  -- Schedules (new in 028). A saved schedule is one CHOSEN GeneratedSchedule, so
+  -- we insert its sections/score/score_breakdown/form_data verbatim. Idempotent
+  -- via 027's partial unique index (user_id, client_dedup_key). form_data &
+  -- sections are NOT NULL → COALESCE form_data to '{}', skip empty-section rows.
+  FOR rec IN
+    SELECT value FROM jsonb_array_elements(COALESCE(payload->'schedules', '[]'::jsonb))
+  LOOP
+    CONTINUE WHEN COALESCE(rec->>'dedupKey', '') = '';
+    CONTINUE WHEN jsonb_array_length(COALESCE(rec->'sections', '[]'::jsonb)) = 0;
+
+    INSERT INTO saved_schedules
+      (user_id, state, name, form_data, sections, score, score_breakdown, client_dedup_key)
+    VALUES (
+      uid,
+      rec->>'state',
+      COALESCE(NULLIF(rec->>'name', ''), 'My Schedule'),
+      COALESCE(rec->'formData', '{}'::jsonb),
+      rec->'sections',
+      -- score column is INTEGER but real GeneratedSchedule scores are decimals
+      -- (e.g. 85.3); ::numeric::integer rounds, matching how PostgREST coerces
+      -- the JSON float in the authed insert path.
+      NULLIF(rec->>'score', '')::numeric::integer,
+      rec->'scoreBreakdown',
+      rec->>'dedupKey'
+    )
+    ON CONFLICT (user_id, client_dedup_key) WHERE client_dedup_key IS NOT NULL
+    DO NOTHING;
+
+    IF FOUND THEN
+      inserted := inserted + 1;
+    END IF;
+  END LOOP;
+
+  RETURN inserted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION drain_anonymous_plans(jsonb) FROM public;
+REVOKE ALL ON FUNCTION drain_anonymous_plans(jsonb) FROM anon;
+GRANT EXECUTE ON FUNCTION drain_anonymous_plans(jsonb) TO authenticated;


### PR DESCRIPTION
## What changes for someone using the site

If you build a class schedule in the Smart Schedule Builder **before** signing in and click **"Sign in to save"**, the exact schedule you picked — its sections, score, and the filters you used — is now kept and added to your account once you sign in. Previously that schedule was thrown away on the way to the login screen. This is the same "your work follows you in" behavior that plans and saved courses already have; schedules were the last save-type missing it.

As before, nothing is auto-merged: on a shared computer you get a confirmation ("Add 1 schedule to your account?") before anything lands, and you can Discard.

## How it works

A saved schedule is different from a plan or a favorite: it's **one specific schedule you chose** out of many ranked options, so there's nothing to recompute from inputs — we have to keep the actual chosen sections. So the logged-out draft (kept in tab-scoped `sessionStorage`, which survives the OAuth redirect) carries the full sections array + score + score breakdown + form filters, and the server drains them verbatim.

- **`lib/anon-draft.ts`** — new `AnonScheduleDraft` + `schedules[]` on the draft; `scheduleDedupKey(state, sections)` = state + sorted `college_code:crn` (re-saving the same schedule is idempotent and order-independent); `stashScheduleDraft`; the existing plan/favorite stashers now preserve `schedules` too; `parseAndValidateDraft` defaults a missing `schedules` array so older drafts stay valid.
- **`components/schedule/ScheduleResults.tsx`** — when logged out, stash the chosen schedule before opening the login modal (the name computation is hoisted so the stash and the authed insert share it).
- **`components/auth/DraftDrainPrompt.tsx`** — the shared-computer confirm now counts/summarizes schedules.
- **`AuthProvider`** is unchanged — it already sends the whole draft to the drain RPC, so schedules flow through automatically.

## Migrations (already applied to prod, Project CC)

| # | Name | What |
|---|---|---|
| 027 | `saved_schedules_dedup` | adds `client_dedup_key TEXT` + partial unique index `(user_id, client_dedup_key)` — mirrors 024's saved_plans pattern; existing rows stay unconstrained |
| 028 | `drain_anonymous_schedules` | `CREATE OR REPLACE drain_anonymous_plans` (same name/signature) to also drain `payload->'schedules'` into `saved_schedules` |

Same-name `CREATE OR REPLACE` means the live client keeps working; older clients that don't send a `schedules` key COALESCE to `[]` (no-op), so the migration is safe to apply before this code merges.

**Gotcha caught in verification:** `saved_schedules.score` is `INTEGER`, but real `GeneratedSchedule` scores are decimals (e.g. `85.3`). The first cut cast `::integer` and threw `invalid input syntax for type integer: "85.3"`; fixed to `::numeric::integer` (rounds 85.3→85), matching how the authed insert's JSON float gets coerced by PostgREST. (Caught by the Playwright test, which exercised real data; the initial SQL smoke test had used an integer score and missed it.)

## Security

`drain_anonymous_plans` keeps its posture: `SECURITY DEFINER` + pinned `search_path`, writes only `auth.uid()` rows, `EXECUTE` for `authenticated` only (anon revoked; self-guards on `auth.uid() IS NULL`). Verified in prod after the re-apply: `authenticated`=true, `anon`=false.

## Test plan

- **Unit — 19/19 pass** (`lib/__tests__/anon-draft.test.ts`): `scheduleDedupKey` stability + order-independence; `upsertSchedule` replace-by-key; `parseAndValidateDraft` accepts schedules-only, rejects all-empty, defaults a missing `schedules` array (back-compat with older plans-only / plans+favorites drafts); `stashScheduleDraft` preserves existing plans+favorites and de-dupes on re-save.
- **Server (prod, transaction rolled back via RAISE):** drained a schedule through the real RPC — first call inserts 1, second is a no-op (idempotent via the partial unique index), decimal score `85.3` stored as `85`; nothing persisted (0 leftover rows confirmed).
- **Playwright (worktree dev server):** logged out, built a VA schedule (`/va/schedule?subjects=ENG`), clicked "Sign in to save"; asserted `sessionStorage['ccp:anon-draft'].schedules[0]` has a `va::`-prefixed dedupKey + non-empty sections, that plans/favorites stayed present-but-empty, and that the login modal opened.
- `npm run build` green; `npm run check:migration-drift` green (027/028 are `ALTER` + `CREATE OR REPLACE`, no new table); typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
