### PR TITLE
chore: clear 22 eslint errors so the test CI gate passes again

### DIFF
--- a/app/account/AccountDashboard.tsx
+++ b/app/account/AccountDashboard.tsx
@@ -507,6 +507,7 @@ export default function AccountDashboard({
           plans, schedules, bookmarks, transfer tracking, seat alerts, and email
           subscriptions — as a JSON file.
         </p>
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- API route file download (JSON attachment), not page navigation; <Link> would client-navigate and break the download */}
         <a
           href="/api/account/export"
           className="inline-flex items-center gap-2 rounded-lg border border-gray-300 dark:border-slate-600 px-4 py-2 text-sm font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition"

--- a/scripts/fl/scrape-smartcatalogiq-programs.ts
+++ b/scripts/fl/scrape-smartcatalogiq-programs.ts
@@ -126,9 +126,9 @@ async function main() {
       let data;
       if (det && det.programsPaths.length > 0) {
         // Walk every populated program section and merge (dedup by url/title).
-        const merged: any[] = [];
+        const merged: Awaited<ReturnType<typeof scrapeSmartCatalogIqPrograms>>["programs"] = [];
         const seen = new Set<string>();
-        let meta: any = null;
+        let meta: Awaited<ReturnType<typeof scrapeSmartCatalogIqPrograms>> | null = null;
         for (const programsPath of det.programsPaths) {
           const part = await scrapeSmartCatalogIqPrograms({
             collegeSlug: c.slug,

--- a/scripts/il/scrape-smartcatalogiq-programs.ts
+++ b/scripts/il/scrape-smartcatalogiq-programs.ts
@@ -126,9 +126,9 @@ async function main() {
       let data;
       if (det && det.programsPaths.length > 0) {
         // Walk every populated program section and merge (dedup by url/title).
-        const merged: any[] = [];
+        const merged: Awaited<ReturnType<typeof scrapeSmartCatalogIqPrograms>>["programs"] = [];
         const seen = new Set<string>();
-        let meta: any = null;
+        let meta: Awaited<ReturnType<typeof scrapeSmartCatalogIqPrograms>> | null = null;
         for (const programsPath of det.programsPaths) {
           const part = await scrapeSmartCatalogIqPrograms({
             collegeSlug: c.slug,

--- a/scripts/ks/scrape-hutchinson.ts
+++ b/scripts/ks/scrape-hutchinson.ts
@@ -27,6 +27,7 @@
  *   npx tsx scripts/ks/scrape-hutchinson.ts --term 261S
  */
 import * as cheerio from "cheerio";
+import type { AnyNode } from "domhandler";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -128,7 +129,7 @@ async function discoverPageCount(termCode: string): Promise<number> {
   return pages.length > 0 ? Math.max(...pages) : 1;
 }
 
-function parseCourseAccordion($el: cheerio.Cheerio<any>, $: cheerio.CheerioAPI, stdTerm: string): CourseSection[] {
+function parseCourseAccordion($el: cheerio.Cheerio<AnyNode>, $: cheerio.CheerioAPI, stdTerm: string): CourseSection[] {
   const titleRaw = $el.find("a.accordian-program-title").first().text().trim();
   // e.g. "Basic Concepts for Allied Health Studies - BI100"
   const titleMatch = titleRaw.match(/^(.*?)\s+-\s+([A-Z]{2,4})(\d{3}[A-Z]?)$/);

--- a/scripts/mi/scrape-smartcatalogiq-programs.ts
+++ b/scripts/mi/scrape-smartcatalogiq-programs.ts
@@ -126,9 +126,9 @@ async function main() {
       let data;
       if (det && det.programsPaths.length > 0) {
         // Walk every populated program section and merge (dedup by url/title).
-        const merged: any[] = [];
+        const merged: Awaited<ReturnType<typeof scrapeSmartCatalogIqPrograms>>["programs"] = [];
         const seen = new Set<string>();
-        let meta: any = null;
+        let meta: Awaited<ReturnType<typeof scrapeSmartCatalogIqPrograms>> | null = null;
         for (const programsPath of det.programsPaths) {
           const part = await scrapeSmartCatalogIqPrograms({
             collegeSlug: c.slug,

--- a/scripts/nc/scrape-smartcatalogiq-programs.ts
+++ b/scripts/nc/scrape-smartcatalogiq-programs.ts
@@ -126,9 +126,9 @@ async function main() {
       let data;
       if (det && det.programsPaths.length > 0) {
         // Walk every populated program section and merge (dedup by url/title).
-        const merged: any[] = [];
+        const merged: Awaited<ReturnType<typeof scrapeSmartCatalogIqPrograms>>["programs"] = [];
         const seen = new Set<string>();
-        let meta: any = null;
+        let meta: Awaited<ReturnType<typeof scrapeSmartCatalogIqPrograms>> | null = null;
         for (const programsPath of det.programsPaths) {
           const part = await scrapeSmartCatalogIqPrograms({
             collegeSlug: c.slug,

--- a/scripts/tx/scrape-smartcatalogiq-programs.ts
+++ b/scripts/tx/scrape-smartcatalogiq-programs.ts
@@ -126,9 +126,9 @@ async function main() {
       let data;
       if (det && det.programsPaths.length > 0) {
         // Walk every populated program section and merge (dedup by url/title).
-        const merged: any[] = [];
+        const merged: Awaited<ReturnType<typeof scrapeSmartCatalogIqPrograms>>["programs"] = [];
         const seen = new Set<string>();
-        let meta: any = null;
+        let meta: Awaited<ReturnType<typeof scrapeSmartCatalogIqPrograms>> | null = null;
         for (const programsPath of det.programsPaths) {
           const part = await scrapeSmartCatalogIqPrograms({
             collegeSlug: c.slug,


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — this is a CI hygiene fix. The `test` GitHub check has been failing on `main` for several PRs because `npm run lint` reported 22 errors, so the lint gate was effectively ignored and wouldn't catch *new* lint regressions (every recent PR, including the drain series #1176/#1177/#1179, showed `test` = fail / `check` = pass and was merged through it). This clears all 22 errors so the gate goes green and starts doing its job again.

## What changed

22 errors in two clusters. The ~287 `no-unused-vars`-style **warnings** are intentionally left alone — they don't fail CI, and rewriting 281 of them would be unrelated churn.

| Rule | Where | Fix |
|---|---|---|
| `@next/next/no-html-link-for-pages` (11, all one line) | `AccountDashboard.tsx:510` — the "Download my data" `<a href="/api/account/export">` | Kept the `<a>` + a scoped `eslint-disable` with a reason comment. It's a file download from an API route, **not** page navigation — `<Link>` would client-navigate and break the download. |
| `@typescript-eslint/no-explicit-any` (11) | `merged`/`meta` in the 5 `scrape-smartcatalogiq-programs.ts` copies (fl/il/mi/nc/tx) + `Cheerio<any>` in `ks/scrape-hutchinson.ts` | Typed `merged`/`meta` off the scraper's own return type (`Awaited<ReturnType<typeof scrapeSmartCatalogIqPrograms>>`, so they track the source of truth); changed `Cheerio<any>` → `Cheerio<AnyNode>` (imported from `domhandler`), matching the 4 existing uses in the repo. |

No runtime logic changed — pure type annotations plus one lint-disable comment.

## Test plan

- `npm run lint` → **0 errors** (287 warnings remain, unchanged — they don't block CI).
- `tsc --noEmit` clean; `npx vitest run` → 762 passed / 12 skipped; `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
