### PR TITLE
fix(config): enable transfer routes for 8 states with in-state data

### DIFF
--- a/lib/states/ak/config.ts
+++ b/lib/states/ak/config.ts
@@ -26,7 +26,7 @@ const akConfig: StateConfig = {
       "Ilisagvik College's North Slope Borough Elder Tuition Waiver covers tuition for NSB residents aged 62 or older. Students remain responsible for course fees, registration fees, textbooks, and lab kits. The waiver form must be completed and submitted before each semester's withdrawal deadline; contact Financial Aid at 907-852-1708 or fin.aid@ilisagvik.edu. Alaska has no statewide CC senior-tuition statute — the University of Alaska 60+ reduction under AS 14.40.130 applies to UA campuses, not to Ilisagvik.",
   },
 
-  transferSupported: false,
+  transferSupported: true,
   popularCourses: ["ENGL 101", "MATH 105", "BIOL 100", "PSY 101", "HIST 131"],
   defaultZip: "99723",
   defaultZipCity: "Utqiagvik",

--- a/lib/states/id/config.ts
+++ b/lib/states/id/config.ts
@@ -32,7 +32,7 @@ const idConfig: StateConfig = {
       "Under Idaho Code § 33-2110A, Idaho residents aged 60 and older may register to audit courses at state-supported institutions for $5 per credit hour on a space-available basis. Auditing means no credit or grade. Individual colleges (CSI, CWI, NIC, CEI) may offer their own additional senior discounts on for-credit courses; contact the registrar for specifics. Course and lab fees may still apply.",
   },
 
-  transferSupported: false,
+  transferSupported: true,
   popularCourses: ["ENGL 101", "ENGL 102", "MATH 143", "MATH 123", "PSYC 101", "COMM 101"],
   defaultZip: "83702",
   defaultZipCity: "Boise",

--- a/lib/states/in/config.ts
+++ b/lib/states/in/config.ts
@@ -26,7 +26,7 @@ const inConfig: StateConfig = {
 
   // Indiana's statewide Core Transfer Library / TransferIN equivalencies are
   // not yet ingested — see scrapers.transfers note below.
-  transferSupported: false,
+  transferSupported: true,
   popularCourses: ["ENGL 111", "MATH 123", "PSYC 101", "COMM 101", "APHY 101"],
   defaultZip: "46204",
   defaultZipCity: "Indianapolis",

--- a/lib/states/ks/config.ts
+++ b/lib/states/ks/config.ts
@@ -25,7 +25,7 @@ const ksConfig: StateConfig = {
       "Kansas has no statewide senior-tuition statute for community and technical colleges. K.S.A. 76-731a covers state universities under the Board of Regents but does not extend to the 24-college community/technical system. Each college sets its own policy — commonly a reduced or waived senior rate for residents 60 or 65+ on a space-available basis, sometimes excluding lab fees and non-credit classes. Contact your college's registrar for the specific rate and eligibility.",
   },
 
-  transferSupported: false,
+  transferSupported: true,
   // Top 8 by section count across all wired KS colleges. Different colleges use
   // different prefixes (EG/EN/ENG for English Composition); list reflects the
   // raw rank in scraped data.

--- a/lib/states/ne/config.ts
+++ b/lib/states/ne/config.ts
@@ -23,7 +23,7 @@ const neConfig: StateConfig = {
       "Nebraska has no statewide senior-tuition statute; each community college sets its own policy. A common pattern is a reduced (often ~50%) senior tuition rate for residents aged 62 and older on credit courses, sometimes excluding non-credit classes and third-party-paid tuition (e.g. Metropolitan Community College, Mid-Plains Community College). Contact your college's registrar or business office for the specific rate and eligibility.",
   },
 
-  transferSupported: false,
+  transferSupported: true,
   // Top 8 by section count across all 7 scraped NE colleges (9,636 sections).
   // Computed once from data/ne/courses; refresh periodically as new colleges
   // come online. ACFS 1015 = Adult Coping & Family Skills (workforce);

--- a/lib/states/ok/config.ts
+++ b/lib/states/ok/config.ts
@@ -44,7 +44,7 @@ const okConfig: StateConfig = {
       "OSRHE policy 35-5-1(g) lets Oklahoma residents 65+ enroll in undergraduate credit courses tuition-free at state colleges on a space-available basis. Confirm specifics with each college's registrar.",
   },
 
-  transferSupported: false,
+  transferSupported: true,
   popularCourses: ["ENGL 1113", "ENGL 1213", "MATH 1513", "HIST 1493", "PSYC 1113", "COMM 1113"],
   defaultZip: "73102",
   defaultZipCity: "Oklahoma City",

--- a/lib/states/wi/config.ts
+++ b/lib/states/wi/config.ts
@@ -21,7 +21,7 @@ const wiConfig: StateConfig = {
       "Under Wis. Stat. § 38.24(4m), Wisconsin technical college district boards must let residents aged 60 and older audit a course without paying the auditor's fee, on a space-available basis and with instructor approval. Separately, § 38.24(1m)(b) exempts residents 62 and older from program fees in vocational-adult programs. Auditing means no credit or grade, and material or special-course fees may still apply. Contact your technical college's registrar about enrollment timing.",
   },
 
-  transferSupported: false,
+  transferSupported: true,
   // Top course codes by section count across the scraped WTCS colleges.
   // WTCS uses the statewide "DDD-DDD" course-number scheme (e.g. 801-136 =
   // English Composition I); computed from data/wi/courses.

--- a/lib/states/wy/config.ts
+++ b/lib/states/wy/config.ts
@@ -23,7 +23,7 @@ const wyConfig: StateConfig = {
       "Wyoming has no statewide senior-tuition statute; each community college sets its own policy, usually for residents aged 60 and older. Examples range from a full tuition waiver on a limited number of credits (Northwest College's Golden Age program) to a reduced per-credit rate or percentage discount (Laramie County Community College, Western Wyoming Community College). Course and mandatory fees often still apply, and seats are typically space-available. Contact your college's registrar for the specific terms.",
   },
 
-  transferSupported: false,
+  transferSupported: true,
   popularCourses: ["ENGL 1010", "MATH 1000", "BIOL 1010", "PSYC 1000", "HIST 1110"],
   defaultZip: "82001",
   defaultZipCity: "Cheyenne",


### PR DESCRIPTION
## What changes for someone using the site

Students in **8 states can now use the Transfer Course Finder** for their state — it was silently hidden. These states had in-state transfer-equivalency data scraped back on June 1-3, but a config flag (`transferSupported`) was left off, so `/{state}/transfer` was hidden from navigation and the page unreachable. This flips it on for all eight, exposing pages that already had data behind them:

| State | Transfer mappings now visible |
|---|---|
| Oklahoma | 50,297 |
| Wyoming | 15,401 |
| Wisconsin | 7,562 |
| Kansas | 4,010 |
| Idaho | 3,853 |
| Nebraska | 1,996 |
| Indiana | 311 |
| Alaska | 148 |

## How this surfaced

The lint cleanup ([#1180](https://github.com/rohan-c0de/cc-coursemap/pull/1180)) touched `scripts/`, which re-triggered the `scraper-coverage` CI job (it only runs on PRs touching `lib/states/**` / `scripts/**` / `data/**/transfer-equiv.json`). Its `check:config-data` guard — built for exactly this — flagged 8 states whose `transferSupported: false` contradicted the presence of transfer data. The data-scrape PRs that added these (#989/#992/#994/#997 + scheduled scrapes) added the data but never flipped the flag, and were merged through the red check.

## Verification (before enabling each)

- **In-state only** (the hard rule): confirmed every state's transfer destinations are in-state — e.g. WY → University of Wyoming + WY community colleges; OK → 37 Oklahoma institutions; KS → Wichita State; NE → Nebraska-Lincoln; AK → UA Anchorage; IN → USI. No cross-state mappings.
- **Routes render**: loaded all 8 `/{state}/transfer` pages on a local dev server — every one returns HTTP 200 with the real "Transfer Course Finder" UI, no errors. Oklahoma (the 50k-row outlier) renders in **76 ms warm** — it's a search UI, not a full-data render, so no perf concern.
- `npm run check:config-data` → **passes (51/51 states)**; `tsc` + `npm run build` green.

## Not touched: `wa`

`check:config-data` also emits a non-blocking **warning** that `wa` declares prereq coverage with no backing data. That is **intentional and documented** in `lib/states/wa/config.ts` — `aggregate-from-courses` is kept on purpose ("so the CI check passes and the aggregation runs"; ctcLink exposes no prereq text and the SBCTC catalogs are WAF-blocked). Changing it would contradict that decision, so it's left as-is. Warnings don't fail the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
