### PR TITLE
feat: advertise free accounts to logged-out visitors (Milestone B)

### DIFF
--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import SearchForm from "@/components/SearchForm";
 import StartingSoonCallout from "@/components/StartingSoonCallout";
 import NotifyBanner from "@/components/NotifyBanner";
+import AccountPromo from "@/components/auth/AccountPromo";
 import StateContext from "@/components/StateContext";
 import { getCurrentTerm, getNextTerm } from "@/lib/terms";
 import { getAllStates, hasPrereqsCoverage, isValidState } from "@/lib/states/registry";
@@ -278,6 +279,9 @@ export default async function HomePage({ params }: Props) {
 
           {/* Notify banner */}
           <NotifyBanner nextTerm={nextTerm.label} state={state} />
+
+          {/* Logged-out growth CTA — browsing stays free; promotes saving only */}
+          <AccountPromo className="mt-4" />
         </div>
       </section>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import ThemeToggle from "@/components/ThemeToggle";
 import UserMenu from "@/components/auth/UserMenu";
 import CourseSearchHero from "@/components/CourseSearchHero";
 import USMap from "@/components/USMap";
+import AccountPromo from "@/components/auth/AccountPromo";
 
 const STATE_NAMES = getAllStates().map((s) => s.name);
 const STATE_LIST_SENTENCE =
@@ -362,6 +363,9 @@ export default async function LandingPage() {
           </div>
         </div>
       </section>
+
+      {/* Logged-out growth CTA — browsing stays free; promotes saving only */}
+      <AccountPromo className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12" />
 
     </div>
   );

--- a/components/auth/AccountPromo.tsx
+++ b/components/auth/AccountPromo.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/lib/hooks/useAuth";
+import { PROMO_DISMISS_KEY, shouldShowAccountPromo } from "@/lib/account-promo";
+
+/**
+ * Logged-out-only growth CTA: advertises that a free account SAVES a visitor's
+ * work (plans / schedules / courses) and unlocks seat alerts. Browsing stays
+ * free and un-gated — this never walls reads; it only promotes saving (the
+ * anon→account drain already carries logged-out work into the new account on
+ * sign-in). Dismiss is tab-scoped (sessionStorage, like the anon-draft) so it
+ * doesn't nag across navigation. Reads ONLY the useAuth context — never imports
+ * Supabase — so the AuthProvider logged-out SEO fast-path is preserved.
+ *
+ * `className` styles the OUTER wrapper (spacing/width per placement); when the
+ * promo is hidden the component renders null, so no empty padded gap is left.
+ */
+export default function AccountPromo({ className = "" }: { className?: string }) {
+  const { user, isLoading, openLoginModal } = useAuth();
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    try {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time client read of the tab-scoped dismiss flag on mount (sessionStorage is client-only)
+      if (sessionStorage.getItem(PROMO_DISMISS_KEY) === "1") setDismissed(true);
+    } catch {
+      // sessionStorage unavailable — just show the promo.
+    }
+  }, []);
+
+  if (!shouldShowAccountPromo({ isLoading, user, dismissed })) return null;
+
+  const dismiss = () => {
+    try {
+      sessionStorage.setItem(PROMO_DISMISS_KEY, "1");
+    } catch {
+      // ignore
+    }
+    setDismissed(true);
+  };
+
+  return (
+    <div className={className}>
+      <div className="rounded-xl border border-teal-200 dark:border-teal-800 bg-teal-50 dark:bg-teal-900/20 px-4 py-4 sm:flex sm:items-center sm:justify-between sm:gap-4">
+        <div>
+          <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">
+            Save your work with a free account
+          </p>
+          <p className="mt-1 text-xs text-gray-600 dark:text-slate-400">
+            Free to search and plan — no account needed. Create one to save your
+            plans, schedules, and courses, and get notified when a seat opens.
+          </p>
+        </div>
+        <div className="mt-3 sm:mt-0 flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={openLoginModal}
+            className="rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-700 transition whitespace-nowrap"
+          >
+            Create a free account
+          </button>
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label="Dismiss account suggestion"
+            className="rounded-md p-1.5 text-teal-700/70 hover:text-teal-900 dark:text-teal-300/70 dark:hover:text-teal-100 hover:bg-teal-100 dark:hover:bg-teal-800/40 transition"
+          >
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/__tests__/account-promo.test.ts
+++ b/lib/__tests__/account-promo.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { shouldShowAccountPromo, PROMO_DISMISS_KEY } from "@/lib/account-promo";
+
+describe("shouldShowAccountPromo", () => {
+  it("shows for a logged-out, resolved, not-dismissed visitor", () => {
+    expect(shouldShowAccountPromo({ isLoading: false, user: null, dismissed: false })).toBe(true);
+  });
+
+  it("stays hidden while auth is still loading (no flash for a resolving session)", () => {
+    expect(shouldShowAccountPromo({ isLoading: true, user: null, dismissed: false })).toBe(false);
+  });
+
+  it("stays hidden for a signed-in user", () => {
+    expect(shouldShowAccountPromo({ isLoading: false, user: { id: "u1" }, dismissed: false })).toBe(false);
+    // even if loading already flipped and not dismissed
+    expect(shouldShowAccountPromo({ isLoading: false, user: { id: "u1" }, dismissed: true })).toBe(false);
+  });
+
+  it("stays hidden once dismissed", () => {
+    expect(shouldShowAccountPromo({ isLoading: false, user: null, dismissed: true })).toBe(false);
+  });
+
+  it("exposes the tab-scoped dismiss key", () => {
+    expect(PROMO_DISMISS_KEY).toBe("ccp:promo-dismissed");
+  });
+});

--- a/lib/account-promo.ts
+++ b/lib/account-promo.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure helpers for the logged-out AccountPromo CTA. Split out from the
+ * "use client" component so the render guard is unit-testable without a DOM
+ * (the vitest env is "node").
+ */
+
+export const PROMO_DISMISS_KEY = "ccp:promo-dismissed";
+
+/**
+ * The promo shows ONLY to a logged-out, not-yet-dismissed visitor whose auth
+ * state has resolved (isLoading false) — so it never flashes for a signed-in
+ * user while their session is still loading, and never walls anything.
+ */
+export function shouldShowAccountPromo(opts: {
+  isLoading: boolean;
+  user: unknown;
+  dismissed: boolean;
+}): boolean {
+  return !opts.isLoading && !opts.user && !opts.dismissed;
+}


### PR DESCRIPTION
## What changes for someone using the site

Logged-out visitors now see a small, dismissible card on the **homepage** (bottom, under "Why this exists") and on each **state page** (under the "schedules not posted yet" banner) that explains: *"Save your work with a free account — free to search and plan, no account needed; create one to save your plans, schedules, and courses, and get notified when a seat opens."* The card's button opens the existing sign-in dialog; an **×** dismisses it for the rest of the tab session.

Browsing, searching, planning, and viewing all stay **100% free and un-gated** — this only *advertises* what an account adds (saving + seat alerts), per the gating decision (login-required-to-**save** + accounts-to-grow-an-engaged-user-base). Signed-in users never see it.

## How it works

- **`components/auth/AccountPromo.tsx`** — a client component that renders **only** for a logged-out, not-yet-dismissed visitor *whose auth has already resolved* (`isLoading` false), so it never flashes for a signed-in user mid-load. "Create a free account" calls the existing `useAuth().openLoginModal()` (no new auth surface). The **×** sets `sessionStorage['ccp:promo-dismissed']` (tab-scoped, like the anon-draft) so it doesn't nag across navigation. It reads **only** the `useAuth` context — **zero Supabase imports** — so the AuthProvider logged-out SEO fast-path is preserved by construction.
- **`lib/account-promo.ts`** — the pure `shouldShowAccountPromo()` render guard, split out so it's unit-testable in the node test env (no DOM), plus the dismiss key.
- **Placement** — `<AccountPromo/>` on `app/page.tsx` and `app/[state]/page.tsx`. A `className` prop styles the outer wrapper per page; when the promo is hidden it renders `null`, so there's **no empty padded gap** for signed-in users.

The copy deliberately reinforces the homepage's existing "Free, no signup" framing rather than contradicting it.

## Test plan

- **Unit (5 pass)** — `shouldShowAccountPromo`: shows only when logged-out + resolved + not-dismissed; hidden while `isLoading` (no flash), hidden when a `user` is present, hidden once dismissed.
- **Playwright (worktree dev server)** — logged-out: promo visible on `/` and `/va`; "Create a free account" opens the login dialog (`dialog[open]` + magic-link form); **×** hides it; navigating `/va → /` keeps it hidden (sessionStorage persists); a fresh tab shows it again. Captured light + dark screenshots — tasteful, on-brand, responsive.
- **SEO fast-path** — `AccountPromo` imports only the `useAuth` context (no Supabase), so a logged-out load pulls no new auth chunk. (The one `lib/supabase/client` chunk seen in dev is AuthProvider's pre-existing dynamic `import()` prefetched by Next dev — unrelated to this change.)
- `npm run lint` = 0 errors, `tsc` clean, `npm run build` green.

## Not included

The inline "notify me when a seat opens" CTA on full sections is a **separate** follow-up (different subsystem — the seat-notification setup flow) and is intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
