### PR TITLE
feat: "get seat-open alerts" CTA on full-section course pages (Milestone B)

### DIFF
--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -23,6 +23,8 @@ import {
 } from "@/lib/data-freshness";
 import SectionSeats from "@/components/SectionSeats";
 import { aggregateSeats, aggregateLabel } from "@/lib/seats";
+import { courseHasFullSection } from "@/lib/seat-alert";
+import SeatAlertCTA from "@/components/SeatAlertCTA";
 import { buildCollegeCompareRows } from "@/lib/compare-colleges";
 import CourseCollegeCompare from "@/components/CourseCollegeCompare";
 
@@ -518,6 +520,12 @@ export default async function CoursePage(props: PageProps) {
             )}
           </div>
         </div>
+
+        {/* Seat-open alert CTA — only when the course has full sections.
+            Bridges to the existing plan-based seat-watch via the planner. */}
+        {courseHasFullSection(sections) && (
+          <SeatAlertCTA state={state} courseCode={`${prefix} ${number}`} />
+        )}
 
         {/* Mode breakdown + prereqs */}
         <div className="flex flex-wrap gap-4 mb-8">

--- a/components/SeatAlertCTA.tsx
+++ b/components/SeatAlertCTA.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+/**
+ * Inline "get notified when a seat opens" CTA, shown on a course-detail page
+ * when the course has full sections (see lib/seat-alert courseHasFullSection).
+ *
+ * Server-safe — a plain Link, no client hooks. It routes the course into the
+ * planner via ?targets=, where the existing "Sign in to save" flow (anon→account
+ * drain #1176, works logged-out) saves it; the plan-based seat-watch cron then
+ * emails the user when a section of that course flips full→open
+ * (profiles.seat_notifications_enabled defaults on). No per-section subscription
+ * and no new backend — this is a bridge to the existing plan-based watcher.
+ */
+export default function SeatAlertCTA({
+  state,
+  courseCode,
+}: {
+  state: string;
+  courseCode: string;
+}) {
+  const href = `/${state}/plan?targets=${encodeURIComponent(courseCode)}`;
+  return (
+    <div className="mb-8 rounded-xl border border-teal-200 dark:border-teal-800 bg-teal-50 dark:bg-teal-900/20 px-4 py-4 sm:flex sm:items-center sm:justify-between sm:gap-4">
+      <div>
+        <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">
+          Some sections are full
+        </p>
+        <p className="mt-1 text-xs text-gray-600 dark:text-slate-400">
+          {`Save ${courseCode} to a plan and we'll email you when a seat opens — free, no spam.`}
+        </p>
+      </div>
+      <Link
+        href={href}
+        className="mt-3 sm:mt-0 inline-flex shrink-0 items-center justify-center rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-700 transition whitespace-nowrap"
+      >
+        Get seat-open alerts
+      </Link>
+    </div>
+  );
+}

--- a/lib/__tests__/seat-alert.test.ts
+++ b/lib/__tests__/seat-alert.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { courseHasFullSection } from "@/lib/seat-alert";
+
+const sec = (seats_open: number | null, seats_total: number | null = null) => ({
+  seats_open,
+  seats_total,
+});
+
+describe("courseHasFullSection", () => {
+  it("is true when a section has 0 seats (full)", () => {
+    expect(courseHasFullSection([sec(5, 30), sec(0, 30)])).toBe(true);
+  });
+
+  it("is true when a section has a negative (waitlist) value", () => {
+    expect(courseHasFullSection([sec(-3, 30)])).toBe(true);
+  });
+
+  it("is false when every section is open or has seats (incl. low counts)", () => {
+    expect(courseHasFullSection([sec(5, 30), sec(12, 40), sec(2, 30)])).toBe(false);
+  });
+
+  it("is false for unknown seats (null is not 'full')", () => {
+    expect(courseHasFullSection([sec(null, null)])).toBe(false);
+  });
+
+  it("is false for sentinel values (>=1000 → unlimited/online, not full)", () => {
+    expect(courseHasFullSection([sec(9999, 9999)])).toBe(false);
+  });
+
+  it("is false for an empty section list", () => {
+    expect(courseHasFullSection([])).toBe(false);
+  });
+});

--- a/lib/seat-alert.ts
+++ b/lib/seat-alert.ts
@@ -1,0 +1,16 @@
+import { describeSeats } from "@/lib/seats";
+
+/**
+ * True iff at least one of a course's sections is full — 0 seats, or a negative
+ * (waitlist) value (see lib/seats describeSeats). Gates the SeatAlertCTA so the
+ * "get notified when a seat opens" nudge only appears when an alert is actually
+ * useful — never for a wide-open course, an unknown-seats state, or a sentinel
+ * ("unlimited"/online) value.
+ */
+export function courseHasFullSection(
+  sections: { seats_open: number | null; seats_total: number | null }[],
+): boolean {
+  return sections.some(
+    (s) => describeSeats(s.seats_open, s.seats_total).status === "full",
+  );
+}


### PR DESCRIPTION
## What changes for someone using the site

When a course's sections are full, its course page (e.g. `/va/course/BIO-101`) now shows a **"Get seat-open alerts"** card: *"Some sections are full. Save BIO 101 to a plan and we'll email you when a seat opens — free, no spam."* Clicking it drops the course into the planner (pre-filled). Save the plan with a free account and we email you when a seat frees up. Courses that aren't full show nothing.

This is the last Milestone-B item. It deliberately **reuses the existing plan-based seat-watch** — no new backend, no per-section subscription.

## How it works

Seat alerts are already **plan/course-based**: the cron (`lib/seat-watch-match.ts`) watches the courses in a user's saved plans (`target_courses`) and emails them when a section flips full→open, gated by `profiles.seat_notifications_enabled` (default on). The planner already accepts a `?targets=` pre-fill and its own copy says *"Save your plan and we'll email you when a seat opens."* So this CTA is purely a **bridge** to that flow:

- **`lib/seat-alert.ts`** — pure `courseHasFullSection(sections)` (via `lib/seats` `describeSeats`), so the CTA only appears when an alert is actually useful: it's `false` for open courses, low-but-available counts, unknown seats, and sentinel ("unlimited"/online) values. Unit-tested.
- **`components/SeatAlertCTA.tsx`** — server-safe (a plain `Link`, no client hooks) → `/{state}/plan?targets=<encoded course>`. The planner's existing "Sign in to save" flow (anon→account drain #1176) handles logged-out users, so this works whether or not you're signed in.
- **`app/[state]/course/[code]/page.tsx`** — renders the CTA after the course header when `courseHasFullSection(sections)`. **Course-level**, not per-section, because the watch is course-level.

**Scope:** course-detail page only. Adding the CTA to course *search results* is a separate, optional follow-up — intentionally not in this PR.

## Test plan

- **Unit (6):** `courseHasFullSection` — a 0-seat or negative (waitlist) section → `true`; all-open / low-count → `false`; unknown (null) → `false`; sentinel (≥1000) → `false`; empty list → `false`.
- **Playwright (worktree dev server):**
  - **Bridge destination** — `/va/plan?targets=ENG%20111` pre-fills ENG 111 as a planner target. ✓
  - **CTA renders + links correctly** on 5 real full-section VA courses (BIO 101, ENG 111, SDV 100, BIO 150, MTH 154), each `href=/va/plan?targets=<that course>`. ✓
  - **Conditional gate** — correctly **absent** on HIS 101 (no full sections this term), proving it's not always-on. ✓
  - Verified the rendered copy spacing (caught + fixed a JSX whitespace gotcha around the interpolated course code) and the teal card renders cleanly in light + dark.
- `npm run lint` = 0 errors, `tsc` clean, `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
