### PR TITLE
feat: transfer-progress tracker PR1 — target university + mark courses done (Milestone C)

### DIFF
--- a/app/plan/[id]/SavedPlanView.tsx
+++ b/app/plan/[id]/SavedPlanView.tsx
@@ -1,7 +1,15 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import SemesterPlanner from "@/components/SemesterPlanner";
+import { createClient } from "@/lib/supabase/client";
+import { toggleCompleted, completedCount } from "@/lib/transfer-tracker";
+
+interface University {
+  slug: string;
+  name: string;
+}
 
 interface SavedPlanViewProps {
   planId: string;
@@ -10,6 +18,12 @@ interface SavedPlanViewProps {
   name: string;
   targetCourses: string[];
   createdAt: string;
+  /** In-state universities the user can pick as their transfer goal. */
+  universities: University[];
+  /** The plan's current target-university slug, or null if unset. */
+  targetUniversity: string | null;
+  /** Course codes the user has marked completed on this plan. */
+  completedCourses: string[];
 }
 
 function formatDate(iso: string): string {
@@ -38,8 +52,41 @@ export default function SavedPlanView({
   name,
   targetCourses,
   createdAt,
+  universities,
+  targetUniversity,
+  completedCourses,
 }: SavedPlanViewProps) {
-  void planId;
+  const [targetUni, setTargetUni] = useState<string | null>(targetUniversity);
+  const [completed, setCompleted] = useState<string[]>(completedCourses);
+
+  // Persist the two tracker fields IN PLACE on this plan. The plan's structure
+  // (target_courses / plan_data) stays immutable — only target_university and
+  // completed_courses update. RLS ("Users manage own plans" FOR ALL, 017)
+  // scopes the UPDATE to the owner. Optimistic, revert on error.
+  async function persistTargetUniversity(slug: string | null) {
+    const prev = targetUni;
+    setTargetUni(slug);
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("saved_plans")
+      .update({ target_university: slug })
+      .eq("id", planId);
+    if (error) setTargetUni(prev);
+  }
+
+  async function persistCompleted(next: string[]) {
+    const prev = completed;
+    setCompleted(next);
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("saved_plans")
+      .update({ completed_courses: next })
+      .eq("id", planId);
+    if (error) setCompleted(prev);
+  }
+
+  const { done, total } = completedCount(targetCourses, completed);
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-slate-900">
       {/* Header */}
@@ -102,6 +149,75 @@ export default function SavedPlanView({
             </Link>
           </div>
         </div>
+
+        {/* Transfer goal & progress (Milestone C, PR 1 — capture only).
+            Pick a target university + check off completed courses; the progress
+            computation (how completed courses transfer to that university)
+            lands in PR 2. Writes update the two tracker columns in place. */}
+        <section className="mb-6 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
+          <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+            Transfer goal &amp; progress
+          </h2>
+
+          <label className="mt-3 block text-sm text-slate-600 dark:text-slate-400">
+            University you&apos;re aiming to transfer to
+            <select
+              value={targetUni ?? ""}
+              onChange={(e) => persistTargetUniversity(e.target.value || null)}
+              className="mt-1 block w-full rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm text-slate-900 dark:text-slate-100 focus:border-teal-500 focus:ring-1 focus:ring-teal-500 outline-none transition"
+            >
+              <option value="">Choose a university…</option>
+              {universities.map((u) => (
+                <option key={u.slug} value={u.slug}>
+                  {u.name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {targetCourses.length > 0 ? (
+            <div className="mt-4">
+              <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                {done} of {total} {total === 1 ? "course" : "courses"} completed
+              </p>
+              <ul className="mt-2 space-y-1.5">
+                {targetCourses.map((code) => {
+                  const isDone = completed.includes(code);
+                  return (
+                    <li key={code}>
+                      <label className="inline-flex items-center gap-2 text-sm cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={isDone}
+                          onChange={() => persistCompleted(toggleCompleted(completed, code))}
+                          className="h-4 w-4 rounded border-gray-300 dark:border-slate-600 text-teal-600 focus:ring-teal-500"
+                        />
+                        <span
+                          className={
+                            isDone
+                              ? "line-through text-slate-400 dark:text-slate-500"
+                              : "text-slate-700 dark:text-slate-300"
+                          }
+                        >
+                          {code}
+                        </span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ) : (
+            <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">
+              This plan has no target courses to track yet.
+            </p>
+          )}
+
+          <p className="mt-3 text-xs text-slate-400 dark:text-slate-500">
+            We&apos;ll use this to show how your completed courses transfer to your
+            chosen university — coming soon.
+          </p>
+        </section>
 
         <SemesterPlanner
           state={state}

--- a/app/plan/[id]/page.tsx
+++ b/app/plan/[id]/page.tsx
@@ -22,6 +22,7 @@
 import { notFound, redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getStateConfig } from "@/lib/states/registry";
+import { getUniversities } from "@/lib/transfer";
 import SavedPlanView from "./SavedPlanView";
 
 type Props = {
@@ -48,7 +49,7 @@ export default async function SavedPlanPage({ params }: Props) {
 
   const { data: plan } = await supabase
     .from("saved_plans")
-    .select("id, state, name, target_courses, created_at")
+    .select("id, state, name, target_courses, target_university, completed_courses, created_at")
     .eq("id", id)
     .single();
 
@@ -66,6 +67,11 @@ export default async function SavedPlanPage({ params }: Props) {
     notFound();
   }
 
+  // In-state universities the user can pick as their transfer goal (cached
+  // file fast-path; falls back to the transfers table). Empty when the state
+  // has no transfer data — the picker then simply offers no options.
+  const universities = await getUniversities(plan.state);
+
   return (
     <SavedPlanView
       planId={plan.id}
@@ -74,6 +80,9 @@ export default async function SavedPlanPage({ params }: Props) {
       name={plan.name}
       targetCourses={plan.target_courses ?? []}
       createdAt={plan.created_at}
+      universities={universities}
+      targetUniversity={plan.target_university ?? null}
+      completedCourses={plan.completed_courses ?? []}
     />
   );
 }

--- a/lib/__tests__/transfer-tracker.test.ts
+++ b/lib/__tests__/transfer-tracker.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { toggleCompleted, completedCount } from "@/lib/transfer-tracker";
+
+describe("toggleCompleted", () => {
+  it("adds a course when absent", () => {
+    expect(toggleCompleted(["ENG 111"], "MTH 154")).toEqual(["ENG 111", "MTH 154"]);
+  });
+
+  it("removes a course when present", () => {
+    expect(toggleCompleted(["ENG 111", "MTH 154"], "ENG 111")).toEqual(["MTH 154"]);
+  });
+
+  it("never produces a duplicate", () => {
+    const once = toggleCompleted(["ENG 111"], "MTH 154");
+    expect(once.filter((c) => c === "MTH 154")).toHaveLength(1);
+    // toggling the same code again removes it (not a second copy)
+    expect(toggleCompleted(once, "MTH 154")).toEqual(["ENG 111"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = ["ENG 111"];
+    toggleCompleted(input, "MTH 154");
+    expect(input).toEqual(["ENG 111"]);
+  });
+});
+
+describe("completedCount", () => {
+  it("counts only target courses that are completed", () => {
+    expect(completedCount(["ENG 111", "MTH 154", "BIO 101"], ["ENG 111", "BIO 101"])).toEqual({
+      done: 2,
+      total: 3,
+    });
+  });
+
+  it("ignores completed codes that aren't in the targets", () => {
+    expect(completedCount(["ENG 111"], ["ENG 111", "HIS 101"])).toEqual({ done: 1, total: 1 });
+  });
+
+  it("handles an empty plan", () => {
+    expect(completedCount([], [])).toEqual({ done: 0, total: 0 });
+  });
+});

--- a/lib/transfer-tracker.ts
+++ b/lib/transfer-tracker.ts
@@ -1,0 +1,26 @@
+/**
+ * Pure helpers for the transfer-progress tracker (Milestone C). A "transfer
+ * goal" = a saved plan + a target university + the courses the user has marked
+ * completed. Split from the UI so they're unit-testable without a DOM (the
+ * vitest env is "node").
+ */
+
+/**
+ * Toggle a course code in/out of the completed set: remove it if present, add
+ * it (deduped) if absent. Returns a new array.
+ */
+export function toggleCompleted(completed: string[], code: string): string[] {
+  if (completed.includes(code)) return completed.filter((c) => c !== code);
+  return Array.from(new Set([...completed, code]));
+}
+
+/** How many of the plan's target courses are marked completed (set-based, so
+ *  stray duplicates or extra completed codes never inflate the count). */
+export function completedCount(
+  targetCourses: string[],
+  completed: string[],
+): { done: number; total: number } {
+  const set = new Set(completed);
+  const done = targetCourses.filter((c) => set.has(c)).length;
+  return { done, total: targetCourses.length };
+}

--- a/supabase/migrations/029_saved_plans_tracker.sql
+++ b/supabase/migrations/029_saved_plans_tracker.sql
@@ -1,0 +1,26 @@
+-- ============================================================================
+-- 029: saved_plans transfer-progress tracker fields
+-- ============================================================================
+-- WHAT: Adds two nullable/defaulted columns to saved_plans:
+--       • target_university TEXT — the university slug the user is aiming to
+--         transfer to (matches transfers.university / the getUniversities slug).
+--       • completed_courses TEXT[] — the course codes the user has marked done.
+-- WHY:  Milestone C transfer-progress tracker, PR 1 (capture). PR 2 reads these
+--       to compute % complete + how the completed courses transfer to the
+--       target university (from the transfer-equiv data).
+-- MODEL: A "transfer goal" = a saved plan + target_university + completed_courses.
+--        The plan's STRUCTURE (target_courses, plan_data) stays immutable — the
+--        Save flow still INSERTs a new row; only these two TRACKER fields are
+--        updated in place on the existing plan.
+-- RLS:  No policy change. saved_plans "Users manage own plans" is FOR ALL (017),
+--       which already permits the owner to UPDATE these columns.
+-- CAVEATS: Additive + idempotent (IF NOT EXISTS). No backfill (existing plans
+--          get NULL target_university + empty completed_courses).
+-- EXECUTION: Supabase Dashboard SQL Editor (or MCP apply_migration).
+-- ============================================================================
+
+ALTER TABLE saved_plans
+  ADD COLUMN IF NOT EXISTS target_university TEXT;
+
+ALTER TABLE saved_plans
+  ADD COLUMN IF NOT EXISTS completed_courses TEXT[] NOT NULL DEFAULT '{}';


### PR DESCRIPTION
## What changes for someone using the site

On a saved plan page (`/plan/[id]`), signed-in users now get a **"Transfer goal & progress"** section: pick the **university you're aiming to transfer to** and **check off the courses you've already completed**. Both save to your account, and the page shows a live **"X of N courses completed"** count.

This is **PR 1 of 2** for the transfer-progress tracker (the prototype's "your path" dashboard, now unblocked by the auth buildout). PR 1 is the **data model + capture**. **PR 2** turns it into a real progress view — % toward your goal and how your completed courses transfer to that university (direct / elective / no-credit), from the transfer-equiv data.

## How it works

A **"transfer goal" = a saved plan + a target university + completed-course marks** — reusing the `saved_plans` abstraction from Milestone A/B rather than a new table. The plan's *structure* (`target_courses` / `plan_data`) stays immutable (Save still creates a new plan); only the two new **tracker** fields update in place.

- **migration 029** — `saved_plans` gains `target_university TEXT` (nullable) + `completed_courses TEXT[]` (NOT NULL default `{}`). **No RLS change**: the existing "Users manage own plans" policy is `FOR ALL` — the 017 migration explicitly left it open for a future edit-in-place PR, which is this one.
- **`lib/transfer-tracker.ts`** — pure `toggleCompleted()` + `completedCount()`, split out so they're unit-testable without a DOM.
- **`app/plan/[id]/page.tsx`** (server) — selects the new columns + loads in-state universities via `getUniversities(state)` and passes them down.
- **`SavedPlanView.tsx`** (client) — the picker + per-course "done" checkboxes; writes are optimistic client `UPDATE`s scoped to the owner by RLS (revert on error).

## Test plan

- **Unit (7):** `toggleCompleted` (add / remove / no-duplicate / no-mutate) and `completedCount` (counts only target courses; ignores stray completed codes; empty plan).
- **Migration + RLS (prod, rolled back):** applied 029 to Project CC and confirmed both columns. Then, as the `authenticated` role (so RLS is enforced, not bypassed), inserted a plan for a real user and `UPDATE`d both tracker fields — row reflected `target=university-of-virginia, completed={ENG 111}` — then `RAISE`d to roll back (0 rows persisted). Proves the owner-UPDATE path the UI uses.
- `npm run lint` = 0 errors, `tsc` clean, `npm run build` green.

## Known gap

The signed-in capture UI itself isn't exercised in an automated headless run (no real auth session — same limitation as the drain PRs #1176/#1177). It's a quick **manual post-merge check**: open a saved plan, pick a university, check a course, reload → both persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
