### PR TITLE
feat: transfer-progress tracker PR2 — show how completed courses transfer (Milestone C)

### DIFF
--- a/app/plan/[id]/SavedPlanView.tsx
+++ b/app/plan/[id]/SavedPlanView.tsx
@@ -1,15 +1,44 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import SemesterPlanner from "@/components/SemesterPlanner";
 import { createClient } from "@/lib/supabase/client";
-import { toggleCompleted, completedCount } from "@/lib/transfer-tracker";
+import {
+  toggleCompleted,
+  completedCount,
+  progressSummary,
+  type TransferVerdict,
+} from "@/lib/transfer-tracker";
 
 interface University {
   slug: string;
   name: string;
 }
+
+// Transfer verdict badge styles. Deliberately indigo / violet / rose / gray +
+// ✓ ≈ ✕ icons — NOT the seat green/amber/red palette — so a transfer outcome is
+// never confusable with a seat-availability signal. Icons carry the meaning so
+// it's not color-only.
+const VERDICT_STYLE: Record<TransferVerdict, { label: string; cls: string }> = {
+  direct: {
+    label: "✓ Transfers",
+    cls: "bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300",
+  },
+  elective: {
+    label: "≈ Elective",
+    cls: "bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300",
+  },
+  "no-credit": {
+    label: "✕ No credit",
+    cls: "bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300",
+  },
+  none: {
+    label: "— No data",
+    cls: "bg-gray-100 dark:bg-slate-700 text-gray-500 dark:text-slate-400",
+  },
+};
 
 interface SavedPlanViewProps {
   planId: string;
@@ -24,6 +53,9 @@ interface SavedPlanViewProps {
   targetUniversity: string | null;
   /** Course codes the user has marked completed on this plan. */
   completedCourses: string[];
+  /** Per-target-course transfer verdict to the current target university
+   *  (server-computed). Empty {} when no target university is set. */
+  verdicts: Record<string, TransferVerdict>;
 }
 
 function formatDate(iso: string): string {
@@ -55,7 +87,9 @@ export default function SavedPlanView({
   universities,
   targetUniversity,
   completedCourses,
+  verdicts,
 }: SavedPlanViewProps) {
+  const router = useRouter();
   const [targetUni, setTargetUni] = useState<string | null>(targetUniversity);
   const [completed, setCompleted] = useState<string[]>(completedCourses);
 
@@ -71,7 +105,13 @@ export default function SavedPlanView({
       .from("saved_plans")
       .update({ target_university: slug })
       .eq("id", planId);
-    if (error) setTargetUni(prev);
+    if (error) {
+      setTargetUni(prev);
+    } else {
+      // Re-run the server component so per-course verdicts recompute for the
+      // newly chosen university (the `verdicts` prop is server-derived).
+      router.refresh();
+    }
   }
 
   async function persistCompleted(next: string[]) {
@@ -86,6 +126,8 @@ export default function SavedPlanView({
   }
 
   const { done, total } = completedCount(targetCourses, completed);
+  const summary = progressSummary(completed, verdicts);
+  const hasGoal = targetUni != null && targetUni !== "";
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-slate-900">
@@ -150,10 +192,11 @@ export default function SavedPlanView({
           </div>
         </div>
 
-        {/* Transfer goal & progress (Milestone C, PR 1 — capture only).
-            Pick a target university + check off completed courses; the progress
-            computation (how completed courses transfer to that university)
-            lands in PR 2. Writes update the two tracker columns in place. */}
+        {/* Transfer goal & progress (Milestone C). Pick a target university +
+            check off completed courses; each course shows how it transfers to
+            that university (direct / elective / no-credit), with a live tally of
+            the completed ones. Tracker fields update in place (RLS-scoped);
+            changing the university re-runs the server to recompute verdicts. */}
         <section className="mb-6 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
           <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">
             Transfer goal &amp; progress
@@ -180,11 +223,23 @@ export default function SavedPlanView({
               <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
                 {done} of {total} {total === 1 ? "course" : "courses"} completed
               </p>
+
+              {hasGoal && completed.length > 0 && (
+                <p className="mt-1 text-xs text-slate-600 dark:text-slate-400">
+                  Of your {completed.length} completed: {summary.direct} transfer directly
+                  {" · "}
+                  {summary.elective} as elective{" · "}
+                  {summary.noCredit} no-credit
+                  {summary.noData > 0 ? ` · ${summary.noData} no transfer data` : ""}
+                </p>
+              )}
+
               <ul className="mt-2 space-y-1.5">
                 {targetCourses.map((code) => {
                   const isDone = completed.includes(code);
+                  const verdict = verdicts[code] ?? "none";
                   return (
-                    <li key={code}>
+                    <li key={code} className="flex items-center justify-between gap-2">
                       <label className="inline-flex items-center gap-2 text-sm cursor-pointer">
                         <input
                           type="checkbox"
@@ -202,6 +257,13 @@ export default function SavedPlanView({
                           {code}
                         </span>
                       </label>
+                      {hasGoal && (
+                        <span
+                          className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${VERDICT_STYLE[verdict].cls}`}
+                        >
+                          {VERDICT_STYLE[verdict].label}
+                        </span>
+                      )}
                     </li>
                   );
                 })}
@@ -214,8 +276,9 @@ export default function SavedPlanView({
           )}
 
           <p className="mt-3 text-xs text-slate-400 dark:text-slate-500">
-            We&apos;ll use this to show how your completed courses transfer to your
-            chosen university — coming soon.
+            {hasGoal
+              ? "Transfer outcomes are in-state equivalencies from each university's published guides — verify with the receiving school's registrar."
+              : "Pick a university above to see how each course transfers (direct, elective, or no credit)."}
           </p>
         </section>
 

--- a/app/plan/[id]/page.tsx
+++ b/app/plan/[id]/page.tsx
@@ -22,7 +22,8 @@
 import { notFound, redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getStateConfig } from "@/lib/states/registry";
-import { getUniversities } from "@/lib/transfer";
+import { getUniversities, loadTransferMappingsByUniversity } from "@/lib/transfer";
+import { transferVerdict, type TransferVerdict } from "@/lib/transfer-tracker";
 import SavedPlanView from "./SavedPlanView";
 
 type Props = {
@@ -72,17 +73,30 @@ export default async function SavedPlanPage({ params }: Props) {
   // has no transfer data — the picker then simply offers no options.
   const universities = await getUniversities(plan.state);
 
+  // Per-target-course transfer verdict to the chosen university (best outcome:
+  // direct > elective > no-credit; "none" if unmapped). Computed server-side
+  // for the CURRENT target_university only; the client re-summarizes live as
+  // courses are checked, and a university change triggers router.refresh() so
+  // this recomputes. Empty {} when no goal is set (or the plan has no targets).
+  const targetCourses: string[] = plan.target_courses ?? [];
+  let verdicts: Record<string, TransferVerdict> = {};
+  if (plan.target_university && targetCourses.length > 0) {
+    const mappings = await loadTransferMappingsByUniversity(plan.state, plan.target_university);
+    verdicts = Object.fromEntries(targetCourses.map((c) => [c, transferVerdict(mappings, c)]));
+  }
+
   return (
     <SavedPlanView
       planId={plan.id}
       state={plan.state}
       systemName={config.systemName}
       name={plan.name}
-      targetCourses={plan.target_courses ?? []}
+      targetCourses={targetCourses}
       createdAt={plan.created_at}
       universities={universities}
       targetUniversity={plan.target_university ?? null}
       completedCourses={plan.completed_courses ?? []}
+      verdicts={verdicts}
     />
   );
 }

--- a/lib/__tests__/transfer-tracker.test.ts
+++ b/lib/__tests__/transfer-tracker.test.ts
@@ -1,5 +1,33 @@
 import { describe, expect, it } from "vitest";
-import { toggleCompleted, completedCount } from "@/lib/transfer-tracker";
+import {
+  toggleCompleted,
+  completedCount,
+  transferVerdict,
+  progressSummary,
+} from "@/lib/transfer-tracker";
+import type { TransferMapping } from "@/lib/types";
+
+/** Minimal TransferMapping fixture — only the fields transferVerdict reads
+ *  matter (cc_prefix, cc_number, no_credit, is_elective); the rest are filler. */
+const m = (
+  cc_prefix: string,
+  cc_number: string,
+  o: { no_credit?: boolean; is_elective?: boolean } = {},
+): TransferMapping => ({
+  cc_prefix,
+  cc_number,
+  cc_course: `${cc_prefix} ${cc_number}`,
+  cc_title: "",
+  cc_credits: "3",
+  university: "u",
+  university_name: "U",
+  univ_course: "X 100",
+  univ_title: "",
+  univ_credits: "3",
+  notes: "",
+  no_credit: o.no_credit ?? false,
+  is_elective: o.is_elective ?? false,
+});
 
 describe("toggleCompleted", () => {
   it("adds a course when absent", () => {
@@ -38,5 +66,51 @@ describe("completedCount", () => {
 
   it("handles an empty plan", () => {
     expect(completedCount([], [])).toEqual({ done: 0, total: 0 });
+  });
+});
+
+describe("transferVerdict", () => {
+  it("picks the BEST outcome when a course has both elective + direct rows", () => {
+    // one-to-many: same course, one elective row + one direct row → direct wins
+    expect(transferVerdict([m("ENG", "111", { is_elective: true }), m("ENG", "111")], "ENG 111")).toBe(
+      "direct",
+    );
+  });
+
+  it("returns elective when only elective rows exist", () => {
+    expect(transferVerdict([m("ENG", "111", { is_elective: true })], "ENG 111")).toBe("elective");
+  });
+
+  it("returns no-credit when only no_credit rows exist", () => {
+    expect(transferVerdict([m("ENG", "111", { no_credit: true })], "ENG 111")).toBe("no-credit");
+  });
+
+  it("returns none when the course isn't mapped to this university", () => {
+    expect(transferVerdict([m("MTH", "154")], "ENG 111")).toBe("none");
+  });
+});
+
+describe("progressSummary", () => {
+  it("buckets completed courses by verdict, no-data as its own bucket", () => {
+    const verdicts = {
+      "ENG 111": "direct",
+      "MTH 154": "elective",
+      "BIO 101": "no-credit",
+      "HIS 101": "none",
+    } as const;
+    expect(progressSummary(["ENG 111", "MTH 154", "BIO 101", "HIS 101"], verdicts)).toEqual({
+      direct: 1,
+      elective: 1,
+      noCredit: 1,
+      noData: 1,
+    });
+  });
+
+  it("treats a missing verdict as no-data", () => {
+    expect(progressSummary(["ENG 111"], {})).toEqual({ direct: 0, elective: 0, noCredit: 0, noData: 1 });
+  });
+
+  it("handles no completed courses", () => {
+    expect(progressSummary([], {})).toEqual({ direct: 0, elective: 0, noCredit: 0, noData: 0 });
   });
 });

--- a/lib/transfer-tracker.ts
+++ b/lib/transfer-tracker.ts
@@ -2,8 +2,21 @@
  * Pure helpers for the transfer-progress tracker (Milestone C). A "transfer
  * goal" = a saved plan + a target university + the courses the user has marked
  * completed. Split from the UI so they're unit-testable without a DOM (the
- * vitest env is "node").
+ * vitest env is "node"). Dependency-free apart from a type-only TransferMapping
+ * import + the (also dependency-free) transfer-rank ranker, so this stays safe
+ * to import from client components.
  */
+import type { TransferMapping } from "@/lib/types";
+import { rankMapping } from "@/lib/transfer-rank";
+
+export type TransferVerdict = "direct" | "elective" | "no-credit" | "none";
+
+export interface ProgressSummary {
+  direct: number;
+  elective: number;
+  noCredit: number;
+  noData: number;
+}
 
 /**
  * Toggle a course code in/out of the completed set: remove it if present, add
@@ -23,4 +36,44 @@ export function completedCount(
   const set = new Set(completed);
   const done = targetCourses.filter((c) => set.has(c)).length;
   return { done, total: targetCourses.length };
+}
+
+/**
+ * Best transfer outcome for a single course code against ONE university's
+ * mappings (direct > elective > no-credit; "none" if unmapped). `mappings`
+ * must already be filtered to one university (loadTransferMappingsByUniversity).
+ * Uses transfer-rank's rankMapping so the one-to-many collapse always surfaces
+ * the best outcome — never first/last-wins. Matches the code by prefix+number.
+ */
+export function transferVerdict(
+  mappings: TransferMapping[],
+  code: string,
+): TransferVerdict {
+  let best = 0; // rankMapping: no_credit→1, is_elective→2, else direct→3
+  for (const m of mappings) {
+    if (`${m.cc_prefix} ${m.cc_number}` !== code) continue;
+    const r = rankMapping(m);
+    if (r > best) best = r;
+  }
+  return best === 3 ? "direct" : best === 2 ? "elective" : best === 1 ? "no-credit" : "none";
+}
+
+/**
+ * Tally how the COMPLETED courses transfer, using a per-course verdict map.
+ * "noData" (no published mapping) is its own bucket — never counted as a fail,
+ * so it can be excluded from any percentage (the fair-denominator rule).
+ */
+export function progressSummary(
+  completed: string[],
+  verdicts: Record<string, TransferVerdict>,
+): ProgressSummary {
+  const out: ProgressSummary = { direct: 0, elective: 0, noCredit: 0, noData: 0 };
+  for (const code of completed) {
+    const v = verdicts[code] ?? "none";
+    if (v === "direct") out.direct++;
+    else if (v === "elective") out.elective++;
+    else if (v === "no-credit") out.noCredit++;
+    else out.noData++;
+  }
+  return out;
 }


### PR DESCRIPTION
## What changes for someone using the site

On a saved plan (`/plan/[id]`) where you've set a **target university** (from PR 1), each target course now shows **how it transfers** to that university — **✓ Transfers** (direct), **≈ Elective**, **✕ No credit**, or **— No data** — and a live one-line tally summarizes your completed courses: *"Of your N completed: A transfer directly · B as elective · C no-credit · D no transfer data."* As you check courses off, the tally updates instantly; changing the university recomputes the verdicts.

This is **PR 2 of 2** — it completes the transfer-progress tracker (PR 1 added the data model + the pick-a-university / mark-done capture). No new backend, no migration; it reuses the transfer-equivalency data the site already has.

## How it works

- **`lib/transfer-tracker.ts`** — two new pure helpers: `transferVerdict(mappings, code)` collapses a course's one-to-many mappings to the **best** outcome (direct > elective > no-credit; `none` if unmapped) via `transfer-rank`'s `rankMapping` — never first/last-wins; and `progressSummary(completed, verdicts)` buckets the completed courses, with **"no data" as its own bucket** (never counted as a failure — the fair-denominator rule).
- **`app/plan/[id]/page.tsx`** (server) — when a `target_university` is set, loads that university's mappings via the cached `loadTransferMappingsByUniversity` and builds a per-target-course verdict map, passed to the view.
- **`SavedPlanView.tsx`** (client) — renders a verdict badge per course + the live summary. Badges use **indigo / violet / rose / gray + ✓ ≈ ✕** — deliberately **not** the seat green/amber/red palette, so a transfer outcome is never confusable with seat availability (icons carry the meaning, so it's not color-only). Changing the target university calls `router.refresh()` so the server recomputes verdicts for the new school. Honest footnote: in-state equivalencies, verify with the receiving school's registrar.

## Test plan

- **Unit (14):** `transferVerdict` (a course with both elective + direct rows → **direct**; elective-only → elective; no_credit-only → no-credit; unmapped → none) and `progressSummary` (buckets by verdict; missing verdict → no-data; empty), alongside the PR 1 helpers.
- **Build + data layer:** `npm run build` green; the public `/va/transfer` page renders real VA universities (George Mason, Old Dominion, UVA, VCU, Virginia Tech) + mappings, confirming the loader path the verdicts use returns real in-state data in this build.
- `tsc` clean, `lint` 0 errors.

## Known gap

The signed-in `/plan/[id]` view isn't exercised in an automated headless run (no auth session — same as #1184). Quick **manual post-merge check**: open a saved plan, pick a university, mark a course done → its badge + the tally reflect the transfer verdict; switch universities → verdicts recompute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
