### PR TITLE
docs: codify the goal-driven-PR workflow (portable skill + RLS-testing recipe + commit rule)

### DIFF
--- a/.agents/skills/supabase-postgres-best-practices/references/security-rls-testing.md
+++ b/.agents/skills/supabase-postgres-best-practices/references/security-rls-testing.md
@@ -1,0 +1,44 @@
+---
+title: Test RLS and SECURITY DEFINER Functions in a Rolled-Back Transaction
+impact: HIGH
+impactDescription: Prove owner-scoped writes work without polluting prod or needing a logged-in E2E
+tags: rls, security-definer, testing, verification, auth
+---
+
+## Test RLS and SECURITY DEFINER Functions in a Rolled-Back Transaction
+
+When a write is gated by RLS or runs inside a `SECURITY DEFINER` function keyed on `auth.uid()`, you often can't exercise it from an automated test (no real authenticated session) — and you must not leave test rows in production. Verify it server-side in a transaction you roll back.
+
+**Incorrect (bypasses RLS, or pollutes prod):**
+
+```sql
+-- Running as the service_role / table owner BYPASSES RLS entirely,
+-- so this proves nothing about the policy:
+update saved_plans set target_university = 'x' where id = '...';
+
+-- Or: insert a real test row and hope to delete it afterward — risky;
+-- a failure leaves orphaned data in a real user's account.
+```
+
+**Correct (assume the real role, assert, then RAISE to roll back):**
+
+```sql
+-- Run as `authenticated` with a real user's JWT claims so RLS actually
+-- applies; do the write, assert, then RAISE to abort — nothing persists.
+-- The error message carries the assertion back to you.
+DO $$
+DECLARE pid uuid; got text;
+BEGIN
+  PERFORM set_config('request.jwt.claims', '{"sub":"<real-auth-user-uuid>"}', true);
+  SET LOCAL role authenticated;                 -- RLS now enforced for this txn
+  INSERT INTO saved_plans (user_id, state, name, target_courses, plan_data)
+    VALUES (auth.uid(), 'va', 'RLS TEST', '{}', '{}'::jsonb) RETURNING id INTO pid;
+  UPDATE saved_plans SET target_university = 'university-of-virginia' WHERE id = pid;
+  SELECT target_university INTO got FROM saved_plans WHERE id = pid;
+  RAISE EXCEPTION 'RLS_TEST_OK got=%', got;     -- aborts the txn → 0 rows persist
+END $$;
+```
+
+The same shape verifies a `SECURITY DEFINER` RPC: set the claims, `SELECT my_rpc(...)`, assert the effect, `RAISE` to roll back. It catches bugs the function body's *deferred* validation misses — e.g. a `rec->>'score'::integer` cast that throws on a real decimal value (`85.3`) but passed every fixture that used a whole number; cast via `::numeric::integer` to match how a JSON float is coerced on the live insert path. After running, confirm `select count(*)` of the sentinel row is `0` so you know the rollback held.
+
+Reference: [Postgres DO blocks](https://www.postgresql.org/docs/current/sql-do.html) · [Supabase RLS](https://supabase.com/docs/guides/database/postgres/row-level-security)

--- a/.claude/skills/goal-driven-pr/SKILL.md
+++ b/.claude/skills/goal-driven-pr/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: goal-driven-pr
+description: Ship a well-scoped change as one clean, reviewable PR by front-loading judgment into a tight goal, grounding in real code, verifying hard, and stopping at the PR for review. Use when executing a detailed goal/spec handed to you, authoring such a goal, deciding how to split a feature into PRs, or shipping any non-trivial build-then-PR change.
+---
+
+# goal-driven-pr
+
+A portable workflow for turning an intent into a merged change with minimal rework. The bet: **spend the judgment up front** — a tight, evidence-grounded goal plus a clear stop point — so execution runs autonomously and review happens once, on a self-contained diff, not mid-build.
+
+It assumes the project already documents its own guardrails (branch/worktree isolation, tests, build, lint, any migration/deploy discipline) in its CLAUDE.md / memory. This is the *operating loop* that leans on them; it does not restate them.
+
+## The loop
+
+1. **Author (or sharpen) a tight goal** — see *Authoring a goal*.
+2. **Ground before building** — read the real files you'll touch, and the real prod/external state you'll depend on, *first*. Cite specific `file:line` and actual schemas/APIs, never assumptions.
+3. **Build** the smallest change that satisfies one concern.
+4. **Verify hard** — see *Verification*.
+5. **Open the PR** — plain-English first; name any gap. **Stop for review. Do not merge.**
+
+## Authoring a goal
+
+Self-contained and skimmable — someone (or a fresh session) can execute it without re-deriving context. Keep it tight; if your harness caps goal length, measure and trim to fit. Structure:
+
+- **What & why** — the user-visible change + the reason, in a line or two. State what's explicitly **out of scope**.
+- **Pre-flight** — isolation + safety checks to do first (create the branch/worktree; confirm prerequisites).
+- **Ground** — name the *actual* files to read and what each provides, so the executor grounds in real code instead of guessing.
+- **Steps** — concrete edits with real identifiers (paths, function/column names, exact strings where they matter).
+- **Verify** — the checks that must pass before the PR, including how to prove behavior you can't fully exercise.
+- **PR** — branch name, a *plain-English-first* body, and **DO NOT MERGE — stop for review.**
+
+Ground the *goal itself* in real code before writing it — a goal full of invented filenames or wrong signatures wastes the whole execution.
+
+## Scope: one concern per PR — split when subsystems differ
+
+- Keep a PR to a single concern; a reviewer should hold the whole diff in their head.
+- **Split** when parts touch different subsystems or carry different risk (a UI nudge vs. a new backend table; a data-model + capture step vs. the view that reads it). Sequence them; each lands and is verified on its own.
+- **Stage only the files your change touched — never a blind `git add -A`.** Build steps and codegen routinely rewrite generated/derived files you must not commit.
+
+## Surface genuine forks BEFORE building
+
+When the request has a real fork — a product decision, an architecture choice, an MVP-vs-full scope — that materially changes what you build, **ask first** with a crisp options question; don't guess. Building the wrong large thing costs far more than one question. Reserve this for decisions that change the work; otherwise pick the obvious default and say so.
+
+## Verification
+
+Typecheck/lint green and "it ran without error" are necessary, not sufficient. Also:
+
+- **Exercise the real path** the way it'll be used (load the page, hit the endpoint, run the flow) — not just a happy-path unit.
+- **Use realistic inputs in at least one check.** Fixtures of round, simple values hide whole bug classes — a column that's an integer in the schema but a decimal in real data; a field that's always present in fixtures but null in prod. Run one check against real-shaped data.
+- **When you can't run the path end-to-end** (needs an authenticated session, a third-party callback, prod-only state), prove the critical piece another way and **state the gap honestly in the PR**:
+  - extract the logic into a pure function and unit-test it;
+  - exercise the server/database side directly in a **rolled-back transaction** — do the write as the real role, assert, then abort so nothing persists;
+  - leave the genuinely-unverifiable step as an explicit, *named* manual post-merge check — not hidden.
+- **Verify against the deployed/real state, not your assumption of it.** Schemas drift; configs differ across environments. Check before you depend on it.
+
+## PR + stop
+
+- Lead the body with **what changes for a user**, in plain language, before the technical detail. Name known gaps — completely accurate beats vaguely impressive.
+- Open the PR and **stop**. Merge is the reviewer's call. Don't push more commits after saying it's ready — a post-merge commit orphans.
+
+## After merge
+
+Confirm it actually shipped (a concrete post-deploy check), then do any promised manual check. Record durable, non-obvious lessons where the project keeps them — and prefer a machine-enforced check (CI / lint / hook) over prose when the lesson can be one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,8 @@ This matters because:
 
 Never assume the working directory is the main repo — skills like `blog-pipeline` and `auto-add-state` call `EnterWorktree`, which changes the CWD. After any skill completes, verify `pwd` and `git branch --show-current` before proceeding.
 
+**Stage only the files your change touched — never `git add -A`.** `npm run dev`/`npm run build` regenerate ~70+ derived `data/*.json` files (`last-updated.json`, `term-counts.json`, `*/transfer-dest-rollup.json`, …); committing that churn balloons the diff and can revert another state's data. Use explicit `git add <paths>` and check `git diff --cached --name-only` before committing.
+
 ## Git — narrate as you go
 
 The user is learning git in real time and wants to understand what's happening, not just approve blind steps. When running any git or `gh` command, narrate it in **one or two plain-English sentences** before or after the tool call:


### PR DESCRIPTION
## What changes for someone using the site

Nothing — this is **internal workflow documentation**. It captures *why* this session's "owner drafts a tight goal → Claude executes → PR → review" loop produced 16 clean PRs (the whole auth/accounts buildout, #1170–#1186), so the pattern is reusable here and in future projects.

## What's in it (Stage 2 of the approved plan)

Per the Stage-1 lessons analysis, the key finding was that **~80% of the operating discipline was already codified** (CLAUDE.md's worktree / narrate / PR / verify sections + ~14 `feedback_*` memories) — that's *why* the loop ran clean. So this adds only the genuine gaps, and **references rather than duplicates** the existing discipline:

1. **`.claude/skills/goal-driven-pr/SKILL.md`** (new, **project-agnostic**) — the reusable loop: author a tight, evidence-grounded goal → ground in real code first → build → verify hard → open PR → **stop for review**. Plus the heuristics that proved out this session: *one concern per PR, split when subsystems differ* (seat-CTA vs. tracker; tracker PR1/PR2), *surface genuine scope/architecture forks before building*, *use real-shaped data in at least one check* (the decimal-score bug), and *how to prove behavior you can't run end-to-end*. Written to drop cleanly into a non-CC project.
2. **`.agents/skills/supabase-postgres-best-practices/references/security-rls-testing.md`** (new) — the **rolled-back-transaction** recipe for verifying RLS / `SECURITY DEFINER` writes without a logged-in E2E or polluting prod (`SET LOCAL role authenticated` + `RAISE` to abort). Follows that skill's `_template`/`_contributing` convention and auto-slots into its Security category via the `security-` prefix. Carries the `::numeric::integer` decimal caveat from #1179.
3. **`CLAUDE.md`** (+1 rule) — *stage only the files your change touched; never `git add -A`* — because `npm run build`/`dev` regenerate ~70+ derived `data/*.json` files that must not be committed. (The portable *split-by-concern* and *surface-forks* heuristics live in the skill, not here — no duplication, CLAUDE.md stays tight.)

## Verification

Docs/skills/markdown only — no code, so there's nothing to build or test (CI lint/vitest don't touch `.md`). Confirmed: both new files have valid frontmatter; `goal-driven-pr` sits at the standard `.claude/skills/<name>/SKILL.md` path (real dir, like the other project skills); the supabase reference lands at the symlink's real `.agents/skills/...` home and joins the Security category by prefix; CLAUDE.md gained exactly one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
