### PR TITLE
docs(skill): document the collaborative goal-drafting loop in goal-driven-pr

### DIFF
--- a/.claude/skills/goal-driven-pr/SKILL.md
+++ b/.claude/skills/goal-driven-pr/SKILL.md
@@ -30,6 +30,8 @@ Self-contained and skimmable — someone (or a fresh session) can execute it wit
 
 Ground the *goal itself* in real code before writing it — a goal full of invented filenames or wrong signatures wastes the whole execution.
 
+**Draft it collaboratively.** The goal is often best *authored by the assistant* from the owner's brief: the owner gives the intent + constraints (even minimal context); the assistant grounds in the real code first, then drafts this tight, structured goal; the owner reviews/edits and feeds it back to execute (e.g. via the harness's goal command). This front-loads the assistant's grounding and precision while the owner keeps judgment over scope and intent. When handed a feature idea, **offer to draft the goal** rather than make the owner write the spec from scratch — and the owner stays the approver: the executor still stops at the PR.
+
 ## Scope: one concern per PR — split when subsystems differ
 
 - Keep a PR to a single concern; a reviewer should hold the whole diff in their head.


### PR DESCRIPTION
## What changes for someone using the site

Nothing — internal workflow docs. The `goal-driven-pr` skill's **"Authoring a goal"** section explained the *anatomy* of a good goal but never said **who writes it**. This adds a short **"Draft it collaboratively"** note capturing the mode we actually used across the whole auth/accounts buildout: **the assistant drafts the tight goal from the owner's brief (grounding in real code first), the owner reviews/edits, then feeds it back to execute** — and the executor still stops at the PR for review.

## Why

It closes a real gap the owner flagged: the skill should describe the draft → review → feed-back collaboration, not just the goal's structure. Without it, the skill reads as "the owner writes the structured spec," when in practice the highest-leverage move is for the assistant to offer to draft it (it does the grounding + precision; the owner keeps judgment over scope/intent).

## The change

One paragraph appended to the **"Authoring a goal"** section of `.claude/skills/goal-driven-pr/SKILL.md`. Project-agnostic wording ("the assistant," "the harness's goal command") so it stays portable; references the existing stop-at-the-PR rule rather than restating it.

## Test plan

Docs-only (one markdown section) — nothing to build or test (CI lint/vitest don't touch `.md`). Verified: frontmatter intact, the new subsection sits between "## Authoring a goal" and "## Scope," and the diff touches only that one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)