### PR TITLE
sciq: fall back to broader BFS when programsRoot is empty (+70 phsc plannable)

### DIFF
--- a/data/fl/DEFERRED-programs.md
+++ b/data/fl/DEFERRED-programs.md
@@ -4,22 +4,29 @@ Programs rollout for Florida (FCS, 28 colleges). Catalog platform per college is
 fingerprinted by `scripts/fl/discover-catalogs.ts` → `data/fl/catalog-discovery.json`,
 then scraped by the matching platform wrapper (cloned from the NC tooling).
 
-## Shipped — 13 colleges scraped (~1,385 programs); **1,185 plannable across 13 colleges**
+## Shipped — 14 colleges scraped (~1,471 programs); **1,255 plannable across 14 colleges**
 
 Verified via `countRealCourses >= PLAN_MIN_COURSES` on local JSON, plannable per college:
 palmbeachstate 156, irsc 143, fscj 129, pensacolastate 112, daytonastate 108, **cf 85**,
-polk 80, **tcc-fl 77**, sjrstate 65, scf 63, fsw 60, southflorida 54, fgc 53.
+polk 80, **tcc-fl 77**, **phsc 70**, sjrstate 65, scf 63, fsw 60, southflorida 54, fgc 53.
 
-**Parser fix (2026-06-04, PR #__):** cf went 0 → 85 plannable and tcc-fl went 0 → 77
+**Walker fix (2026-06-04):** phsc went 0 → 70 plannable. Its 17 category pages under
+`/academic-programs/` link to programs in a SIBLING URL tree (`/prog-desc/{level}/{slug}`)
+rather than as children — outside the walker's `startsWith(programsRoot)` filter.
+The shared `scrape-smartcatalogiq-programs.ts` walker now falls back to a broader
+BFS at the catalog root (one level above `programsPath`, page-capped at 500) when
+the primary BFS finds zero program-detail pages. Working colleges' control flow is
+unchanged by construction — verified empirically against daytonastate/irsc/bladen.
+
+**Acalog parser fix (2026-06-04):** cf went 0 → 85 plannable and tcc-fl went 0 → 77
 plannable after `scripts/lib/scrape-acalog-programs.ts` was broadened to accept
 no-space course codes (`ACG2021`) and to parse adhoc-list-items as real courses
-when the text starts with a code. cf is FL's no-space-code case; tcc-fl is the same
-pattern. See NC's parser commit for the full story (one shared lib, four states).
+when the text starts with a code.
 
 | Platform | Colleges scraped |
 |---|---|
 | Acalog | cf, fgc, fsw, polk, scf, sjrstate, southflorida, tcc-fl |
-| SmartCatalogIQ | daytonastate, irsc, palmbeachstate, pensacolastate |
+| SmartCatalogIQ | daytonastate, irsc, palmbeachstate, pensacolastate, phsc |
 | Coursedog | fscj |
 
 **Recovery log (2026-06-04):** palmbeachstate + pensacolastate (SmartCatalogIQ) were
@@ -31,13 +38,10 @@ stray "Acalog" footer mention can't re-trip this.
 
 ## Deferred / incomplete this pass
 
-- **phsc (SmartCatalogIQ) — 0; a real blocker, not a re-run.** Its SmartCatalogIQ
-  instance is stale (latest published edition is 2023-2024, no 2025-2026) and its
-  programs nest one level below the walker's depth: `…/academic-programs/` lists 17
-  *category* pages (associate-in-science-degree, college-credit-certificate-programs, …)
-  and the actual program pages live inside those. Needs the shared SmartCatalogIQ
-  deeper-walk enhancement (also affects NC lenoir/mayland/western-piedmont, IL
-  moraine-valley/triton) — tracked as a cross-state lever, not a FL-only fix.
+- ~~phsc (SmartCatalogIQ) — 0; real blocker~~ **RESOLVED 2026-06-04** (walker fallback;
+  see above). Catalog is at the 2023-2024 edition (no 2025-2026 published) but the
+  data is current with what phsc publishes, and 70/86 programs now plan cleanly.
+  Re-investigate when phsc publishes a newer edition.
 - ~~cf, tcc-fl (Acalog) — 0 plannable~~ **RESOLVED 2026-06-04** (parser fix; see above).
 - **CourseLeaf (easternflorida, lssc, valencia) — 0.** Their program index doesn't
   match the common CourseLeaf path conventions; needs per-college index discovery.

--- a/data/fl/programs/phsc.json
+++ b/data/fl/programs/phsc.json
@@ -1,0 +1,9628 @@
+{
+  "college_slug": "phsc",
+  "catalog_year": "2023-2024",
+  "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/academic-programs/",
+  "scraped_at": "2026-06-04T21:21:58.883Z",
+  "programs": [
+    {
+      "title": "General Education Requirements for the AA Program",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/aa/general-education-requirements-for-the-aa-program",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English/Reading Developmental Education Courses (0-8 Hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "0021",
+              "title": "Modularized Developmental Writing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "0022",
+              "title": "Compressed Developmental Writing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "0056",
+              "title": "Corequisite Writing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REA",
+              "number": "0011",
+              "title": "Modularized Developmental Reading",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REA",
+              "number": "0019",
+              "title": "Compressed Developmental Reading",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REA",
+              "number": "0056",
+              "title": "Corequisite Reading",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math Developmental Education Courses (0-6 Hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "0028",
+              "title": "Introductory Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "0055",
+              "title": "Accelerate in Mathematics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "0056",
+              "title": "Foundations of Mathematics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Crime Scene/Forensic Science Technology, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-cst",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Core Courses",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSC",
+              "number": "1085",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085L",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCJ",
+              "number": "1020",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1640",
+              "title": "Criminalistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1641",
+              "title": "Introduction to Crime Scene Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1643",
+              "title": "Advanced Crime Scene Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1644",
+              "title": "Crime Scene Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1645",
+              "title": "Introduction to Forensic Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1671",
+              "title": "Latent Fingerprint Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1677",
+              "title": "Modern Fingerprint Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1770",
+              "title": "Crime Scene Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1772",
+              "title": "Crime Scene Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "2608",
+              "title": "Courtroom Presentation of Evidence",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "2950",
+              "title": "Crime Scene Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Law Enforcement Certification",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJE",
+              "number": "1000",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1300",
+              "title": "Police Organization and Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1500",
+              "title": "Police Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "2601",
+              "title": "Introduction to Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJL",
+              "number": "2100",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "1000",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1300",
+              "title": "Police Organization and Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJL",
+              "number": "2100",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Technology, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-acc",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "1630",
+              "title": "Applied Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Core Courses",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACG",
+              "number": "2071",
+              "title": "Principles of Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACG",
+              "number": "2100",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACG",
+              "number": "2110",
+              "title": "Intermediate Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACG",
+              "number": "2450",
+              "title": "Microcomputers in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2852",
+              "title": "Excel for the Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2013",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2023",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1100",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAX",
+              "number": "2000",
+              "title": "Federal Income Tax I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAX",
+              "number": "2010",
+              "title": "Federal Income Tax II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Business Administration AS to BS Transfer Program, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-ba",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "1105",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2013",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2023",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "1630",
+              "title": "Applied Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Common Core Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACG",
+              "number": "2071",
+              "title": "Principles of Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STA",
+              "number": "2023",
+              "title": "Introduction to Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Professional Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1136",
+              "title": "Introduction to E-Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "2233",
+              "title": "Applied Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "1011",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Criminal Justice Technology, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-cjj",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "1630",
+              "title": "Applied Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSC",
+              "number": "1121",
+              "title": "Survey of the Physical Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Professional Courses",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCJ",
+              "number": "2010",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "1000",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1000",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1300",
+              "title": "Police Organization and Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1500",
+              "title": "Police Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "2601",
+              "title": "Introduction to Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJL",
+              "number": "2100",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEP",
+              "number": "2302",
+              "title": "Adolescent Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPC",
+              "number": "2608",
+              "title": "Introduction to Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1012",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "2400",
+              "title": "Police Community Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1640",
+              "title": "Criminalistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJL",
+              "number": "2062",
+              "title": "Rules of Evidence for Police",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Law Enforcement Certification",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJE",
+              "number": "1000",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1300",
+              "title": "Police Organization and Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1500",
+              "title": "Police Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "2601",
+              "title": "Introduction to Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJL",
+              "number": "2100",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "1000",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1300",
+              "title": "Police Organization and Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJL",
+              "number": "2100",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Computer Programming and Analysis, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-cpa",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "The following program core of 15 hours applies to all IT AS degree programs:",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "1179",
+              "title": "Microcomputer Repair Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1110",
+              "title": "Microcomputer Software Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "Introduction to Computer Programming - Python",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1820",
+              "title": "Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "2108",
+              "title": "Advanced Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2220",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2071",
+              "title": "Database Programming and SQL",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2360",
+              "title": "C# Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2040",
+              "title": "Programming for Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2801",
+              "title": "JavaScript Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2250",
+              "title": "Java Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2941",
+              "title": "Information Technology Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Aided Drafting and Design Technology, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-ddt",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements:",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Courses:",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCN",
+              "number": "1001",
+              "title": "Building Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETC",
+              "number": "1250",
+              "title": "Properties of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "1100",
+              "title": "Technical Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "1530",
+              "title": "Architectural Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "2218",
+              "title": "Introduction to Geometric Dimensioning & Tolerancing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGN",
+              "number": "2123",
+              "title": "Skills and Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "2320",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "2340",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "2381",
+              "title": "Computer Aided Drafting for Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "2110",
+              "title": "Engineering Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "2941",
+              "title": "Internship in Drafting and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1411",
+              "title": "Introduction to Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Media / Multimedia Technology",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-dmt",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Core Courses",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1820",
+              "title": "Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2801",
+              "title": "JavaScript Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2000",
+              "title": "Introduction to Digital Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2030",
+              "title": "Digital Video Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2105",
+              "title": "Social Media Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2109",
+              "title": "Digital Imaging Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2200",
+              "title": "Basic Video Camera",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2205",
+              "title": "Basic Video Editing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2284",
+              "title": "Advanced Videography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2500",
+              "title": "Fundamentals of Interactive Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2581",
+              "title": "Portfolio Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2940",
+              "title": "Digital Media Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRA",
+              "number": "1160",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRA",
+              "number": "1151",
+              "title": "Digital Illustration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-dh",
+      "total_credits": 86,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSC",
+              "number": "1085",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085L",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086L",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1025",
+              "title": "Introductory Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1025L",
+              "title": "Introductory Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "2010",
+              "title": "Microbiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "2010L",
+              "title": "Microbiology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1012",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPC",
+              "number": "2608",
+              "title": "Introduction to Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Freshman—Session I",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DES",
+              "number": "1020",
+              "title": "Oral Head and Neck Anatomy, Histology and Embryology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "1020L",
+              "title": "Oral, Head, and Neck Anatomy Laboratory",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1002",
+              "title": "Dental Hygiene I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1002L",
+              "title": "Dental Hygiene I Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "1200",
+              "title": "Dental Radiography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "1200L",
+              "title": "Dental Radiography Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Freshman—Session II",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEH",
+              "number": "2400",
+              "title": "General and Oral Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1800",
+              "title": "Dental Hygiene II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "1800L",
+              "title": "Dental Hygiene II Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2602",
+              "title": "Periodontics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "2201",
+              "title": "Science of Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "1601",
+              "title": "Medical Emergencies for the Dental Professional",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "1100",
+              "title": "Dental Materials",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "1100L",
+              "title": "Dental Materials Lab",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Freshman—Session III",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEH",
+              "number": "2802L",
+              "title": "Dental Hygiene III Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sophomore—Session I",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEH",
+              "number": "2702",
+              "title": "Community Dental Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2005",
+              "title": "Dental Hygiene III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2804L",
+              "title": "Dental Hygiene IV Clinical",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2300",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sophomore—Session II",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEH",
+              "number": "2605",
+              "title": "Advanced Principles of Dental Hygiene Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2702L",
+              "title": "Community Dental Health Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2810",
+              "title": "Dental Hygiene IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "2806L",
+              "title": "Dental Hygiene V Clinical",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYG",
+              "number": "2000",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Financial Services, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-fins",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "1630",
+              "title": "Applied Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BRC",
+              "number": "2001",
+              "title": "Introduction to Financial Institutions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REE",
+              "number": "2200",
+              "title": "Real Estate Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2013",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1100",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1122",
+              "title": "Fundamentals of Financial Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "2001",
+              "title": "Principles of Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "2940",
+              "title": "Internship in Financial Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "1011",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKA",
+              "number": "1021",
+              "title": "Principles of Selling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RMI",
+              "number": "1002",
+              "title": "Principles of Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-fst",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Core Courses",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FFP",
+              "number": "1505",
+              "title": "Fire Prevention Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FFP",
+              "number": "1540",
+              "title": "Private Fire Protection Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FFP",
+              "number": "2810",
+              "title": "Firefighting Tactics and Strategy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FFP",
+              "number": "2720",
+              "title": "Company Officer Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FFP",
+              "number": "2740",
+              "title": "Fire Service Course Delivery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FFP",
+              "number": "2780",
+              "title": "Fire Department Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FFP",
+              "number": "2120",
+              "title": "Building Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FFP",
+              "number": "2811",
+              "title": "Firefighting Tactics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FFP",
+              "number": "2770",
+              "title": "Ethical and Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FFP",
+              "number": "2610",
+              "title": "Cause and Origin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FFP",
+              "number": "2111",
+              "title": "Fire Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-ems",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1119",
+              "title": "Emergency Medical Technology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1119L",
+              "title": "Emergency Medical Technology Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1431",
+              "title": "Emergency Medical Technology Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "1630",
+              "title": "Applied Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "2531",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "1101",
+              "title": "Perspectives of Health and Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1012",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1020",
+              "title": "Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sophomore—Session I",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "2620",
+              "title": "Paramedics I",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2620L",
+              "title": "Paramedics I Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2621",
+              "title": "Paramedics I Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sophomore—Session II",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "2622",
+              "title": "Paramedics II",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2622L",
+              "title": "Paramedics II Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2623",
+              "title": "Paramedics Clinical II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sophomore—Session III",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "2624",
+              "title": "Paramedics III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2624L",
+              "title": "Paramedics III Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2625",
+              "title": "Paramedic Internship",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Technology, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-engt",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1084",
+              "title": "Introduction to Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "2320",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "2340",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1110",
+              "title": "Introduction to Quality Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1420",
+              "title": "Manufacturing Processes and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1701",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETM",
+              "number": "1010",
+              "title": "Mechanical Measurement & Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Specialization Courses: Advanced Manufacturing Track",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETI",
+              "number": "1644",
+              "title": "Production & Inventory Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "2622",
+              "title": "Concepts of Lean Six Sigma Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETM",
+              "number": "2315",
+              "title": "Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETS",
+              "number": "1511",
+              "title": "Motors and Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETS",
+              "number": "1535",
+              "title": "Automated Process and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETM",
+              "number": "2401",
+              "title": "Mechanical Devices and Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETS",
+              "number": "1542",
+              "title": "Introduction to Programmable Logic",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1084",
+              "title": "Introduction to Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1110",
+              "title": "Introduction to Quality Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1420",
+              "title": "Manufacturing Processes and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1701",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETM",
+              "number": "1010",
+              "title": "Mechanical Measurement & Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Industrial Management Technology, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-imt",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Industrial Management Courses:",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "1011",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1345",
+              "title": "Principles of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technology Electives: (Choose one or two courses as needed to complete the 60 total hours required for this degree.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "2013",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1136",
+              "title": "Introduction to E-Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "2350",
+              "title": "Introduction to International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKA",
+              "number": "1021",
+              "title": "Principles of Selling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "1100",
+              "title": "Document Formatting and Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Nursing (RN) Generic Program, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-ngt",
+      "total_credits": 14,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "1012",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "1105",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085L",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "2010",
+              "title": "Microbiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "2010L",
+              "title": "Microbiology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Internet Services Technology, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-isti",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "The following program core of 15 hours applies to all IT AS degree programs:",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "1179",
+              "title": "Microcomputer Repair Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1110",
+              "title": "Microcomputer Software Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "Introduction to Computer Programming - Python",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "The following 27 hours apply specifically to the Internet Services Technology AS degree:",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "1020C",
+              "title": "Introduction to Networks (CISCO Academy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1700C",
+              "title": "Switching, Routing, and Wireless Essentials (Cisco Academy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2793",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1820",
+              "title": "Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2040",
+              "title": "Programming for Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "2827",
+              "title": "Advanced Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1401",
+              "title": "Principles of Information Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2801",
+              "title": "JavaScript Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2941",
+              "title": "Information Technology Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "The following 18 hours meet the General Education Requirements:",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Studies (Legal Assisting), Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-la",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Courses",
+          "credits_required": 46,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OST",
+              "number": "1100",
+              "title": "Document Formatting and Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "1764",
+              "title": "Word Processing—Microsoft Word",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "1003",
+              "title": "Introduction to Law and Legal Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "1201",
+              "title": "Civil Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "1260",
+              "title": "Evidence and Trial Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "1303",
+              "title": "Criminal Law for Paralegals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "2104",
+              "title": "Legal Research and Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "2114",
+              "title": "Legal Research and Writing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "2273",
+              "title": "Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "2615",
+              "title": "Real Property Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "2600",
+              "title": "Wills, Estates, and Trusts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "2800",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "2940",
+              "title": "Paralegal Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUL",
+              "number": "2561",
+              "title": "Cyberlaw",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "2763",
+              "title": "Law Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLS",
+              "number": "2401",
+              "title": "Career Enhancement",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Marketing Management, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-mm",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "1630",
+              "title": "Applied Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Courses:",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2023",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1136",
+              "title": "Introduction to E-Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "2112",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "1011",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMB",
+              "number": "1001",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKA",
+              "number": "1021",
+              "title": "Principles of Selling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "2502",
+              "title": "Consumer Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKA",
+              "number": "2511",
+              "title": "Principles of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1345",
+              "title": "Principles of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "2941",
+              "title": "Internship in Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "1811",
+              "title": "Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Cyber and IT Security, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-its",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "The following 18 hours meet the General Education Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "the following 27 hrs apply specifically to the Cyber and Information Security program:",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "2880",
+              "title": "Introduction to Computer Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1820",
+              "title": "Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2352",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2354",
+              "title": "Introduction to Cyberwarfare and Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1401",
+              "title": "Principles of Information Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "2510",
+              "title": "Wireless LANs and Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2040",
+              "title": "Programming for Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2071",
+              "title": "Database Programming and SQL",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "2123",
+              "title": "Network Security and Intrusion Detection",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "The following program core of 15 hrs applies to all IT degree programs",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "1179",
+              "title": "Microcomputer Repair Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1110",
+              "title": "Microcomputer Software Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "Introduction to Computer Programming - Python",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing (RN) ADN Transition Program, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-nlt",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUN",
+              "number": "2201",
+              "title": "Science of Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1012",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "2010",
+              "title": "Microbiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "1105",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "2010L",
+              "title": "Microbiology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085L",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086L",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Freshman-Session IIIB (Paramedics Only)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "1006",
+              "title": "Nursing Fundamentals/ADN Transition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "1006L",
+              "title": "Nursing Fundamentals Clinical/ADN Transition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sophomore-Session I",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "1200",
+              "title": "Adult Nursing I/ADN Transition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "1200L",
+              "title": "Adult Nursing I Clinical /ADN Transition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "2403",
+              "title": "Maternal-Child Nursing/ADN Transition",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "2403L",
+              "title": "Maternal-Child Nursing Clinical/ADN Transition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Office Administration, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-oa",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements:",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "1630",
+              "title": "Applied Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Courses:",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "2941",
+              "title": "Internship in Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMB",
+              "number": "1001",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "1100",
+              "title": "Document Formatting and Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "1100",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "1764",
+              "title": "Word Processing—Microsoft Word",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "1811",
+              "title": "Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1345",
+              "title": "Principles of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2852",
+              "title": "Excel for the Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "1011",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2356",
+              "title": "Electronic Records Management - MS Access",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Pilot Technology, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-ppt",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Courses",
+          "credits_required": 46,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "1010",
+              "title": "Foundations of Air Transportation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "1210",
+              "title": "Aviation Meteorology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "1310",
+              "title": "Aviation Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "2640",
+              "title": "Advanced Aircraft Turbo-Prop and Turbine Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "1610",
+              "title": "Aircraft Systems & Components",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "2441",
+              "title": "Aviation Safety and Human Factors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "1440",
+              "title": "Airport/Aviation Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATF",
+              "number": "2620",
+              "title": "Commercial Pilot Simulator",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATF",
+              "number": "2400",
+              "title": "Multi-Engine Flight",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATF",
+              "number": "2305",
+              "title": "Instrument Pilot Flight",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "1100",
+              "title": "Pilot Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "2110",
+              "title": "Commercial Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATF",
+              "number": "2201",
+              "title": "Commercial Pilot I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATF",
+              "number": "2202",
+              "title": "Commercial Pilot II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATF",
+              "number": "2203",
+              "title": "Commercial Pilot III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "1120",
+              "title": "Instrument Pilot Ground School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "1820",
+              "title": "Introduction to Air Traffic Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLS",
+              "number": "2401",
+              "title": "Career Enhancement",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-rad",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSC",
+              "number": "1085",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085L",
+              "title": "Human Anatomy and Physiology I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086L",
+              "title": "Human Anatomy and Physiology II Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "1105",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "2233",
+              "title": "Applied Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "2311",
+              "title": "Calculus and Analytic Geometry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "2312",
+              "title": "Calculus and Analytic Geometry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "2313",
+              "title": "Calculus and Analytic Geometry III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAP",
+              "number": "2302",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Freshman—Session I",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTE",
+              "number": "1513",
+              "title": "Radiographic Procedures II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "1513L",
+              "title": "Radiographic Procedures II Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "1458",
+              "title": "Radiographic Imaging and Exposure II with Quality Management",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "1458L",
+              "title": "Radiographic Imaging and Exposure II with Quality Management Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "1814",
+              "title": "Radiography Clinical Practicum II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Freshman—Session II",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTE",
+              "number": "1000",
+              "title": "Introduction to Radiologic Science Principles",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "1503",
+              "title": "Radiographic Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "1503L",
+              "title": "Radiographic Procedures I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "1111",
+              "title": "Introduction to Radiographic Patient Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "1111L",
+              "title": "Radiography Patient Care Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Freshman—Session III",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTE",
+              "number": "1804",
+              "title": "Radiography Clinical Practicum I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "1418",
+              "title": "Principles of Radiographic Imaging and Exposure I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "1418L",
+              "title": "Principles of Radiographic Imaging Exposure I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sophomore—Session I",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTE",
+              "number": "1523",
+              "title": "Radiographic Procedures III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "1523L",
+              "title": "Radiographic Procedures III Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "2824",
+              "title": "Radiography Clinical Practicum III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "2782",
+              "title": "Pathology for Radiographers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sophomore—Session II",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTE",
+              "number": "2834",
+              "title": "Radiography Clinical Practicum IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "1630",
+              "title": "Applied Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "2385",
+              "title": "Radiation Biology and Protection",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sophomore—Session III",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTE",
+              "number": "2061",
+              "title": "Radiographic Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTE",
+              "number": "2844",
+              "title": "Radiography Clinical Practicum V",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1012",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Systems Technology, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-nst",
+      "total_credits": 87,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "The following 27 hours apply specifically to the Network Systems Technology/Advanced Network Infrastructure specialization:",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "1020C",
+              "title": "Introduction to Networks (CISCO Academy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1700C",
+              "title": "Switching, Routing, and Wireless Essentials (Cisco Academy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "2211C",
+              "title": "Enterprise Networking, Security and Automation (Cisco Academy - ENSA)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2793",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1401",
+              "title": "Principles of Information Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1145",
+              "title": "Cloud Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "2123",
+              "title": "Network Security and Intrusion Detection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2393",
+              "title": "Network Forensics and Incident Response",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2941",
+              "title": "Information Technology Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2880",
+              "title": "Introduction to Computer Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "The following 27 hours apply specifically to the Network Systems Technology/Cybersecurity specialization:",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "1020C",
+              "title": "Introduction to Networks (CISCO Academy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1700C",
+              "title": "Switching, Routing, and Wireless Essentials (Cisco Academy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2793",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2352",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2354",
+              "title": "Introduction to Cyberwarfare and Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2393",
+              "title": "Network Forensics and Incident Response",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1401",
+              "title": "Principles of Information Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2040",
+              "title": "Programming for Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "2123",
+              "title": "Network Security and Intrusion Detection",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "The following program core of 15 hours applies to all IT degree programs:",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "1179",
+              "title": "Microcomputer Repair Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1110",
+              "title": "Microcomputer Software Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "Introduction to Computer Programming - Python",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "The following 18 hours meet the General Education requirements:",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Maintenance Administration, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/aviation-maintenance-administration",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Core and Specialized Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "1010",
+              "title": "Foundations of Air Transportation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "1210",
+              "title": "Aviation Meteorology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "2441",
+              "title": "Aviation Safety and Human Factors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "2475",
+              "title": "Aviation Maintenance Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social and Human Services, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/as-shs",
+      "total_credits": 132,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - 36 credit hours",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1012",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYG",
+              "number": "2000",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLP",
+              "number": "2140",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEP",
+              "number": "2004",
+              "title": "Lifespan Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1020",
+              "title": "Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYG",
+              "number": "2010",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "1630",
+              "title": "Applied Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Common Core Courses - 24 credit hours",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "1001",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "1302",
+              "title": "Basic Counseling Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2400",
+              "title": "Substance Abuse Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2525",
+              "title": "Issues in Mental Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2200",
+              "title": "Introduction to Group Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "1540",
+              "title": "Principles for Understanding and Working with Families",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2940",
+              "title": "Human Services Internship I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2941",
+              "title": "Human Services Internship II",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Optional: Addiction Certificate Courses - 12 credit hours",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "1431",
+              "title": "Issues in Addiction Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "1450",
+              "title": "Dual Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2420",
+              "title": "Evaluation of Treatment Environments",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2428",
+              "title": "Treatment & Resources in Substance Abuse",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Freshman—Session I",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "1001",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "1302",
+              "title": "Basic Counseling Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1012",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Freshman—Session II",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "2525",
+              "title": "Issues in Mental Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYG",
+              "number": "2000",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLP",
+              "number": "2140",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sophomore—Session I",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "2400",
+              "title": "Substance Abuse Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEP",
+              "number": "2004",
+              "title": "Lifespan Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1020",
+              "title": "Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "1540",
+              "title": "Principles for Understanding and Working with Families",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2200",
+              "title": "Introduction to Group Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2940",
+              "title": "Human Services Internship I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sophomore—Session II",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SYG",
+              "number": "2010",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2941",
+              "title": "Human Services Internship II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "1630",
+              "title": "Applied Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Vehicles Systems Operation, Associate in Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/as/unmanned-vehicle-systems-operations",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "History of the United States II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "2041",
+              "title": "American Federal Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Core Courses",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "1210",
+              "title": "Aviation Meteorology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "1560",
+              "title": "Introduction to Unmanned Vehicle Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EOC",
+              "number": "1660",
+              "title": "Introduction to Unmanned Maritime Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "1563",
+              "title": "Unmanned Aerial System Applications in Aerial Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2561",
+              "title": "Advanced Unmanned Vehicle Systems Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2564",
+              "title": "Unmanned Vehicles Systems Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2949",
+              "title": "Unmanned Vehicle Systems Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "1100",
+              "title": "Pilot Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "2441",
+              "title": "Aviation Safety and Human Factors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EET",
+              "number": "1084",
+              "title": "Introduction to Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETS",
+              "number": "1511",
+              "title": "Motors and Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETS",
+              "number": "1542",
+              "title": "Introduction to Programmable Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "2030",
+              "title": "Fundamentals of Remote Sensing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "2040",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "1566",
+              "title": "Unmanned Vehicle System Mission Planning",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician―Applied Technology Diploma",
+      "credential": "diploma",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/atd/atd-emt",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSC",
+              "number": "2531",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Course Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "1119",
+              "title": "Emergency Medical Technology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1119L",
+              "title": "Emergency Medical Technology Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "1431",
+              "title": "Emergency Medical Technology Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Bachelor of Science, Bachelor of Science in Nursing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/bachelor-of-science/bs-nur",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Core Courses",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "3065C",
+              "title": "Examination and Assessment",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "3119",
+              "title": "Nursing Theoretical Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "3655",
+              "title": "Cultural Health Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "3895",
+              "title": "Teaching and Learning for the Healthcare Professional",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "4128",
+              "title": "Pathology/Pharmacology Principles for Nursing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "3826",
+              "title": "Legal and Ethical Issues in Nursing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "4837",
+              "title": "Health Care Policy and Economics in Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "4164",
+              "title": "Nursing Research and Informatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "4827",
+              "title": "Principles of Leadership and Management in Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "4636C",
+              "title": "Community Nursing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "4945C",
+              "title": "Nursing Capstone Experience",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Bachelor of Applied Science in Supervision and Management",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/bas/bas-sm",
+      "total_credits": 141,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Core Courses (21 credit hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAN",
+              "number": "3353",
+              "title": "Management Theory and Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "3213",
+              "title": "Advanced Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUL",
+              "number": "3310",
+              "title": "Legal and Ethical Environment in Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "3400",
+              "title": "Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "4011",
+              "title": "Management Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "4301",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "4891",
+              "title": "Strategic Management and Decision Making",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Organizational Administration Concentration (21 credit hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LDR",
+              "number": "3115",
+              "title": "Contemporary Issues in Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "3240",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "3803",
+              "title": "Marketing for Managers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "4004",
+              "title": "Entrepreneurship and Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "4356",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "4900",
+              "title": "Capstone Project in Supervision and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "4930",
+              "title": "Selected Topics in Supervision and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "4940",
+              "title": "Business Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Public Safety/Public Service Concentration (21 credit hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PAD",
+              "number": "3820",
+              "title": "Foundations of Public Safety Administrations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "3034",
+              "title": "Policy Development and Implementation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "3874",
+              "title": "Community Relations Theory and Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSC",
+              "number": "4214",
+              "title": "Emergency Planning and Response",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "4223",
+              "title": "Public Budgeting and Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "4232",
+              "title": "Grant Administration and Resource Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "4930",
+              "title": "Selected Topics in Public Safety Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "4940",
+              "title": "Business Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Cybersecurity Management Concentration (21 credit hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "3407",
+              "title": "Introduction to C++ Programming for Managers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "3771",
+              "title": "Cybersecurity Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "4781",
+              "title": "Cybersecurity in Business and Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "4782",
+              "title": "Cybersecurity in Government Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "4361",
+              "title": "Prevention and Protection Strategies in Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISM",
+              "number": "4324",
+              "title": "Cybersecurity Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "4930",
+              "title": "Selected Topics in Supervision and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "4940",
+              "title": "Business Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Health Care Management Concentration (21 credit hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSA",
+              "number": "3110",
+              "title": "Health Care Organization and Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSA",
+              "number": "3111",
+              "title": "Health Care Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSA",
+              "number": "3422",
+              "title": "Regulation and Compliance in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSA",
+              "number": "4383",
+              "title": "Quality Management in Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSA",
+              "number": "4430",
+              "title": "Health Care Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSA",
+              "number": "4502",
+              "title": "Health Care Risk Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "4930",
+              "title": "Selected Topics in Supervision and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "4940",
+              "title": "Business Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Aviation Administration Concentration (21 credit hours)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "3030",
+              "title": "Principles of Aeronautical Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "3133",
+              "title": "Aviation Logistics Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "3671",
+              "title": "Safety Management Systems and Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "4150",
+              "title": "Aviation Business Strategy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "4460",
+              "title": "Environmental Issues for Aeronautical Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "4675",
+              "title": "Aviation Safety Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "4930",
+              "title": "Selected Topics in Supervision and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "4940",
+              "title": "Business Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Corrections Basic Recruit Training for Special Operations Recruits-Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-cso",
+      "total_credits": 7,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJK",
+              "number": "0300",
+              "title": "Introduction to Corrections",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0305",
+              "title": "Communications",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0310",
+              "title": "Officer Safety",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0315",
+              "title": "Facility and Equipment",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0320",
+              "title": "Intake and Release",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0325",
+              "title": "Supervising in a Correctional Facility",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0330",
+              "title": "Supervising Special Populations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0335",
+              "title": "Responding to Incidents and Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0032",
+              "title": "First Aid for Criminal Justice Officers Proficiency",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0041",
+              "title": "Criminal Justice Firearms Proficiency",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0052",
+              "title": "Criminal Justice Defensive Tactics Proficiency",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Educator Preparation Institute (EPI) Certificate",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/institutional-credit-certificate/educator-preparation-institute-epi-certificate",
+      "total_credits": 84,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EPI",
+              "number": "0001",
+              "title": "Classroom Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0002",
+              "title": "Instructional Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0003",
+              "title": "Educational Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0004",
+              "title": "Teaching and Learning Process",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0010",
+              "title": "Foundations of Research-Based Practices in Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0020",
+              "title": "Professional Foundations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0030",
+              "title": "Diversity in the Classroom",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0945",
+              "title": "Field Experience I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0940",
+              "title": "Field Experience II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EPI",
+              "number": "0001",
+              "title": "Classroom Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0002",
+              "title": "Instructional Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0003",
+              "title": "Educational Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0004",
+              "title": "Teaching and Learning Process",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0010",
+              "title": "Foundations of Research-Based Practices in Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0011",
+              "title": "Foundations of Assessment and Differentiated Instruction in Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0020",
+              "title": "Professional Foundations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0030",
+              "title": "Diversity in the Classroom",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0945",
+              "title": "Field Experience I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0940",
+              "title": "Field Experience II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EPI",
+              "number": "0001",
+              "title": "Classroom Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0002",
+              "title": "Instructional Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0003",
+              "title": "Educational Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0004",
+              "title": "Teaching and Learning Process",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0010",
+              "title": "Foundations of Research-Based Practices in Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0011",
+              "title": "Foundations of Assessment and Differentiated Instruction in Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0014",
+              "title": "Demonstration of Accomplishment in Reading",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0020",
+              "title": "Professional Foundations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0030",
+              "title": "Diversity in the Classroom",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0945",
+              "title": "Field Experience I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPI",
+              "number": "0940",
+              "title": "Field Experience II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Crossover from Correctional Officer to Law Enforcement Officer―Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-ctl",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJK",
+              "number": "0002",
+              "title": "Introduction to Law Enforcement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0018",
+              "title": "Legal",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0019",
+              "title": "Interviewing and Report Writing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0020",
+              "title": "Law Enforcement Vehicle Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0063",
+              "title": "Fundamentals of Patrol",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0403",
+              "title": "DUI Traffic Stops",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0401",
+              "title": "Traffic Stops",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0402",
+              "title": "Traffic Crash Investigations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0093",
+              "title": "Critical Incidents",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0393",
+              "title": "Crossover Program Updates",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0421",
+              "title": "Conducted Electrical Weapon/Dart-Firing Stun Gun",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0016",
+              "title": "Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0021",
+              "title": "Serving Your Community",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0072",
+              "title": "Crimes Against Persons",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0073",
+              "title": "Crimes Against Property and Society",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0079",
+              "title": "Crime Scene Follow-up Investigations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0400",
+              "title": "Traffic Incidents",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Dental Assisting-Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-da",
+      "total_credits": 41,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisite Requirements:",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician / Firefighter-Combined - Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-femt",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Session I",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "0110",
+              "title": "Emergency Medical Technician",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Session II",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FFP",
+              "number": "0030",
+              "title": "Firefighter Part I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FFP",
+              "number": "0031",
+              "title": "Firefighter Part II",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Academy - Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-ff",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FFP",
+              "number": "0030",
+              "title": "Firefighter Part I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FFP",
+              "number": "0031",
+              "title": "Firefighter Part II",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Law Enforcement Basic Training for Special Operations Forces Recruits - Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-lso",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJK",
+              "number": "0002",
+              "title": "Introduction to Law Enforcement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0018",
+              "title": "Legal",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0019",
+              "title": "Interviewing and Report Writing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0063",
+              "title": "Fundamentals of Patrol",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0401",
+              "title": "Traffic Stops",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0403",
+              "title": "DUI Traffic Stops",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0402",
+              "title": "Traffic Crash Investigations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0020",
+              "title": "Law Enforcement Vehicle Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0421",
+              "title": "Conducted Electrical Weapon/Dart-Firing Stun Gun",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0032",
+              "title": "First Aid for Criminal Justice Officers Proficiency",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0041",
+              "title": "Criminal Justice Firearms Proficiency",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0052",
+              "title": "Criminal Justice Defensive Tactics Proficiency",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0016",
+              "title": "Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0021",
+              "title": "Serving Your Community",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0072",
+              "title": "Crimes Against Persons",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0073",
+              "title": "Crimes Against Property and Society",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0079",
+              "title": "Crime Scene Follow-up Investigations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0400",
+              "title": "Traffic Incidents",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Auxiliary Law Enforcement Officer―Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-lea",
+      "total_credits": 6,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJK",
+              "number": "0020",
+              "title": "Law Enforcement Vehicle Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0023",
+              "title": "Introduction to Law Enforcement (Auxiliary)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0024",
+              "title": "Legal Concepts",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0025",
+              "title": "Patrol and Professional Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0026",
+              "title": "Interactions in a Diverse Community (Auxiliary)",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0027",
+              "title": "Calls for Service and Arrest Procedures",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0028",
+              "title": "Traffic Stops and Crash Investigations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0029",
+              "title": "Crime Scene and Courtroom Procedures",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0031",
+              "title": "First Aid for Criminal Justice Officers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0040",
+              "title": "Criminal Justice Firearms",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0421",
+              "title": "Conducted Electrical Weapon/Dart-Firing Stun Gun",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0051",
+              "title": "Criminal Justice Defensive Tactics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Florida Law Enforcement Academy―Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-leb",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJK",
+              "number": "0002",
+              "title": "Introduction to Law Enforcement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0018",
+              "title": "Legal",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0019",
+              "title": "Interviewing and Report Writing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0020",
+              "title": "Law Enforcement Vehicle Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0031",
+              "title": "First Aid for Criminal Justice Officers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0040",
+              "title": "Criminal Justice Firearms",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0051",
+              "title": "Criminal Justice Defensive Tactics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0063",
+              "title": "Fundamentals of Patrol",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0401",
+              "title": "Traffic Stops",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0403",
+              "title": "DUI Traffic Stops",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0402",
+              "title": "Traffic Crash Investigations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0093",
+              "title": "Critical Incidents",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0096",
+              "title": "Criminal Justice Officer Physical Fitness Training (Law Enforcement)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0421",
+              "title": "Conducted Electrical Weapon/Dart-Firing Stun Gun",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0016",
+              "title": "Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0021",
+              "title": "Serving Your Community",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0072",
+              "title": "Crimes Against Persons",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0073",
+              "title": "Crimes Against Property and Society",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0079",
+              "title": "Crime Scene Follow-up Investigations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0400",
+              "title": "Traffic Incidents",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Crossover from Law Enforcement Officer to Correctional Officer-Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-ltc",
+      "total_credits": 3,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJK",
+              "number": "0300",
+              "title": "Introduction to Corrections",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0305",
+              "title": "Communications",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0310",
+              "title": "Officer Safety",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0315",
+              "title": "Facility and Equipment",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0320",
+              "title": "Intake and Release",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0325",
+              "title": "Supervising in a Correctional Facility",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0330",
+              "title": "Supervising Special Populations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0335",
+              "title": "Responding to Incidents and Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0393",
+              "title": "Crossover Program Updates",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Medical Assistant - Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-ma",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Session 1, Term A",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSC",
+              "number": "0530",
+              "title": "Medical Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "0003",
+              "title": "Introduction to Health Occupations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "0450",
+              "title": "Fundamentals of Body Structures and Functions",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Session 1, Term B",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "0434",
+              "title": "Fundamentals of Disease Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CVT",
+              "number": "0507",
+              "title": "Basic Arrhythmias",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "0530",
+              "title": "Pharmacology for Medical Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Session 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEA",
+              "number": "0002",
+              "title": "Medical Assisting Procedures Theory",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "0002L",
+              "title": "Medical Assisting Procedures Laboratory",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Session 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEA",
+              "number": "0204",
+              "title": "Medical Assisting Clinical",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy-Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-phlb",
+      "total_credits": 5,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HCP",
+              "number": "0731",
+              "title": "Phlebotomy Theory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCP",
+              "number": "0731L",
+              "title": "Phlebotomy Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCP",
+              "number": "0742",
+              "title": "Phlebotomy Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing-Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-pn",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PRN",
+              "number": "0000",
+              "title": "Fundamentals of Nursing/PN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0000L",
+              "title": "Fundamentals of Nursing Clinical/PN",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0080",
+              "title": "Body Structure and Function",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0030",
+              "title": "Medication Administration/Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0002",
+              "title": "Fundamentals of Nursing II/PN",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0002L",
+              "title": "Fundamentals of Nursing II Clinical/PN",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0204",
+              "title": "Medical Surgical Nursing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0204L",
+              "title": "Medical Surgical Nursing I Clinical",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0205",
+              "title": "Medical Surgical Nursing II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0205L",
+              "title": "Medical Surgical Nursing II Clinical",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0500",
+              "title": "Gerontological Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0500L",
+              "title": "Gerontological Nursing Clinical",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0120",
+              "title": "Maternal-Child Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PRN",
+              "number": "0120L",
+              "title": "Maternal Child Nursing Lab/Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Crossover from Correctional Probation Officer to CMS Correctional Basic Recruit Training―Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-ptc",
+      "total_credits": 4,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJK",
+              "number": "0300",
+              "title": "Introduction to Corrections",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0310",
+              "title": "Officer Safety",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0315",
+              "title": "Facility and Equipment",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0320",
+              "title": "Intake and Release",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0325",
+              "title": "Supervising in a Correctional Facility",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0330",
+              "title": "Supervising Special Populations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0335",
+              "title": "Responding to Incidents and Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0040",
+              "title": "Criminal Justice Firearms",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0393",
+              "title": "Crossover Program Updates",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Crossover from Correctional Probation Officer to Law Enforcement Officer―Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-ptl",
+      "total_credits": 11,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJK",
+              "number": "0018",
+              "title": "Legal",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0020",
+              "title": "Law Enforcement Vehicle Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0040",
+              "title": "Criminal Justice Firearms",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0063",
+              "title": "Fundamentals of Patrol",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0403",
+              "title": "DUI Traffic Stops",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0401",
+              "title": "Traffic Stops",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0402",
+              "title": "Traffic Crash Investigations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0093",
+              "title": "Critical Incidents",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0421",
+              "title": "Conducted Electrical Weapon/Dart-Firing Stun Gun",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0016",
+              "title": "Communications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0021",
+              "title": "Serving Your Community",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0072",
+              "title": "Crimes Against Persons",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0073",
+              "title": "Crimes Against Property and Society",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0079",
+              "title": "Crime Scene Follow-up Investigations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0400",
+              "title": "Traffic Incidents",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0394",
+              "title": "CPO: Cross-over Program Updates",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Surgical Technology―Career Certificate",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-st",
+      "total_credits": 480,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 240,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSC",
+              "number": "0003",
+              "title": "Introduction to Health Occupations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "0530",
+              "title": "Medical Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "0450",
+              "title": "Fundamentals of Body Structures and Functions",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Session IV - Year 2",
+          "credits_required": 240,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STS",
+              "number": "0141",
+              "title": "Fundamentals of Surgical Technology II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STS",
+              "number": "0160",
+              "title": "Surgical Procedures II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STS",
+              "number": "0256",
+              "title": "Surgical Technology Clinical II",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology-Advanced - Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-wta",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PMT",
+              "number": "0085",
+              "title": "Advanced Welder 1: SMAW Pipe II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMT",
+              "number": "0125",
+              "title": "Advanced Welder 1: SMAW Pipe III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMT",
+              "number": "0075",
+              "title": "Advanced Welder 1: SMAW Pipe I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMT",
+              "number": "0150",
+              "title": "Advanced Welder 1: GTAW Pipe I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMT",
+              "number": "0151",
+              "title": "Advanced Welder 1: GTAW Pipe II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMT",
+              "number": "0172",
+              "title": "Advanced Welder 1: GTAW Pipe/SMAW Pipe 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMT",
+              "number": "0076",
+              "title": "Advanced Welder 2: Career Preparation I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMT",
+              "number": "0086",
+              "title": "Advanced Welder 2: Career Preparation II",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Correctional Officer (BRTP)―Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/psvc-co",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJK",
+              "number": "0300",
+              "title": "Introduction to Corrections",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0305",
+              "title": "Communications",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0310",
+              "title": "Officer Safety",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0315",
+              "title": "Facility and Equipment",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0320",
+              "title": "Intake and Release",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0325",
+              "title": "Supervising in a Correctional Facility",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0330",
+              "title": "Supervising Special Populations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0335",
+              "title": "Responding to Incidents and Emergencies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0031",
+              "title": "First Aid for Criminal Justice Officers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0040",
+              "title": "Criminal Justice Firearms",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0051",
+              "title": "Criminal Justice Defensive Tactics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJK",
+              "number": "0340",
+              "title": "Officer Wellness and Physical Abilities",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology - Career Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/psvc/cc-wdt",
+      "total_credits": 34,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PMT",
+              "number": "0090",
+              "title": "Welding I",
+              "credits": 13,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMT",
+              "number": "0091",
+              "title": "Welding II",
+              "credits": 13,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMT",
+              "number": "0092",
+              "title": "Welding III",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Addiction Services - Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-adsc",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "1001",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "1302",
+              "title": "Basic Counseling Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "1431",
+              "title": "Issues in Addiction Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "1450",
+              "title": "Dual Diagnosis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2400",
+              "title": "Substance Abuse Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2420",
+              "title": "Evaluation of Treatment Environments",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2428",
+              "title": "Treatment & Resources in Substance Abuse",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2940",
+              "title": "Human Services Internship I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer-Aided Design Technical―Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-af",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EGN",
+              "number": "2123",
+              "title": "Skills and Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "1100",
+              "title": "Technical Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "1530",
+              "title": "Architectural Drafting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "2320",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "2340",
+              "title": "Computer Aided Drafting II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Artificial Intelligence Awareness - Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-aiaw",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "Introduction to Computer Programming - Python",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automation―Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-am",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1084",
+              "title": "Introduction to Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETS",
+              "number": "1511",
+              "title": "Motors and Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETS",
+              "number": "1542",
+              "title": "Introduction to Programmable Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETM",
+              "number": "2401",
+              "title": "Mechanical Devices and Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Technology Management—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-atm",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACG",
+              "number": "2071",
+              "title": "Principles of Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACG",
+              "number": "2100",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACG",
+              "number": "2450",
+              "title": "Microcomputers in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2852",
+              "title": "Excel for the Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "1630",
+              "title": "Applied Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Accounting Technology Operations—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-ato",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACG",
+              "number": "2071",
+              "title": "Principles of Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACG",
+              "number": "2450",
+              "title": "Microcomputers in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2852",
+              "title": "Excel for the Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting Technology Specialist—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-ats",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACG",
+              "number": "2071",
+              "title": "Principles of Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Computer Programmer―Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-bdp",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "The following 33 credit hours meet the requirements for this certificate:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "1179",
+              "title": "Microcomputer Repair Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1820",
+              "title": "Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "2108",
+              "title": "Advanced Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "Introduction to Computer Programming - Python",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2220",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2071",
+              "title": "Database Programming and SQL",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2801",
+              "title": "JavaScript Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1110",
+              "title": "Microcomputer Software Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Development and Entrepreneurship—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-bde",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "2112",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "1011",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1345",
+              "title": "Principles of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "1630",
+              "title": "Applied Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Operations―Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-bo",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1345",
+              "title": "Principles of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Specialist―Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-bs",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1345",
+              "title": "Principles of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "2112",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Computer Programming Specialist―Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-cps",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1820",
+              "title": "Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "Introduction to Computer Programming - Python",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2220",
+              "title": "C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2071",
+              "title": "Database Programming and SQL",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Crime Scene Technician―Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-cst",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJE",
+              "number": "1640",
+              "title": "Criminalistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1641",
+              "title": "Introduction to Crime Scene Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1643",
+              "title": "Advanced Crime Scene Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1644",
+              "title": "Crime Scene Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1645",
+              "title": "Introduction to Forensic Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1671",
+              "title": "Latent Fingerprint Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "1770",
+              "title": "Crime Scene Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "2608",
+              "title": "Courtroom Presentation of Evidence",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJE",
+              "number": "2950",
+              "title": "Crime Scene Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Security—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-cs",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1110",
+              "title": "Microcomputer Software Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "1020C",
+              "title": "Introduction to Networks (CISCO Academy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1700C",
+              "title": "Switching, Routing, and Wireless Essentials (Cisco Academy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2793",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2354",
+              "title": "Introduction to Cyberwarfare and Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2352",
+              "title": "Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2393",
+              "title": "Network Forensics and Incident Response",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1401",
+              "title": "Principles of Information Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Database and E-Commerce Security—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-decs",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2071",
+              "title": "Database Programming and SQL",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "1179",
+              "title": "Microcomputer Repair Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1110",
+              "title": "Microcomputer Software Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Media / Multimedia Authoring - Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-dma",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIG",
+              "number": "2000",
+              "title": "Introduction to Digital Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2030",
+              "title": "Digital Video Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2109",
+              "title": "Digital Imaging Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2500",
+              "title": "Fundamentals of Interactive Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Media / Multimedia Production - Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-dmp",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIG",
+              "number": "2000",
+              "title": "Introduction to Digital Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2500",
+              "title": "Fundamentals of Interactive Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2030",
+              "title": "Digital Video Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2109",
+              "title": "Digital Imaging Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRA",
+              "number": "1160",
+              "title": "Introduction to Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Technology Support Specialist—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-ets",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1084",
+              "title": "Introduction to Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "2320",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1110",
+              "title": "Introduction to Quality Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1420",
+              "title": "Manufacturing Processes and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1701",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETM",
+              "number": "1010",
+              "title": "Mechanical Measurement & Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Digital Media / Multimedia Video Production - Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-dmvp",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIG",
+              "number": "2030",
+              "title": "Digital Video Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2200",
+              "title": "Basic Video Camera",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2205",
+              "title": "Basic Video Editing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2284",
+              "title": "Advanced Videography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Media / Multimedia Web Production / Graphic Designer - Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-dmwp",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1820",
+              "title": "Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2000",
+              "title": "Introduction to Digital Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2105",
+              "title": "Social Media Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2500",
+              "title": "Fundamentals of Interactive Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIG",
+              "number": "2109",
+              "title": "Digital Imaging Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurship—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-entr",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "2112",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "1011",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Internet of Things Applications—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-iot",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "The following 24 credit hours meet the requirements for this certificate:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "Introduction to Computer Programming - Python",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "1179",
+              "title": "Microcomputer Repair Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1820",
+              "title": "Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2071",
+              "title": "Database Programming and SQL",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1110",
+              "title": "Microcomputer Software Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Marketing Operations—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-mo",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1136",
+              "title": "Introduction to E-Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "1011",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "2502",
+              "title": "Consumer Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKA",
+              "number": "1021",
+              "title": "Principles of Selling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "QMB",
+              "number": "1001",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKA",
+              "number": "2511",
+              "title": "Principles of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Network Infrastructure—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-nic",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "The following 21 credit hours meet the requirements for this certificate:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "1020C",
+              "title": "Introduction to Networks (CISCO Academy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1700C",
+              "title": "Switching, Routing, and Wireless Essentials (Cisco Academy)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "2211C",
+              "title": "Enterprise Networking, Security and Automation (Cisco Academy - ENSA)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1401",
+              "title": "Principles of Information Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Management—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-om",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "1100",
+              "title": "Document Formatting and Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "1764",
+              "title": "Word Processing—Microsoft Word",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1345",
+              "title": "Principles of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2852",
+              "title": "Excel for the Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2356",
+              "title": "Electronic Records Management - MS Access",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Network Support Technician—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-nstc",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "The following 21 credit hours meet the requirement for this certificate:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "1179",
+              "title": "Microcomputer Repair Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1110",
+              "title": "Microcomputer Software Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2793",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1145",
+              "title": "Cloud Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology Administration—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-itad",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "The following 18 hours meet the requirements for this certificate:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "1179",
+              "title": "Microcomputer Repair Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1820",
+              "title": "Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2793",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1110",
+              "title": "Microcomputer Software Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Office Specialist—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-os",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "1100",
+              "title": "Document Formatting and Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "1764",
+              "title": "Word Processing—Microsoft Word",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1345",
+              "title": "Principles of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2852",
+              "title": "Excel for the Office",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic―Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-para",
+      "total_credits": 38,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSC",
+              "number": "2531",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Session I",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "2620",
+              "title": "Paramedics I",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2620L",
+              "title": "Paramedics I Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2621",
+              "title": "Paramedics I Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Session II",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "2622",
+              "title": "Paramedics II",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2622L",
+              "title": "Paramedics II Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2623",
+              "title": "Paramedics Clinical II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Session III",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "2624",
+              "title": "Paramedics III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2624L",
+              "title": "Paramedics III Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "2625",
+              "title": "Paramedic Internship",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Support—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-oss",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "1100",
+              "title": "Document Formatting and Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "1764",
+              "title": "Word Processing—Microsoft Word",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pneumatics, Hydraulics and Motors for Manufacturing―Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-phmm",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1084",
+              "title": "Introduction to Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1420",
+              "title": "Manufacturing Processes and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETM",
+              "number": "2315",
+              "title": "Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETS",
+              "number": "1511",
+              "title": "Motors and Controls",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Real Estate Paralegal-Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-rep",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "1003",
+              "title": "Introduction to Law and Legal Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "1201",
+              "title": "Civil Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLA",
+              "number": "2615",
+              "title": "Real Property Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management―Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-sbm",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2021",
+              "title": "Principles of Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2013",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1136",
+              "title": "Introduction to E-Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNA",
+              "number": "1100",
+              "title": "Interpersonal Behavior in Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Web Development Specialist—Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-wds",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "The following 36 hours meet the requirements for this certificate:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "1179",
+              "title": "Microcomputer Repair Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2520",
+              "title": "Project Management in IT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1820",
+              "title": "Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2793",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2040",
+              "title": "Programming for Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "2827",
+              "title": "Advanced Web Page Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1401",
+              "title": "Principles of Information Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "Introduction to Computer Programming - Python",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2801",
+              "title": "JavaScript Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1110",
+              "title": "Microcomputer Software Essentials",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social and Human Services Assistant―Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/ccc-shsa",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "1001",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "1302",
+              "title": "Basic Counseling Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2400",
+              "title": "Substance Abuse Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2525",
+              "title": "Issues in Mental Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "2940",
+              "title": "Human Services Internship I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1012",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SYG",
+              "number": "2000",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLP",
+              "number": "2140",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics - Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/mechatronics-certificate",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1084",
+              "title": "Introduction to Electronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETD",
+              "number": "2320",
+              "title": "Computer Aided Drafting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1420",
+              "title": "Manufacturing Processes and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1701",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETM",
+              "number": "2315",
+              "title": "Hydraulics and Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETM",
+              "number": "2401",
+              "title": "Mechanical Devices and Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETS",
+              "number": "1511",
+              "title": "Motors and Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETS",
+              "number": "1535",
+              "title": "Automated Process and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETI",
+              "number": "1110",
+              "title": "Introduction to Quality Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETS",
+              "number": "1542",
+              "title": "Introduction to Programmable Logic",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Healthcare Informatics Specialist-Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://phsc.smartcatalogiq.com/en/2023-2024/catalog-and-student-handbook/prog-desc/tc/tc-hcis",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "Microcomputer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "2531",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Code: TC-HCIS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "1005",
+              "title": "Project Management for Health Information Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1102",
+              "title": "Introduction to Healthcare Informatics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2212",
+              "title": "Health Records Data Analysis and Workflow Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1800",
+              "title": "Health Information Technology Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "2652",
+              "title": "Electronic Health Records",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "1110",
+              "title": "Healthcare Delivery Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/scripts/lib/scrape-smartcatalogiq-programs.ts
+++ b/scripts/lib/scrape-smartcatalogiq-programs.ts
@@ -206,6 +206,7 @@ async function discoverProgramPaths(
   baseUrl: string,
   programsRoot: string,
   followSiblingPaths = false,
+  maxPages = Infinity,
 ): Promise<string[]> {
   const visited = new Set<string>();
   const programLinks = new Set<string>();
@@ -219,6 +220,10 @@ async function discoverProgramPaths(
     : programsRoot;
 
   while (queue.length > 0) {
+    // Backstop on broad-BFS fallback runs (see scrapeSmartCatalogIqPrograms) so a
+    // huge catalog can't run forever. Working colleges' primary BFS leaves this
+    // at the default Infinity — same control flow as before.
+    if (visited.size >= maxPages) break;
     const path = queue.shift()!;
     if (visited.has(path)) continue;
     visited.add(path);
@@ -505,8 +510,24 @@ export async function scrapeSmartCatalogIqPrograms(
 
   const programsRoot = `/en/${year}/${catalogPath}/${programsPath}/`;
   console.log(`  [${collegeSlug}] Walking ${programsRoot} for program detail pages...`);
-  const paths = await discoverProgramPaths(baseUrl, programsRoot, config.followSiblingPaths ?? false);
+  let paths = await discoverProgramPaths(baseUrl, programsRoot, config.followSiblingPaths ?? false);
   console.log(`  [${collegeSlug}] Found ${paths.length} program detail pages`);
+
+  // Fallback: some SmartCatalogIQ catalogs (phsc: /academic-programs/ → /prog-desc/)
+  // place program detail pages in a SIBLING URL tree under the catalog root —
+  // outside the configured programsPath, so the primary BFS finds nothing.
+  // When that happens, walk the broader catalog root (/en/{year}/{catalogPath}/)
+  // with a hard page cap so a huge catalog can't run away. Page-detail gate is
+  // unchanged (<h1 class="degreeTitle">), so this only adds reach, never noise.
+  // Working catalogs never enter this branch — the primary BFS always finds >0.
+  if (paths.length === 0) {
+    const catalogRoot = `/en/${year}/${catalogPath}/`;
+    console.log(
+      `  [${collegeSlug}] No programs at ${programsRoot}; falling back to broader BFS at ${catalogRoot} (cap 500)`,
+    );
+    paths = await discoverProgramPaths(baseUrl, catalogRoot, false, 500);
+    console.log(`  [${collegeSlug}] Fallback found ${paths.length} program detail pages`);
+  }
 
   if (paths.length === 0) {
     return {


### PR DESCRIPTION
## What changes for someone using the site

**Pasco-Hernando State College (FL) now has 70 plannable degree programs** in the Degree-Path Planner where it previously had zero — including Crime Scene/Forensic Science Technology (26 required courses), Accounting Technology (19), Computer Programming and Analysis, Dental Hygiene, Cyber and IT Security, and 65 others. phsc joins 13 other FL colleges with a renderable planner; Florida's planner coverage is now **14 plannable colleges, 1,255 plannable programs**.

phsc serves ~25k students across five Pasco/Hernando County campuses. This was the last FL college flagged in the program-rollout DEFERRED list.

## What landed technically

phsc's SmartCatalogIQ catalog lays programs out *unusually*: 17 category pages under `/academic-programs/` (Associate in Science, College Credit Certificates, etc.) — but each category page links to programs in a **sibling URL tree** at `/prog-desc/{level}/{slug}`, not as children of `/academic-programs/`. The shared walker (`scripts/lib/scrape-smartcatalogiq-programs.ts`, used across FL/NC/IL/MA/MI/GA/TX) requires every discovered link to `startsWith(programsRoot)` — so the sibling tree was invisible to it and phsc returned 0 programs every scrape attempt.

Two surgical edits:

1. `discoverProgramPaths` gains an optional `maxPages` arg (default `Infinity`) — used only by the fallback path so a runaway catalog can't BFS forever. Working colleges' primary call passes no cap and runs unchanged.
2. After the primary BFS at `/en/{year}/{catalogPath}/{programsPath}/` returns zero program detail pages, fall back to a broader BFS rooted at `/en/{year}/{catalogPath}/` (one level up), page-capped at 500. Same `<h1 class="degreeTitle">` detection gate; same 80ms sleep between fetches.

The fallback is **regression-safe by construction**: working catalogs always find ≥1 program-detail page at the primary root, so they never enter the fallback. Verified empirically — re-scraped daytonastate (108 plannable), irsc (143), and bladen (86) with the new code; counts identical to baseline, no "Fallback found" log line in any of them. Their re-scraped JSONs are intentionally **not staged** here to keep the diff tight (per the goal's "commit only verified gains" discipline — the metric that matters, plannable count, didn't change).

## Honest gaps (named, not hidden)

The original DEFERRED notes lumped 6 colleges under "deeper walk needed". A grounded sweep showed 5 of them have **unrelated** problems and are explicitly **out of scope**:

| College | Why excluded |
|---|---|
| nc/mayland | Newest catalog is 2020-2021 (5 yrs stale) — `caldwell-skip` precedent says don't ship 5-year-old requirements |
| nc/lenoir, nc/western-piedmont | No `/en/YYYY/` edition path at catalog root — a different discovery problem needing fresh investigation |
| il/moraine-valley | Has 2025-2026 catalog but no program-area links visible from the edition root — needs a structural probe before any fix |
| il/triton | Walker already finds 174 program detail pages; the **page parser** skips all of them. That's a parser issue, not a walker issue — separate PR |

phsc's catalog is itself at the 2023-2024 edition (no 2025-2026 published by phsc). The data is current with what phsc publishes — and the daytonastate precedent ships 2019-2020 data, so shipping 2023-2024 is unambiguously fine.

## Files

- `scripts/lib/scrape-smartcatalogiq-programs.ts` — the walker fallback (+22 / −1)
- `data/fl/programs/phsc.json` — new, 86 programs (70 plannable)
- `data/fl/DEFERRED-programs.md` — moved phsc from "deferred" to "shipped"; FL totals updated; struck the "deeper walk needed" framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
