### PR TITLE
account: alphabetize default-state dropdown (A→Z)

### DIFF
--- a/app/account/AccountDashboard.tsx
+++ b/app/account/AccountDashboard.tsx
@@ -159,7 +159,7 @@ export default function AccountDashboard({
   const [transfers, setTransfers] = useState(initialTransfers);
   const [plans, setPlans] = useState(initialPlans);
 
-  const states = getAllStates();
+  const states = [...getAllStates()].sort((a, b) => a.name.localeCompare(b.name));
 
   const schedulesGrouped = useMemo(() => groupByState(schedules), [schedules]);
   const coursesGrouped = useMemo(() => groupByState(courses), [courses]);


### PR DESCRIPTION
## What changes for someone using the site

On the **My Account** page, the "Default state" dropdown now lists states in alphabetical order — Alabama, Alaska, Arizona… ending Wyoming — instead of registration order (Virginia, NC, SC, DC, …). With 51 entries the list was slow to scan; alphabetical matches the obvious convention. **"None" stays pinned at the top**, and the currently-selected state still appears checked when the page loads.

No other state list on the site changes. The homepage state grid, `/colleges`, and the sitemaps already sorted independently at their own call sites and are untouched.

## Technical

One-line change in `app/account/AccountDashboard.tsx:162`:

```diff
-  const states = getAllStates();
+  const states = [...getAllStates()].sort((a, b) => a.name.localeCompare(b.name));
```

- Wraps the registry list in a spread + `localeCompare` sort. This matches the existing pattern at `app/page.tsx:55` and `app/page.tsx:287`.
- The **spread is required**: `getAllStates()` returns the shared `ALL_CONFIGS` reference (`lib/states/registry.ts:272-274`); mutating it would reorder every other caller (sitemaps, `[state]` pages, etc.).
- `getAllStates()` itself is **not** modified — many callers iterate the registry in its declared order.
- `<option value="">None</option>` sits outside the `.map` so it remains the first option regardless of the sort.

## Verification

- `npm run lint` → 0 errors (287 pre-existing warnings in unrelated scraper scripts).
- `npm run build` → clean build, no typecheck regression.
- Direct unit check via `tsx`: sorted output is 51 entries, strictly sorted Alabama → Wyoming, includes Virginia, and the original `getAllStates()` array is not mutated.

**Gap (named, post-merge):** the visible dropdown lives behind auth on `/account`. I verified the sort logic directly and confirmed build/lint pass, but I did not click through `/account` with a signed-in session locally (would require seeding Supabase auth state in the worktree). Once this merges, a 30-second prod check on https://communitycollegepath.com/account confirms the rendered list.

## Out of scope

Other raw `getAllStates()` callers I noticed but did NOT audit:
- `app/about/page.tsx:13`
- `app/[state]/page.tsx:456`
- `components/blog/ProductCallout.tsx:4`

They may or may not need the same sort; this PR doesn't touch them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)