### PR TITLE
md: fix RawCourse undefined breaking next build after #1193

### DIFF
--- a/scripts/md/scrape-jenzabar.ts
+++ b/scripts/md/scrape-jenzabar.ts
@@ -335,7 +335,23 @@ async function scrapeJenzabar(
         .replace(/&nbsp;/g, " ")
         .replace(/\s+/g, " ")
         .trim();
-    const allCourseData: RawCourse[] = [];
+    // Inline anonymous type — matches the shape of the main page.evaluate
+    // call's `rows` declaration below. `RawCourse` was used in an earlier
+    // draft of this branch but never defined at file scope, which broke
+    // `next build` after #1193 merged.
+    const allCourseData: {
+      title: string;
+      prefix: string;
+      number: string;
+      crn: string;
+      credits: string;
+      days: string;
+      times: string;
+      location: string;
+      campus: string;
+      instructor: string;
+      seats: string;
+    }[] = [];
     for (const row of allRows) {
       const codeRaw = stripTags(row.courseCode);
       // codeRaw looks like "ACC 101 01" with extra spaces collapsed


### PR DESCRIPTION
## What changes for someone using the site

**This unblocks the prod build.** PR #1193 merged successfully and the data import ran (Supabase now has all 16/16 MD colleges' courses), but the Vercel rebuild failed on a TypeScript error introduced by my cecil REST-API short-circuit. Without this fix, prod is serving the stale pre-#1193 build (13 MD colleges, not 16). With this fix, Vercel can rebuild and serve the new data.

## What landed

One line. The cecil API code path in `scripts/md/scrape-jenzabar.ts` declared `const allCourseData: RawCourse[] = []`, but `RawCourse` was never defined at file scope (the rest of the file uses anonymous inline types). `eslint` didn't catch it; `next build`'s typecheck did. Replaced with the same anonymous inline shape used at the main `page.evaluate` site below.

## Verification

- `npm run build` locally → completes through typecheck, no errors.
- Verified by inspecting the rendered route list (all sitemap routes + dynamic routes generated).
- No data files touched; this is a code-only build fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)