### PR TITLE
programs: fix Acalog parser regex → surry (NC) + mott (MI) plannable

### DIFF
--- a/data/mi/DEFERRED-programs.md
+++ b/data/mi/DEFERRED-programs.md
@@ -3,8 +3,8 @@
 Programs rollout for Michigan. Catalog platform fingerprinted by
 `scripts/mi/discover-catalogs.ts` → `data/mi/catalog-discovery.json`.
 
-## Shipped — 9 colleges scraped (667 programs); **498 plannable across 7 colleges**
-Live-planner verified: delta 134, schoolcraft 122, lansing 96, north-central 56,
+## Shipped — 9 colleges scraped (667 programs); **590 plannable across 8 colleges**
+Live-planner verified: delta 134, schoolcraft 122, mott 92, lansing 96, north-central 56,
 montcalm 49, st-clair 37, oakland 4.
 
 | Platform | Colleges |
@@ -14,8 +14,10 @@ montcalm 49, st-clair 37, oakland 4.
 | CourseDog | muskegon-community-college |
 
 ## Deferred / incomplete
-- **mott-community-college (Acalog) — 0 plannable** despite 99 programs: links courses
-  instead of inlining codes (same as NC gaston/guilford/surry; needs preview_course follow).
+- **mott-community-college (Acalog) — RESOLVED 2026-06-04 (0 → 92 plannable).** mott's
+  codes are inline aria-labels with a hyphen-no-space separator (`ACCT-101`); the
+  `parseCourseFromLabel` regex fix (optional hyphen between prefix and number) recovers
+  them. The earlier "links courses / needs preview_course follow" diagnosis was wrong.
 - **oakland (CourseLeaf, 8) / muskegon (CourseDog, 4)** — low yield; index/tenant variants.
 - **glen-oaks, jackson (CourseDog) — 0** via shared lib.
 - **5 unknown-platform** (macomb, mid-michigan, southwestern, washtenaw, + others):

--- a/data/mi/programs/mott-community-college.json
+++ b/data/mi/programs/mott-community-college.json
@@ -2,7 +2,7 @@
   "college_slug": "mott-community-college",
   "catalog_year": "",
   "catalog_url": "https://catalog.mcc.edu",
-  "scraped_at": "2026-06-01T04:02:15.566Z",
+  "scraped_at": "2026-06-05T00:42:14.694Z",
   "programs": [
     {
       "title": "General Education Requirements",
@@ -14,14 +14,1183 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Composition GenEd (CMP)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities GenEd (HUM)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARBC",
+              "number": "111",
+              "title": "Beginning Standard Arabic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARBC",
+              "number": "112",
+              "title": "Beginning Standard Arabic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "140",
+              "title": "Principles of Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "200",
+              "title": "Survey of Human Communication Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "210",
+              "title": "Persuasion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "220",
+              "title": "Intercultural Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "231",
+              "title": "Discussion Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "233",
+              "title": "Oral Interpretation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "210",
+              "title": "Childrens Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "220",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "221",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "222",
+              "title": "Science Fiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "223",
+              "title": "Black American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "225",
+              "title": "Poetry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "227",
+              "title": "Fiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "230",
+              "title": "Women&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "231",
+              "title": "American Literature to 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "232",
+              "title": "American Literature 1865 to present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "242",
+              "title": "British &amp; Irish Literature 1798 to Present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "181",
+              "title": "Introduction to Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "151",
+              "title": "Elementary French",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "152",
+              "title": "Elementary French II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "251",
+              "title": "Intermediate French",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "252",
+              "title": "Intermediate French II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GERM",
+              "number": "111",
+              "title": "Elementary German",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GERM",
+              "number": "112",
+              "title": "Beginning German",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GERM",
+              "number": "211",
+              "title": "Intermediate German I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GERM",
+              "number": "212",
+              "title": "Intermediate German II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JAPA",
+              "number": "111",
+              "title": "Beginning Japanese",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JAPA",
+              "number": "112",
+              "title": "Beginning Japanese II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JAPA",
+              "number": "211",
+              "title": "Intermediate Japanese",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JAPA",
+              "number": "212",
+              "title": "Intermediate Japanese II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "165",
+              "title": "Philosophy of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "190",
+              "title": "Introduction to Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "195",
+              "title": "Contemporary Moral Issues",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "251",
+              "title": "Religious Worldviews",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "271",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "295",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "297",
+              "title": "Political Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RUSN",
+              "number": "111",
+              "title": "Beginning Russian",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RUSN",
+              "number": "112",
+              "title": "Beginning Russian II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "181",
+              "title": "Elementary Spanish",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "182",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "279",
+              "title": "Spanish Conversation &amp; Culture Through Immersion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "281",
+              "title": "Intermediate Spanish",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "282",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "110",
+              "title": "Theatre Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics GenEd (MTH)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Beginning and Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "140",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "145",
+              "title": "Pre-Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "150",
+              "title": "Probability and Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "165",
+              "title": "Applied Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Analytic Geometry &amp; Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "180",
+              "title": "Analytic Geometry &amp; Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "210",
+              "title": "Math for Elementary Teachers I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "220",
+              "title": "Math for Elementary Teachers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "250",
+              "title": "Multivariable Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "270",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "280",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Science/Math (NSM) or Natural Science Lab GenEd (NSL)",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ASTR",
+              "number": "117",
+              "title": "The Solar System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASTR",
+              "number": "118",
+              "title": "Stellar Astronomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "107",
+              "title": "General Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "111",
+              "title": "Fundamentals of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "112",
+              "title": "Diversity of Life",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "115",
+              "title": "Applied Botany",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "120",
+              "title": "Introduction to Environmental Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "121",
+              "title": "Environmental Science Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "150",
+              "title": "The Human Body",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "156",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "205",
+              "title": "Michigan Wildflowers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "206",
+              "title": "Local Trees and Shrubs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "207",
+              "title": "Aquatic Ecosystems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "Molecular Biotechnology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "220",
+              "title": "Ecology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "222",
+              "title": "Field Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "279",
+              "title": "International Ecology and Conservation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "Fundamentals of Inorganic Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "Fundamentals of Organic &amp; Biochemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "118",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "This course does not have a lab.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "120",
+              "title": "Introduction to Forensic Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "123",
+              "title": "Fundamentals of Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "131",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "132",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "237",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "238",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "151",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOL",
+              "number": "152",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "191",
+              "title": "Physical Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSC",
+              "number": "192",
+              "title": "Earth Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "281",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "282",
+              "title": "General College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "287",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "288",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STEM",
+              "number": "199",
+              "title": "Undergraduate Research Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STEM",
+              "number": "201",
+              "title": "Undergraduate Research Methods II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science GenEd (SOC)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "200",
+              "title": "Peoples and Cultures of Africa",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "210",
+              "title": "Forensic Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "211",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "212",
+              "title": "Human Origins - Intro Phys. Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "213",
+              "title": "Introduction to Archaeology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "125",
+              "title": "Personal Money Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "221",
+              "title": "Principles of Economics (Macroeconomics)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "222",
+              "title": "Principles of Economics (Microeconomics)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "100",
+              "title": "Survey of Forensic Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "141",
+              "title": "Physical Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "142",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "143",
+              "title": "Intro to Geographic Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "145",
+              "title": "Economic Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "251",
+              "title": "Crime Mapping",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "151",
+              "title": "World History: Prehistory to 1500 C.E.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "152",
+              "title": "World History: 1500 C.E. To the Present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "154",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "155",
+              "title": "History of United States: 1877 - Present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "212",
+              "title": "History of E Asia to 1600",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "213",
+              "title": "History of E Asia 1600 to Present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "254",
+              "title": "African American History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "255",
+              "title": "African American History Since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "257",
+              "title": "History of the Holocaust",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "260",
+              "title": "History of Michigan",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "261",
+              "title": "United States Labor History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "262",
+              "title": "American Military History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "263",
+              "title": "History of Women in the United States",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "264",
+              "title": "Medieval Europe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "266",
+              "title": "History of the Modern Middle East",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDDV",
+              "number": "101",
+              "title": "Leadership Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSCN",
+              "number": "170",
+              "title": "Introduction to American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSCN",
+              "number": "173",
+              "title": "State and Local Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSCN",
+              "number": "175",
+              "title": "Civil Liberties",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSCN",
+              "number": "275",
+              "title": "Comparative Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "181",
+              "title": "Applied Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "184",
+              "title": "Exceptional People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "280",
+              "title": "General Psychology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "282",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "283",
+              "title": "Theories of Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "285",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "286",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "287",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "289",
+              "title": "Psychology of Late Adulthood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "290",
+              "title": "Psychology of Adolescence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "291",
+              "title": "Psychology of Human Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "193",
+              "title": "Marriage and the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "194",
+              "title": "Fundamentals of Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "292",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "294",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "296",
+              "title": "Urban Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "297",
+              "title": "Introduction to Criminology Correction",
               "credits": null,
               "or_alternatives": []
             }
@@ -29,54 +1198,6 @@
         }
       ],
       "matched_program_slug": null
-    },
-    {
-      "title": "Associate in General Studies",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2155",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities and Fine Arts (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Social Science (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Additional Associate in General Studies Degree Requirements (44 credits)",
-          "credits_required": 44,
-          "choose_n": null,
-          "courses": []
-        }
-      ],
-      "matched_program_slug": "liberal-arts"
     },
     {
       "title": "Associate in Fine Arts, Studio Art Option",
@@ -91,7 +1212,22 @@
           "name": "English Composition (6 credits)",
           "credits_required": 6,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (6 credits)",
@@ -99,9 +1235,23 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "140",
+              "title": "Principles of Interpersonal Communication",
               "credits": null,
               "or_alternatives": []
             }
@@ -124,6 +1274,20 @@
           "credits_required": 8,
           "choose_n": null,
           "courses": []
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DESN",
+              "number": "115",
+              "title": "Intro to Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         }
       ],
       "matched_program_slug": "art"
@@ -141,7 +1305,71 @@
           "name": "Writing and Communication (9 credits)",
           "credits_required": 9,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "140",
+              "title": "Principles of Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "200",
+              "title": "Survey of Human Communication Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "210",
+              "title": "Persuasion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "220",
+              "title": "Intercultural Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (9-11 credits)",
@@ -168,6 +1396,13 @@
               "or_alternatives": []
             },
             {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Statistics Pathway",
@@ -175,9 +1410,37 @@
               "or_alternatives": []
             },
             {
+              "prefix": "MATH",
+              "number": "150",
+              "title": "Probability and Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "STEM Pathway",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "145",
+              "title": "Pre-Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "170",
+              "title": "Analytic Geometry &amp; Calculus I",
               "credits": null,
               "or_alternatives": []
             }
@@ -199,70 +1462,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Accounting, A.A.S.",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2158",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "or",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        },
-        {
-          "name": "Social Science (4 credits)",
-          "credits_required": 4,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Additional General Education Credits to Fulfill General Education Requirements",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "or",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "accounting"
-    },
-    {
       "title": "Associate in Fine Arts, Music Option",
       "credential": "AA",
       "program_code": null,
@@ -275,7 +1474,22 @@
           "name": "English Composition (6 credits)",
           "credits_required": 6,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (7 credits)",
@@ -297,9 +1511,9 @@
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "or",
+              "prefix": "SPAN",
+              "number": "181",
+              "title": "Elementary Spanish",
               "credits": null,
               "or_alternatives": []
             },
@@ -307,6 +1521,90 @@
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "151",
+              "title": "Elementary French",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "182",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FREN",
+              "number": "152",
+              "title": "Elementary French II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "125",
+              "title": "Personal Money Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "194",
+              "title": "Fundamentals of Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "294",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "286",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "291",
+              "title": "Psychology of Human Development",
               "credits": null,
               "or_alternatives": []
             }
@@ -318,9 +1616,23 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
               "credits": null,
               "or_alternatives": []
             },
@@ -372,10 +1684,10 @@
       "matched_program_slug": "art"
     },
     {
-      "title": "Applied Technology, A.A.S.",
+      "title": "Associate in General Studies",
       "credential": "AA",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2169",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2155",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
@@ -390,10 +1702,25 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
-          "name": "Humanities (3 credits)",
+          "name": "Humanities and Fine Arts (3 credits)",
           "credits_required": 3,
           "choose_n": null,
           "courses": []
@@ -408,32 +1735,16 @@
           "name": "Mathematics (3-4 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "or",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
+          "courses": []
         },
         {
-          "name": "Additional General Education Credits to Fulfill General Education Requirements",
-          "credits_required": null,
+          "name": "Additional Associate in General Studies Degree Requirements (44 credits)",
+          "credits_required": 44,
           "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Credits should be selected according to your degree program from Humanities, Social Science, Mathematics, and Natural Science",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
+          "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "liberal-arts"
     },
     {
       "title": "Associate in Science",
@@ -450,9 +1761,37 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "and either",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
               "credits": null,
               "or_alternatives": []
             },
@@ -506,14 +1845,147 @@
       "matched_program_slug": null
     },
     {
-      "title": "Baking & Pastry Arts, A.A.S.",
+      "title": "Accounting, A.A.S.",
       "credential": "AA",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2174",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2158",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
       "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "212",
+              "title": "Data Analytics for Accounting &amp; Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "213",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "223",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "214",
+              "title": "Cost Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "215",
+              "title": "Individual Income Tax Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "220",
+              "title": "Governmental &amp; Non-Profit Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "105",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "107",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "290",
+              "title": "Accounting Co-Op/Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "181",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "261",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "294",
+              "title": "Business Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
         {
           "name": "General Education Requirements (minimum of 18 credits required)",
           "credits_required": 18,
@@ -524,61 +1996,64 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
-          "name": "Humanities (3 credits)",
+          "name": "Humanities (3-4 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "181",
+              "title": "Elementary Spanish",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
-          "name": "Social Science (3 credits)",
-          "credits_required": 3,
+          "name": "Social Science (4 credits)",
+          "credits_required": 4,
           "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Business Administration, A.A.S.",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2220",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Social Science (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "221",
+              "title": "Principles of Economics (Macroeconomics)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Mathematics (3-4 credits)",
@@ -592,16 +2067,152 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "PHIL",
+              "number": "271",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "295",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "222",
+              "title": "Principles of Economics (Microeconomics)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
               "credits": null,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": "business-administration"
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Applied Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2169",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Mathematics (3-4 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "140",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Credits should be selected according to your degree program from Humanities, Social Science, Mathematics, and Natural Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
     },
     {
       "title": "Automotive Technology, A.A.S.",
@@ -613,6 +2224,125 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTO",
+              "number": "119",
+              "title": "Engine Theory and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "131",
+              "title": "Manual Transmission/Drive Axles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "141",
+              "title": "Suspension and Alignment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "151",
+              "title": "Brakes and Braking Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "161",
+              "title": "Electrical Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "182",
+              "title": "Ignition and Fuel Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "191",
+              "title": "Automotive Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "221",
+              "title": "Automatic Transmission Theory and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "262",
+              "title": "Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "271",
+              "title": "Heating Venting and Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "283",
+              "title": "Advanced Engine Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "292",
+              "title": "Service Floor I Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "293",
+              "title": "Service Floor II Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTO",
+              "number": "265",
+              "title": "Introduction to Electric Vehicles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "290",
+              "title": "Light Duty Diesel Repair",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "General Education Requirements (minimum of 15 credits required)",
           "credits_required": 15,
           "choose_n": null,
@@ -622,7 +2352,22 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
@@ -646,6 +2391,175 @@
       "matched_program_slug": "automotive-technology"
     },
     {
+      "title": "Baking & Pastry Arts, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2174",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAKE",
+              "number": "101",
+              "title": "Introduction to Baking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "102",
+              "title": "Bake Shop I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "103",
+              "title": "Basic Cake Decorating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "104",
+              "title": "Intermediate Cake Decorating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "105",
+              "title": "Wedding Cakes &amp; Sugar Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "113",
+              "title": "Artisan Breads",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "114",
+              "title": "Modern Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "115",
+              "title": "Pastry Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "116",
+              "title": "Plated Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "117",
+              "title": "Chocolates and Confections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "206",
+              "title": "Bake Shop II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "100",
+              "title": "Orientation to Food Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "115",
+              "title": "Nutrition and Menu Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "201",
+              "title": "Automated Purchasing and Cost Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "209",
+              "title": "Cooperative Education/Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Social Science (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Mathematics (3-4 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Building and Construction Management, A.A.S.",
       "credential": "AA",
       "program_code": null,
@@ -654,6 +2568,90 @@
       "gpa_minimum": 2,
       "description": null,
       "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCON",
+              "number": "164",
+              "title": "Elementary Surveying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCON",
+              "number": "182",
+              "title": "Building Construction Codes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCON",
+              "number": "202",
+              "title": "Construction Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCON",
+              "number": "268",
+              "title": "Construction Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "110",
+              "title": "Architectural Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "120",
+              "title": "2D CADD Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "172",
+              "title": "Architectural Detailing Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "261",
+              "title": "Bldg Design Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "124",
+              "title": "Electrical Wiring Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "145",
+              "title": "Duct System Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
         {
           "name": "Related Requirement Courses (10 credits)",
           "credits_required": 10,
@@ -664,7 +2662,22 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
@@ -672,9 +2685,23 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "271",
+              "title": "Ethics in Business",
               "credits": null,
               "or_alternatives": []
             }
@@ -686,9 +2713,23 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ECON",
+              "number": "221",
+              "title": "Principles of Economics (Macroeconomics)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "222",
+              "title": "Principles of Economics (Microeconomics)",
               "credits": null,
               "or_alternatives": []
             }
@@ -699,6 +2740,13 @@
           "credits_required": 3,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -718,6 +2766,664 @@
       "matched_program_slug": "business-administration"
     },
     {
+      "title": "Business Administration, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2220",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "106",
+              "title": "Financial Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "261",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "294",
+              "title": "Business Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "181",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Accounting",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "105",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "107",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "213",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "214",
+              "title": "Cost Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "215",
+              "title": "Individual Income Tax Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Food Management",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "100",
+              "title": "Orientation to Food Services",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Management",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENTR",
+              "number": "120",
+              "title": "Entrepreneurial Mindset",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "186",
+              "title": "Business Leadership Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "283",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "284",
+              "title": "Labor Relations for the Supervisor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "286",
+              "title": "Human Resources Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Marketing",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MKTG",
+              "number": "108",
+              "title": "Sales",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "250",
+              "title": "Digital Promotion Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "251",
+              "title": "Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "253",
+              "title": "Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "257",
+              "title": "Consumer Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3-4 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "221",
+              "title": "Principles of Economics (Macroeconomics)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "295",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "271",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2179",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGMT",
+              "number": "181",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Select 4 courses from the following",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENTR",
+              "number": "120",
+              "title": "Entrepreneurial Mindset",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "186",
+              "title": "Business Leadership Supervision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "283",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "284",
+              "title": "Labor Relations for the Supervisor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "286",
+              "title": "Human Resources Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "110",
+              "title": "Introduction to International Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "261",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "294",
+              "title": "Business Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "105",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "106",
+              "title": "Financial Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "206",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "253",
+              "title": "Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "257",
+              "title": "Consumer Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "181",
+              "title": "Elementary Spanish",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3-4 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Beginning and Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Complete any 100 level or higher Humanities, Social Science, Mathematics, or Natural Science course or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "145",
+              "title": "Economic Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "295",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "271",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
       "title": "CAD and Design, A.A.S.",
       "credential": "AA",
       "program_code": null,
@@ -727,10 +3433,220 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "100",
+              "title": "Mechanical Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "120",
+              "title": "2D CADD Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "130",
+              "title": "Parametric Modeling Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "140",
+              "title": "Mechanical Detailing Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "150",
+              "title": "Intro to Analysis CAM &amp; Sim. Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "160",
+              "title": "Fundamentals of Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "201",
+              "title": "Unigraphics Basic Modeling &amp; Drafting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "203",
+              "title": "Advanced Dimensioning &amp; Geometric Dimensioning and Tolerancing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "204",
+              "title": "CADD Product Design Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "205",
+              "title": "CADD Tool &amp; Design Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "206",
+              "title": "Product Data Management Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "110",
+              "title": "Architectural Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "202",
+              "title": "Catia Basic Modeling and Drafting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Select a minimum of 8 credits from below:",
           "credits_required": 8,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "124",
+              "title": "Electrical Wiring Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "134",
+              "title": "Electronic Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "143",
+              "title": "Programmable Logic Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "144",
+              "title": "Programmable Logic Controllers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "170",
+              "title": "Modern Industrial Robotics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "171",
+              "title": "Modern Industrial Robotics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "144",
+              "title": "Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "150",
+              "title": "Material Systems &amp; Evaluation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "246",
+              "title": "CNC Lathe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "247",
+              "title": "CNC Mill",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "249",
+              "title": "MasterCAM",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "120",
+              "title": "Introduction to Fab Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "121A",
+              "title": "Intro to STEM Applications - Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "281",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "281L",
+              "title": "General College Physics I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "143",
+              "title": "Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -750,13 +3666,43 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Social Science (3 credits)",
@@ -770,9 +3716,23 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "140",
+              "title": "Trigonometry",
               "credits": null,
               "or_alternatives": []
             }
@@ -782,66 +3742,10 @@
       "matched_program_slug": null
     },
     {
-      "title": "Business Management, A.A.S.",
+      "title": "Corrections, A.A.S.",
       "credential": "AA",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2179",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Social Science (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Additional General Education Credits to Fulfill General Education Requirements",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Complete any 100 level or higher Humanities, Social Science, Mathematics, or Natural Science course or",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "business-administration"
-    },
-    {
-      "title": "Computer Networking and Cybersecurity, A.A.S.",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2190",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2255",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
@@ -852,10 +3756,94 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "COMS",
-              "number": "170",
+              "prefix": "CORR",
+              "number": "101",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "102",
+              "title": "Client Relations to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "103",
+              "title": "Legal Issues in Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "104",
+              "title": "Client Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "105",
+              "title": "Correctional Institutions/Facilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "161",
+              "title": "Introduction to Law Enforcement and the Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "269",
+              "title": "Introduction to the Juvenile Justice System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "264",
               "title": "",
-              "credits": 4,
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FRSC",
+              "number": "161",
+              "title": "Occupational Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAL",
+              "number": "125",
+              "title": "Cardiopulmonary Resuscitation (CPR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "102",
+              "title": "Circuit Training for Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "106",
+              "title": "Physical Conditioning",
+              "credits": null,
               "or_alternatives": []
             }
           ]
@@ -870,50 +3858,115 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Complete any 100 level or higher Humanities course. / 3 Contact Hours",
-              "credits": 3,
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
               "or_alternatives": []
             }
           ]
         },
         {
-          "name": "Social Science (3 credits)",
-          "credits_required": 3,
+          "name": "Humanities (6 credits)",
+          "credits_required": 6,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "200",
+              "title": "Survey of Human Communication Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSCN",
+              "number": "170",
+              "title": "Introduction to American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSCN",
+              "number": "173",
+              "title": "State and Local Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "286",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "292",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "297",
+              "title": "Introduction to Criminology Correction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Mathematics (3-4 credits)",
           "credits_required": 3,
           "choose_n": null,
           "courses": []
-        },
-        {
-          "name": "Additional General Education Credits to Fulfill General Education Requirements",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Complete any 100 level or higher course from Humanities, Social Science, Mathematics or Natural Science.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
         }
       ],
-      "matched_program_slug": "computer-science"
+      "matched_program_slug": "criminal-justice"
     },
     {
       "title": "Computer Information Systems, A.A.S.",
@@ -925,6 +3978,125 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMC",
+              "number": "115",
+              "title": "A+ Core Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "160",
+              "title": "Introduction to Computer Info Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "169",
+              "title": "Supporting End Users",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "261",
+              "title": "Database Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "264",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "120",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "170",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "171",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "176",
+              "title": "Introduction to .NET programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "276",
+              "title": "Advanced .NET Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "280",
+              "title": "Adv Programming in C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMW",
+              "number": "100",
+              "title": "Introduction to Web Page Creation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMW",
+              "number": "282",
+              "title": "Dynamic Web Pages",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "General Education Requirements (minimum of 18 credits required)",
           "credits_required": 18,
           "choose_n": null,
@@ -934,13 +4106,42 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
           "credits_required": 3,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -955,6 +4156,13 @@
           "credits_required": 3,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -975,6 +4183,20 @@
           "credits_required": null,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -997,6 +4219,55 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJU",
+              "number": "161",
+              "title": "Introduction to Law Enforcement and the Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "162",
+              "title": "Administrative Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "230",
+              "title": "Ethics &amp; Leadership in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "263",
+              "title": "Techniques of Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "265",
+              "title": "Criminal Law and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "269",
+              "title": "Introduction to the Juvenile Justice System",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Related Requirement Courses",
           "credits_required": null,
           "choose_n": null,
@@ -1009,9 +4280,142 @@
               "or_alternatives": []
             },
             {
+              "prefix": "FRSC",
+              "number": "100",
+              "title": "Survey of Forensic Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "210",
+              "title": "Forensic Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "101",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "102",
+              "title": "Client Relations to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "103",
+              "title": "Legal Issues in Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "104",
+              "title": "Client Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "105",
+              "title": "Correctional Institutions/Facilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "151",
+              "title": "Introduction to Security Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "152",
+              "title": "Principles of Loss Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "163",
+              "title": "Patrol Administration Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "165",
+              "title": "Hwy Traffic Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "264",
+              "title": "Court Testimony and Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "271",
+              "title": "Practicum in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "251",
+              "title": "Crime Mapping",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Select 2 classes from the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "102",
+              "title": "Circuit Training for Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "106",
+              "title": "Physical Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "144",
+              "title": "Weight Training: Theory and Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "193",
+              "title": "Self-Defense",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "199",
+              "title": "Advanced Self-Defense",
               "credits": null,
               "or_alternatives": []
             }
@@ -1027,19 +4431,85 @@
           "name": "English Composition (6 credits)",
           "credits_required": 6,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Social Science (12 credits)",
           "credits_required": 12,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "PSCN",
+              "number": "170",
+              "title": "Introduction to American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "297",
+              "title": "Introduction to Criminology Correction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Mathematics (3-4 credits)",
@@ -1051,10 +4521,10 @@
       "matched_program_slug": "criminal-justice"
     },
     {
-      "title": "Corrections, A.A.S.",
+      "title": "Computer Networking and Cybersecurity, A.A.S.",
       "credential": "AA",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2255",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2190",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
@@ -1065,9 +4535,114 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "CRJU",
-              "number": "264",
+              "prefix": "COMS",
+              "number": "170",
               "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMC",
+              "number": "115",
+              "title": "A+ Core Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMC",
+              "number": "125",
+              "title": "A+ Operating System Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "169",
+              "title": "Supporting End Users",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "120",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "144",
+              "title": "Network Infrastructure Configuration &amp; Implementation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "154",
+              "title": "Routing Protocol/Networking Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "164",
+              "title": "Client and Server Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "174",
+              "title": "Advanced Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "184",
+              "title": "Information Security in a Digital Age",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "224",
+              "title": "Network Security Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "274",
+              "title": "Cybersecurity and Ethical Hacking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "282",
+              "title": "Computer Networking Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "130",
+              "title": "Introduction to Linux Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "170",
+              "title": "Introduction to Programming",
               "credits": null,
               "or_alternatives": []
             }
@@ -1083,17 +4658,54 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
-          "name": "Humanities (6 credits)",
-          "credits_required": 6,
+          "name": "Humanities (3 credits)",
+          "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Complete any 100 level or higher Humanities course. / 3 Contact Hours",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
         },
         {
-          "name": "Social Science (15 credits)",
-          "credits_required": 15,
+          "name": "Social Science (3 credits)",
+          "credits_required": 3,
           "choose_n": null,
           "courses": []
         },
@@ -1102,9 +4714,37 @@
           "credits_required": 3,
           "choose_n": null,
           "courses": []
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Complete any 100 level or higher course from Humanities, Social Science, Mathematics or Natural Science.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         }
       ],
-      "matched_program_slug": "criminal-justice"
+      "matched_program_slug": "computer-science"
     },
     {
       "title": "Culinary Arts, A.A.S.",
@@ -1116,6 +4756,111 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "100",
+              "title": "Orientation to Food Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "101",
+              "title": "Culinary Knife Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "103",
+              "title": "Introduction to Ala Carte Dining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "105",
+              "title": "Intro to Professional Cookery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "106",
+              "title": "Professional Cookery I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "107",
+              "title": "A la Carte Dining/Tableservice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "109",
+              "title": "Catering Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "111",
+              "title": "Garde Manger I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "115",
+              "title": "Nutrition and Menu Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "201",
+              "title": "Automated Purchasing and Cost Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "205",
+              "title": "International Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "207",
+              "title": "Garde Manger II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "209",
+              "title": "Cooperative Education/Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "210",
+              "title": "Food and Wine Pairing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "General Education Requirements (minimum of 18 credits required)",
           "credits_required": 18,
           "choose_n": null,
@@ -1125,7 +4870,22 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
@@ -1158,6 +4918,111 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "170",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMO",
+              "number": "180",
+              "title": "Microsoft Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "206",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "261",
+              "title": "Database Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "176",
+              "title": "Introduction to .NET programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "212",
+              "title": "Data Analytics for Accounting &amp; Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "276",
+              "title": "Advanced .NET Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "283",
+              "title": "Data Integration and Analytics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "284",
+              "title": "Data Analytics Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "250",
+              "title": "Digital Promotion Methods",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "General Education Requirements (minimum of 18 credits required)",
           "credits_required": 18,
           "choose_n": null,
@@ -1168,12 +5033,26 @@
           "credits_required": 3,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
               "credits": null,
               "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
             }
           ]
         },
@@ -1181,113 +5060,46 @@
           "name": "Humanities (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Social Science (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "221",
+              "title": "Principles of Economics (Macroeconomics)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Mathematics (8 credits)",
           "credits_required": 8,
           "choose_n": null,
-          "courses": []
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Dental Assisting, A.A.S.",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2205",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Related Requirement Courses",
-          "credits_required": null,
-          "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "and",
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "and",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "and",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        },
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Social Science (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Additional General Education Credits to Fulfill General Education Requirements",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "and",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "and",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "and",
+              "prefix": "MATH",
+              "number": "150",
+              "title": "Probability and Statistics",
               "credits": null,
               "or_alternatives": []
             }
@@ -1306,14 +5118,273 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHYG",
+              "number": "102",
+              "title": "Aspects of Infection &amp; Hazard Control in Dentistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "103",
+              "title": "Oral Radiographic Interpretation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "110",
+              "title": "Dental Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "113",
+              "title": "Oral Radiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "114",
+              "title": "Oral Radiography Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "115",
+              "title": "Head Neck and Oral Anatomy Lecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "118",
+              "title": "Oral Histology &amp; Embryology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "121",
+              "title": "Dental Hygiene I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "121L",
+              "title": "Dental Hygiene I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "122",
+              "title": "Dental Hygiene II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "122C",
+              "title": "Dental Hygiene II Clinic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "124",
+              "title": "Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "125",
+              "title": "Dental Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "143",
+              "title": "Introduction to Periodontology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "180",
+              "title": "Pain Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "180L",
+              "title": "Pain Management Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "212",
+              "title": "General and Oral Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "221",
+              "title": "Dental Hygiene III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "221C",
+              "title": "Dental Hygiene III Clinic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "224",
+              "title": "Dental Hygiene IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "224C",
+              "title": "Dental Hygiene IV Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "227",
+              "title": "Ethics and Current Topics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "232",
+              "title": "Community Dental Health I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "233",
+              "title": "Community Dental Health II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "234",
+              "title": "Dental Materials for Dental Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "234L",
+              "title": "Dental Materials for Dental Hygiene Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHYG",
+              "number": "243",
+              "title": "Advanced Periodontology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Related Requirement Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "156",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "156L",
+              "title": "Microbiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "118",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAL",
+              "number": "125",
+              "title": "Cardiopulmonary Resuscitation (CPR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAL",
+              "number": "129",
+              "title": "Safety and Emergency Response",
               "credits": null,
               "or_alternatives": []
             }
@@ -1329,7 +5400,22 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (6 credits)",
@@ -1337,9 +5423,30 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
               "credits": null,
               "or_alternatives": []
             }
@@ -1349,7 +5456,22 @@
           "name": "Social Science (6 credits)",
           "credits_required": 6,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Mathematics (3-4 credits)",
@@ -1359,6 +5481,934 @@
         }
       ],
       "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2210",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "103",
+              "title": "Professional Ethics Early Childhood Educ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "105",
+              "title": "School Age Development and Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "105L",
+              "title": "School Age Development and Education Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "110",
+              "title": "Applied Child Development &amp; Family Engagement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "190",
+              "title": "Literacy and Numeracy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "199",
+              "title": "Guidance and Discipline",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "200",
+              "title": "Early Childhood Learning Environments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "201",
+              "title": "Curriculum Planning in Early Childhood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "202",
+              "title": "Admin of Programs for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "203",
+              "title": "Learning Env: Infants and Toddlers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "204",
+              "title": "Infant and Toddler Curriculum Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "205",
+              "title": "Field Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "210",
+              "title": "Child Observation &amp; Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "211",
+              "title": "Adapt Early Child Curricula - The Special Needs Child",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "210",
+              "title": "Childrens Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOCY",
+              "number": "193",
+              "title": "Marriage and the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "184",
+              "title": "Exceptional People",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3-4 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "150",
+              "title": "The Human Body",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Dental Assisting, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2205",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAST",
+              "number": "110",
+              "title": "Orientation to Dentistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "111",
+              "title": "Infection Control for Dental Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "112",
+              "title": "Dental and Oral Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "112L",
+              "title": "Dental &amp; Oral Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "113",
+              "title": "Dental Office Emergencies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "115",
+              "title": "Nutrition &amp; Preventive Dentistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "116",
+              "title": "Dental Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "116L",
+              "title": "Dental Materials Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "117",
+              "title": "Operative Techniques I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "117C",
+              "title": "Operative Techniques I Clinic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "117L",
+              "title": "Operative Techniques I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "120",
+              "title": "Oral Pathology for Dental Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "121",
+              "title": "Dental Jurisprudence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "122",
+              "title": "Pharmacology for Dental Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "123",
+              "title": "Advanced Clinical Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "124",
+              "title": "Expanded Functions for Dental Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "124L",
+              "title": "Expanded Functions for Dental Assistants Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "125",
+              "title": "Operative Techniques II Clinic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "126",
+              "title": "Dental Specialities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "127",
+              "title": "Dental Business Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "130",
+              "title": "Operative Techniques Externship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "130C",
+              "title": "Operative Techniques III Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHDA",
+              "number": "114",
+              "title": "Dental Radiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHDA",
+              "number": "114L",
+              "title": "Dental Radiography Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "150",
+              "title": "The Human Body",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3-4 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "150",
+              "title": "The Human Body",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurship & Small Business Management, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2245",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "262",
+              "title": "Business Law II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "120",
+              "title": "Entrepreneurial Mindset",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "130",
+              "title": "Opportunity Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "140",
+              "title": "Business Professional Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "200",
+              "title": "Entrepreneurial Co-Op",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "220",
+              "title": "Financial Management for Small Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "230",
+              "title": "Entrepreneurial Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "250",
+              "title": "Business Plan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "181",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "101",
+              "title": "Applied Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "294",
+              "title": "Business Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "257",
+              "title": "Consumer Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "105",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "253",
+              "title": "Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "283",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (3-4 credits optional)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "181",
+              "title": "Elementary Spanish",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science (3 credits optional)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3-4 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Beginning and Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements (Credits 3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "145",
+              "title": "Economic Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "295",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
     },
     {
       "title": "Electronics and Electrical Technology, A.A.S.",
@@ -1376,8 +6426,127 @@
           "courses": [
             {
               "prefix": "ELEC",
+              "number": "124",
+              "title": "Electrical Wiring Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "134",
+              "title": "Electronic Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "141",
+              "title": "Introduction to Semiconductors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "142",
+              "title": "Semiconductor Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "143",
+              "title": "Programmable Logic Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "144",
+              "title": "Programmable Logic Controllers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "150",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "138",
+              "title": "Control Panel Building",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "155",
+              "title": "Electric Motors Transformers and Power",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "231",
+              "title": "Fundamentals of Labview",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "233",
+              "title": "Embedded Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "236",
+              "title": "Industrial Automation and Control",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Emphasis in Robotics Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "170",
+              "title": "Modern Industrial Robotics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "171",
+              "title": "Modern Industrial Robotics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "171",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "176",
+              "title": "Introduction to .NET programming",
               "credits": null,
               "or_alternatives": []
             }
@@ -1388,6 +6557,118 @@
           "credits_required": null,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "AUTO",
+              "number": "161",
+              "title": "Electrical Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "100",
+              "title": "Mechanical Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "120",
+              "title": "2D CADD Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "130",
+              "title": "Parametric Modeling Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "120",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "170",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "171",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "176",
+              "title": "Introduction to .NET programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "144",
+              "title": "Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "281",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "281L",
+              "title": "General College Physics I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "102",
+              "title": "Industrial &amp; Construction Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "110",
+              "title": "Introduction to Renewable Energy Tech. Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "120",
+              "title": "Introduction to Fab Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "121A",
+              "title": "Intro to STEM Applications - Guitar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "143",
+              "title": "Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -1407,13 +6688,35 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
           "credits_required": 3,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -1435,9 +6738,23 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "140",
+              "title": "Trigonometry",
               "credits": null,
               "or_alternatives": []
             },
@@ -1454,90 +6771,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Entrepreneurship & Small Business Management, A.A.S.",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2245",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities (3-4 credits optional)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Social Science (3 credits optional)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        }
-      ],
-      "matched_program_slug": "business-administration"
-    },
-    {
-      "title": "Early Childhood Education, A.A.S.",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2210",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities (6 credits)",
-          "credits_required": 6,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Social Science (6 credits)",
-          "credits_required": 6,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        }
-      ],
-      "matched_program_slug": "early-childhood-education"
-    },
-    {
       "title": "Food Services Management, A.A.S.",
       "credential": "AA",
       "program_code": null,
@@ -1547,6 +6780,111 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "100",
+              "title": "Orientation to Food Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "101",
+              "title": "Culinary Knife Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "103",
+              "title": "Introduction to Ala Carte Dining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "105",
+              "title": "Intro to Professional Cookery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "106",
+              "title": "Professional Cookery I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "107",
+              "title": "A la Carte Dining/Tableservice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "115",
+              "title": "Nutrition and Menu Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "201",
+              "title": "Automated Purchasing and Cost Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "205",
+              "title": "International Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "208",
+              "title": "Management of Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "209",
+              "title": "Cooperative Education/Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "210",
+              "title": "Food and Wine Pairing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "261",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "General Education Requirements (minimum of 18 credits required)",
           "credits_required": 18,
           "choose_n": null,
@@ -1556,7 +6894,22 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
@@ -1589,14 +6942,133 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DESN",
+              "number": "100",
+              "title": "Design Careers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "115",
+              "title": "Intro to Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "120",
+              "title": "Digital Imaging I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "121",
+              "title": "Digital Imaging II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "130",
+              "title": "Type I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "230",
+              "title": "Type II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "210",
+              "title": "Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "211",
+              "title": "Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "212",
+              "title": "Design III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "240",
+              "title": "Experience Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "270",
+              "title": "Design Portfolio Prep",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "271",
+              "title": "Design Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Related Requirement Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "PHOT",
+              "number": "180",
+              "title": "Basic Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "TAKE 3 Credits from: DESN-105 and DESN-205 or DESN-250:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "105",
+              "title": "Design Center I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "205",
+              "title": "Design Center II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "250",
+              "title": "Design Internship",
               "credits": null,
               "or_alternatives": []
             }
@@ -1608,9 +7080,30 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "MAET",
+              "number": "100",
+              "title": "Intro to Media Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "253",
+              "title": "Advertising",
               "credits": null,
               "or_alternatives": []
             }
@@ -1626,13 +7119,50 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3-4 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "140",
+              "title": "Principles of Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Social Science (3 credits)",
@@ -1644,7 +7174,22 @@
           "name": "Mathematics (3-4 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Additional General Education Credits to Fulfill General Education Requirements",
@@ -1657,6 +7202,27 @@
               "title": "Successfully complete ENGL-102 and COMM-131 or COMM-140",
               "credits": null,
               "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "140",
+              "title": "Principles of Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
             }
           ]
         }
@@ -1664,10 +7230,10 @@
       "matched_program_slug": "art"
     },
     {
-      "title": "Haircare Salon Management, A.A.S.",
+      "title": "Heating, Ventilation, Air Conditioning & Refrigeration Technology, A.A.S.",
       "credential": "AA",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2223",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2167",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
@@ -1678,10 +7244,80 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Current State of Michigan Cosmetology or Barber License / 0 Contact Hours",
-              "credits": 22,
+              "prefix": "HVAC",
+              "number": "140",
+              "title": "Basic Mechanical Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "141",
+              "title": "Air Condition &amp; Refrigeration Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "142",
+              "title": "Heating Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "143",
+              "title": "Sealed System Installation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "144",
+              "title": "Air Conditioning Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "145",
+              "title": "Duct System Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "147",
+              "title": "Refrigerant Handling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "241",
+              "title": "Air Conditioning and Refrigeration Controls II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "242",
+              "title": "Heating Systems II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "243",
+              "title": "Sealed System Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "260",
+              "title": "Heating, Ventilation and Air Conditioning Systems Design I",
+              "credits": null,
               "or_alternatives": []
             }
           ]
@@ -1696,49 +7332,22 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Social Science (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        }
-      ],
-      "matched_program_slug": "business-administration"
-    },
-    {
-      "title": "Heating, Ventilation, Air Conditioning & Refrigeration Technology, A.A.S.",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2167",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
@@ -1762,6 +7371,154 @@
       "matched_program_slug": null
     },
     {
+      "title": "Haircare Salon Management, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2223",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Current State of Michigan Cosmetology or Barber License / 0 Contact Hours",
+              "credits": 22,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "101",
+              "title": "Applied Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "106",
+              "title": "Financial Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "261",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "181",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "105",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Social Science (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Mathematics (3-4 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
       "title": "Health Fitness Professional, A.A.S.",
       "credential": "AA",
       "program_code": null,
@@ -1776,6 +7533,83 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "HEAL",
+              "number": "101",
+              "title": "Nutrition Basics for the Consumer",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAL",
+              "number": "125",
+              "title": "Cardiopulmonary Resuscitation (CPR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAL",
+              "number": "129",
+              "title": "Safety and Emergency Response",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFPR",
+              "number": "100",
+              "title": "Introduction to Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFPR",
+              "number": "200",
+              "title": "Test and Measurements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFPR",
+              "number": "205",
+              "title": "Techniques and Application of Health and Fitness Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFPR",
+              "number": "207",
+              "title": "Health and Fitness Center Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFPR",
+              "number": "210",
+              "title": "Theory and Application of Health and Fitness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFPR",
+              "number": "220",
+              "title": "Exercise Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFPR",
+              "number": "290",
+              "title": "Health and Fitness Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "101",
+              "title": "Circuit Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Student Pathway Declaration - Select 1 option (Occupational or Transfer)",
@@ -1786,6 +7620,48 @@
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Occupational Pathway",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "102",
+              "title": "Circuit Training for Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "106",
+              "title": "Physical Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "144",
+              "title": "Weight Training: Theory and Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "181",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
               "credits": null,
               "or_alternatives": []
             },
@@ -1804,9 +7680,100 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "PEAC",
+              "number": "142",
+              "title": "Running",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "145",
+              "title": "Social Dance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "147",
+              "title": "Pilates: Beginning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "193",
+              "title": "Self-Defense",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Transfer Pathway - Select 2 courses",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "102",
+              "title": "Circuit Training for Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "106",
+              "title": "Physical Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "144",
+              "title": "Weight Training: Theory and Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHEM",
+              "number": "118",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "131",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "131L",
+              "title": "General Chemistry I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "131R",
+              "title": "General Chemistry I Recitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "150",
+              "title": "Probability and Statistics",
               "credits": null,
               "or_alternatives": []
             }
@@ -1822,7 +7789,15 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
@@ -1844,9 +7819,23 @@
               "or_alternatives": []
             },
             {
+              "prefix": "COMM",
+              "number": "140",
+              "title": "Principles of Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Transfer Pathway",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
               "credits": null,
               "or_alternatives": []
             }
@@ -1856,7 +7845,15 @@
           "name": "Social Science (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Mathematics (3-4 credits)",
@@ -1878,9 +7875,37 @@
               "or_alternatives": []
             },
             {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Beginning and Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Transfer Pathway",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
               "credits": null,
               "or_alternatives": []
             }
@@ -1906,9 +7931,278 @@
               "or_alternatives": []
             },
             {
+              "prefix": "BIOL",
+              "number": "150",
+              "title": "The Human Body",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDDV",
+              "number": "101",
+              "title": "Leadership Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Transfer Pathway",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Histologic Technician, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2224",
+      "total_credits": null,
+      "gpa_minimum": 3,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHLT",
+              "number": "258",
+              "title": "Clinical Histologic Techniques",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "156",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "156L",
+              "title": "Microbiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "Fundamentals of Inorganic Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111L",
+              "title": "Fundamentals of Inorganic Chemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111R",
+              "title": "Fundamentals of Inorganic Chemistry Recitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112",
+              "title": "Fundamentals of Organic &amp; Biochemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112L",
+              "title": "Fundamentals of Organic/Biochemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "112R",
+              "title": "Fundamentals of Organic/Biochem Recitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHLT",
+              "number": "102",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHLT",
+              "number": "113",
+              "title": "Multicultural Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "220",
+              "title": "Intercultural Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Mathematics (3-4 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152L",
+              "title": "Human Anatomy and Physiology II Lab",
               "credits": null,
               "or_alternatives": []
             }
@@ -1933,6 +8227,20 @@
           "courses": [
             {
               "prefix": "ELEC",
+              "number": "233",
+              "title": "Embedded Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "237",
+              "title": "Electronics Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
               "number": "XXX",
               "title": "any CADD course 100 level or higher / 4 Contact Hours",
               "credits": 3,
@@ -1950,13 +8258,29 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Social Science (3 credits)",
@@ -1970,9 +8294,23 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
               "credits": null,
               "or_alternatives": []
             }
@@ -1983,6 +8321,13 @@
           "credits_required": null,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "MATH",
+              "number": "140",
+              "title": "Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -1996,14 +8341,259 @@
       "matched_program_slug": null
     },
     {
-      "title": "Histologic Technician, A.A.S.",
+      "title": "Information Technology, A.A.S.",
       "credential": "AA",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2224",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2192",
       "total_credits": null,
-      "gpa_minimum": 3,
+      "gpa_minimum": 2,
       "description": null,
       "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMC",
+              "number": "115",
+              "title": "A+ Core Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMC",
+              "number": "125",
+              "title": "A+ Operating System Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "160",
+              "title": "Introduction to Computer Info Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "169",
+              "title": "Supporting End Users",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "120",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "184",
+              "title": "Information Security in a Digital Age",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "170",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "176",
+              "title": "Introduction to .NET programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMW",
+              "number": "100",
+              "title": "Introduction to Web Page Creation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Applications Developer Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMI",
+              "number": "261",
+              "title": "Database Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "171",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "276",
+              "title": "Advanced .NET Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "280",
+              "title": "Adv Programming in C++",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Networking Technician Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMN",
+              "number": "144",
+              "title": "Network Infrastructure Configuration &amp; Implementation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "154",
+              "title": "Routing Protocol/Networking Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "164",
+              "title": "Client and Server Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "174",
+              "title": "Advanced Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "130",
+              "title": "Introduction to Linux Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Computer Security Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMN",
+              "number": "144",
+              "title": "Network Infrastructure Configuration &amp; Implementation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "164",
+              "title": "Client and Server Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "174",
+              "title": "Advanced Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "224",
+              "title": "Network Security Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "274",
+              "title": "Cybersecurity and Ethical Hacking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Web Developer Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMI",
+              "number": "261",
+              "title": "Database Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "130",
+              "title": "Introduction to Linux Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "276",
+              "title": "Advanced .NET Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMW",
+              "number": "282",
+              "title": "Dynamic Web Pages",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
         {
           "name": "General Education Requirements (minimum of 18 credits required)",
           "credits_required": 18,
@@ -2014,7 +8604,22 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
@@ -2035,54 +8640,11 @@
           "courses": [
             {
               "prefix": "MATH",
-              "number": "130",
-              "title": "",
+              "number": "120",
+              "title": "Intermediate Algebra",
               "credits": null,
               "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Information Technology, A.A.S.",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2192",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Social Science (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": [
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -2096,112 +8658,6 @@
       "matched_program_slug": "computer-science"
     },
     {
-      "title": "Marketing, A.A.S.",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2229",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Social Science (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        }
-      ],
-      "matched_program_slug": "business-administration"
-    },
-    {
-      "title": "Mechanical Operations Technology, A.A.S.",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2231",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Group Total: 8 Credits / 11-12 Contact",
-          "credits_required": 8,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "or",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        },
-        {
-          "name": "Humanities (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Social Science (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "or",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
       "title": "Mechanical & Automated Design Technology AAS",
       "credential": "AAS",
       "program_code": null,
@@ -2210,6 +8666,167 @@
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "100",
+              "title": "Mechanical Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "120",
+              "title": "2D CADD Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "130",
+              "title": "Parametric Modeling Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "140",
+              "title": "Mechanical Detailing Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "160",
+              "title": "Fundamentals of Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "124",
+              "title": "Electrical Wiring Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "134",
+              "title": "Electronic Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "138",
+              "title": "Control Panel Building",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "143",
+              "title": "Programmable Logic Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "144",
+              "title": "Programmable Logic Controllers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "170",
+              "title": "Modern Industrial Robotics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "120",
+              "title": "Mechanical Components and Drives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "130",
+              "title": "Pneumatic &amp; Hydraulic Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "144",
+              "title": "Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "246",
+              "title": "CNC Lathe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "247",
+              "title": "CNC Mill",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "171",
+              "title": "Modern Industrial Robotics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "150",
+              "title": "Material Systems &amp; Evaluation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "151",
+              "title": "Physical Metallurgy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "143",
+              "title": "Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "281",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
         {
           "name": "General Education Requirements (minimum 15 credits)",
           "credits_required": 15,
@@ -2222,9 +8839,23 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
               "credits": null,
               "or_alternatives": []
             }
@@ -2235,6 +8866,13 @@
           "credits_required": 3,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -2250,9 +8888,23 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "140",
+              "title": "Trigonometry",
               "credits": null,
               "or_alternatives": []
             }
@@ -2283,6 +8935,111 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAET",
+              "number": "100",
+              "title": "Intro to Media Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "110",
+              "title": "Media History and Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "120",
+              "title": "Media Aesthetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "140",
+              "title": "Podcast Design &amp; Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "150",
+              "title": "News Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "180",
+              "title": "Intro to Screenwriting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "200",
+              "title": "Television &amp; Commercial Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "210",
+              "title": "Cinema Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "250",
+              "title": "Documentary Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "260",
+              "title": "Media Production Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DESN",
+              "number": "115",
+              "title": "Intro to Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "180",
+              "title": "Basic Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "120",
+              "title": "Acting I - Fundamentals of Acting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "General Education Requirements (minimum of 18 credits required)",
           "credits_required": 18,
           "choose_n": null,
@@ -2292,13 +9049,36 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (6 credits)",
           "credits_required": 6,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "181",
+              "title": "Introduction to Film",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Social Science (3 credits)",
@@ -2321,6 +9101,570 @@
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Select one course from the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "110",
+              "title": "Theatre Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Marketing, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2229",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGMT",
+              "number": "181",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "185",
+              "title": "Retail Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "108",
+              "title": "Sales",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "250",
+              "title": "Digital Promotion Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "251",
+              "title": "Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "253",
+              "title": "Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "257",
+              "title": "Consumer Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "101",
+              "title": "Applied Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "106",
+              "title": "Financial Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "261",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "294",
+              "title": "Business Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "221",
+              "title": "Principles of Economics (Macroeconomics)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3-4 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "222",
+              "title": "Principles of Economics (Microeconomics)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "295",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Mechanical Operations Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2231",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MECH",
+              "number": "144",
+              "title": "Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "150",
+              "title": "Material Systems &amp; Evaluation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "151",
+              "title": "Physical Metallurgy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "246",
+              "title": "CNC Lathe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "247",
+              "title": "CNC Mill",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "100",
+              "title": "Mechanical Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "120",
+              "title": "2D CADD Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "130",
+              "title": "Parametric Modeling Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "124",
+              "title": "Electrical Wiring Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "134",
+              "title": "Electronic Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "170",
+              "title": "Modern Industrial Robotics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "143",
+              "title": "Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "102",
+              "title": "Industrial &amp; Construction Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSM",
+              "number": "222",
+              "title": "Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "171",
+              "title": "Modern Industrial Robotics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "155",
+              "title": "Electric Motors Transformers and Power",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "120",
+              "title": "Mechanical Components and Drives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "130",
+              "title": "Pneumatic &amp; Hydraulic Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "210",
+              "title": "Advanced Machining for Tooling and Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "249",
+              "title": "MasterCAM",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "260",
+              "title": "Advanced CNC Setup, Programming &amp; Operation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "164",
+              "title": "Base Metal Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "166",
+              "title": "Shielded Metal Arc Welding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "168",
+              "title": "Gas Tungsten Arc Welding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "170",
+              "title": "Gas Metal Arc Welding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "174",
+              "title": "Flux Cored Arc Welding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "251",
+              "title": "Welding Metallurgy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group Total: 8 Credits / 11-12 Contact",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Social Science (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Mathematics (3-4 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "130",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "140",
+              "title": "Trigonometry",
               "credits": null,
               "or_alternatives": []
             }
@@ -2370,6 +9714,20 @@
               "title": "Complete 2 of these 3 classes:",
               "credits": null,
               "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "101",
+              "title": "Applied Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "120",
+              "title": "Entrepreneurial Mindset",
+              "credits": null,
+              "or_alternatives": []
             }
           ]
         },
@@ -2383,7 +9741,22 @@
           "name": "English Composition (6 credits)",
           "credits_required": 6,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
@@ -2416,14 +9789,322 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NRSG",
+              "number": "110",
+              "title": "Foundations of Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "110C",
+              "title": "Foundations of Patient Care - Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "110L",
+              "title": "Foundations of Patient Care - Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "110M",
+              "title": "Foundations of Patient Care Med Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "120",
+              "title": "Basic Care of the Adult Patient (A)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "120C",
+              "title": "Basic Care of Adult Patient (A) Clinic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "120L",
+              "title": "Basic Care of Adult Patient (A) - Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "121",
+              "title": "Basic Care of the Adult Patient (B)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "121C",
+              "title": "Basic Care of Adult Patient (B) Clinic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "121L",
+              "title": "Basic Care of the Adult Patient (B) Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "130",
+              "title": "Care of the Childbearing Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "130C",
+              "title": "Care of the Childbearing Family Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "210",
+              "title": "Care of the Pediatric Patient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "210C",
+              "title": "Care of the Pediatric Patient Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "220",
+              "title": "Care of Mental/Behavioral Health Patient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "220C",
+              "title": "Mental/Behavior Health Patient Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "230",
+              "title": "Intermediate Care of the Adult Patient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "230C",
+              "title": "Inter. Care of the Adult Patient Clinica",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "240",
+              "title": "Advanced Care of the Adult Patient",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "240C",
+              "title": "Adv. Care Adult Patient Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "240L",
+              "title": "Adv. Care of the Adult Patient Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "250",
+              "title": "Advanced Patient Care Mgmt. &amp; Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "250C",
+              "title": "Advanced Patient Care Clinical",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Related Requirement Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "200",
+              "title": "Survey of Human Communication Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "101",
+              "title": "Microbiology for Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "156",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "156L",
+              "title": "Microbiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHLT",
+              "number": "112",
+              "title": "Nutrition for Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHLT",
+              "number": "135",
+              "title": "Dosage &amp; Solution Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "100",
+              "title": "Pharmacology and Therapeutics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "105",
+              "title": "Basic Health Assessment and Physical Examination",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "105L",
+              "title": "Basic Health Assessment and Physical Examination Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHLT",
+              "number": "113",
+              "title": "Multicultural Health Care",
               "credits": null,
               "or_alternatives": []
             }
@@ -2439,19 +10120,64 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "200",
+              "title": "Survey of Human Communication Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Social Science (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Mathematics (3-4 credits)",
@@ -2465,9 +10191,58 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "156",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "156L",
+              "title": "Microbiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "if taken in place of",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "101",
+              "title": "Microbiology for Health Sciences",
               "credits": null,
               "or_alternatives": []
             }
@@ -2475,6 +10250,220 @@
         }
       ],
       "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Paramedics (Graduate), A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2238",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHLT",
+              "number": "112",
+              "title": "Nutrition for Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHLT",
+              "number": "135",
+              "title": "Dosage &amp; Solution Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "100",
+              "title": "Pharmacology and Therapeutics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHLT",
+              "number": "102",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHLT",
+              "number": "113",
+              "title": "Multicultural Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NRSG",
+              "number": "105",
+              "title": "Basic Health Assessment and Physical Examination",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "144",
+              "title": "Weight Training: Theory and Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (8 credits)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "118",
+              "title": "Beginning and Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "156",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "156L",
+              "title": "Microbiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "131",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "131L",
+              "title": "General Chemistry I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "131R",
+              "title": "General Chemistry I Recitation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
     },
     {
       "title": "Occupational Therapy Assistant, A.A.S.",
@@ -2486,10 +10475,66 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OTPT",
+              "number": "100",
+              "title": "Physical Medicine Terminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Related Requirement Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "AHLT",
+              "number": "113",
+              "title": "Multicultural Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTPT",
+              "number": "113",
+              "title": "Applied Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTPT",
+              "number": "113L",
+              "title": "Applied Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "291",
+              "title": "Psychology of Human Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAL",
+              "number": "125",
+              "title": "Cardiopulmonary Resuscitation (CPR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAL",
+              "number": "129",
+              "title": "Safety and Emergency Response",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -2509,67 +10554,119 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "295",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Social Science (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Mathematics (3-4 credits)",
           "credits_required": 3,
           "choose_n": null,
           "courses": []
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Paramedics (Graduate), A.A.S.",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2238",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
         },
         {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
           "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Social Science (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (8 credits)",
-          "credits_required": 8,
-          "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         }
       ],
       "matched_program_slug": null
@@ -2584,14 +10681,112 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OTPT",
+              "number": "100",
+              "title": "Physical Medicine Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTPT",
+              "number": "113",
+              "title": "Applied Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OTPT",
+              "number": "113L",
+              "title": "Applied Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Related Requirement Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "AHLT",
+              "number": "113",
+              "title": "Multicultural Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAL",
+              "number": "125",
+              "title": "Cardiopulmonary Resuscitation (CPR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAL",
+              "number": "129",
+              "title": "Safety and Emergency Response",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Basic Cardiac Life Support (BCLS) Healthcare Provider Card or Professional Rescuer and Health Care Provider Card",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PEAC",
+              "number": "144",
+              "title": "Weight Training: Theory and Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "291",
+              "title": "Psychology of Human Development",
               "credits": null,
               "or_alternatives": []
             }
@@ -2607,19 +10802,57 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Social Science (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Mathematics (3-4 credits)",
@@ -2640,14 +10873,133 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHOT",
+              "number": "180",
+              "title": "Basic Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "182",
+              "title": "Introduction to Light and Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "183",
+              "title": "Intro to Commercial Studio Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "186",
+              "title": "Careers in Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "190",
+              "title": "Introduction to Digital Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "192",
+              "title": "Advanced Digital Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "205",
+              "title": "Photography Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "291",
+              "title": "Photography Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Related Requirement Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "DESN",
+              "number": "130",
+              "title": "Type I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "120",
+              "title": "Entrepreneurial Mindset",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "100",
+              "title": "Intro to Media Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Select 4 courses from the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "187",
+              "title": "Photojournalism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "210",
+              "title": "Advanced Studio Lighting Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "211",
+              "title": "Commercial Portraiture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "212",
+              "title": "The Art of Wedding Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "215",
+              "title": "Alternative Processes in Photography",
               "credits": null,
               "or_alternatives": []
             },
@@ -2670,87 +11022,61 @@
           "name": "English Composition (6 credits)",
           "credits_required": 6,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (6 credits)",
           "credits_required": 6,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "200",
+              "title": "Survey of Human Communication Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Social Science (3 credits)",
           "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Mathematics (3-4 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Social Work Technician, A.A.S.",
-      "credential": "AA",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2246",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Occupational Specialty Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Students must complete a total of 7 credits from the following:",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        },
-        {
-          "name": "Related Requirement Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Select 9 credits from the following:",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        },
-        {
-          "name": "General Education Requirements (minimum of 18 credits required)",
-          "credits_required": 18,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "English Composition (6 credits)",
-          "credits_required": 6,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Humanities (3 credits)",
-          "credits_required": 3,
-          "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Social Science (select a minimum of 12 credits from the following)",
-          "credits_required": 12,
           "choose_n": null,
           "courses": []
         },
@@ -2773,6 +11099,167 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTAD",
+              "number": "120",
+              "title": "Respiratory Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "121",
+              "title": "Respiratory Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "122",
+              "title": "Respiratory Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "124",
+              "title": "Respiratory Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "125",
+              "title": "Respiratory Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "130",
+              "title": "Respiratory Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "132",
+              "title": "Respiratory Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "134",
+              "title": "Respiratory Clinical Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "135",
+              "title": "Respiratory Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "150",
+              "title": "Respiratory Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "154",
+              "title": "Respiratory Clinical Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "155",
+              "title": "Respiratory Lab III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "221",
+              "title": "Critical Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "222",
+              "title": "Respiratory Neonatal/Pediatric Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "225",
+              "title": "Respiratory Diagnostics Post Acute Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "227",
+              "title": "Respiratory Clinical Care Practice III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "231",
+              "title": "Respiratory Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "232",
+              "title": "Respiratory Exam Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTAD",
+              "number": "233",
+              "title": "Respiratory Clinical Practice IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHLT",
+              "number": "102",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHLT",
+              "number": "113",
+              "title": "Multicultural Health Care",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "General Education Requirements (minimum of 18 credits required)",
           "credits_required": 18,
           "choose_n": null,
@@ -2782,7 +11269,367 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3-4 credits)",
+          "credits_required": 3,
+          "choose_n": null,
           "courses": []
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "101",
+              "title": "Microbiology for Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "156",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2265",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "143",
+              "title": "Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "164",
+              "title": "Base Metal Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "166",
+              "title": "Shielded Metal Arc Welding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "168",
+              "title": "Gas Tungsten Arc Welding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "170",
+              "title": "Gas Metal Arc Welding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "174",
+              "title": "Flux Cored Arc Welding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "251",
+              "title": "Welding Metallurgy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "260",
+              "title": "Shielded Metal Arc Welding II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "261",
+              "title": "Gas Tungsten Arc Welding II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "262",
+              "title": "Advanced Multi-Process Pipe Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "272",
+              "title": "Advanced Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirements Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "170",
+              "title": "Modern Industrial Robotics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "100",
+              "title": "Mechanical Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "130",
+              "title": "Parametric Modeling Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111",
+              "title": "Fundamentals of Inorganic Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111L",
+              "title": "Fundamentals of Inorganic Chemistry Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "111R",
+              "title": "Fundamentals of Inorganic Chemistry Recitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "171",
+              "title": "Modern Industrial Robotics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "144",
+              "title": "Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "150",
+              "title": "Material Systems &amp; Evaluation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "151",
+              "title": "Physical Metallurgy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "281",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "281L",
+              "title": "General College Physics I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "102",
+              "title": "Industrial &amp; Construction Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "276",
+              "title": "Welding Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group Total: 9 Credits / 12-14 Contact Hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements (minimum of 18 credits required)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "English Composition (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
@@ -2800,31 +11647,25 @@
           "name": "Mathematics (3-4 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
-        },
-        {
-          "name": "Additional General Education Credits to Fulfill General Education Requirements",
-          "credits_required": null,
-          "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "and",
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
               "credits": null,
               "or_alternatives": []
             },
             {
               "prefix": "ELEC",
               "number": "XXX",
-              "title": "or",
+              "title": "Successfully complete MATH-115 or higher or test out of MATH-120 or higher.",
               "credits": null,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "welding"
     },
     {
       "title": "Sign Language Interpreter Education, A.A.S.",
@@ -2836,6 +11677,160 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SLIE",
+              "number": "103",
+              "title": "American Sign Language III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "104",
+              "title": "Selected Features of ASL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "203",
+              "title": "ASL Discourse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "204",
+              "title": "American Sign Language IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "205",
+              "title": "American Sign Language V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "206",
+              "title": "Intro to ASL Linguistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "215",
+              "title": "Professional Responsibility",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "220",
+              "title": "Processing Skills Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "230",
+              "title": "ASL to English I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "231",
+              "title": "ASL to English II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "240",
+              "title": "Interpreting and Transliterating I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "241",
+              "title": "Interpreting and Transliterating II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "242",
+              "title": "Advanced Skill Development Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "255",
+              "title": "Interpreters Certification Prep.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "290",
+              "title": "Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "291",
+              "title": "Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SLIE",
+              "number": "245",
+              "title": "Intro to Deaf Blind Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "250",
+              "title": "Educational Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "120",
+              "title": "Acting I - Fundamentals of Acting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "General Education Requirements (minimum of 18 credits required)",
           "credits_required": 18,
           "choose_n": null,
@@ -2845,7 +11840,22 @@
           "name": "English Composition (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
@@ -2863,25 +11873,230 @@
           "name": "Mathematics (3-5 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "104",
+              "title": "Composition for Technical Fields II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         }
       ],
       "matched_program_slug": null
     },
     {
-      "title": "Welding Technology, A.A.S.",
+      "title": "Social Work Technician, A.A.S.",
       "credential": "AA",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2265",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2246",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
       "requirement_groups": [
         {
-          "name": "Group Total: 9 Credits / 12-14 Contact Hours",
-          "credits_required": 9,
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "SOCW",
+              "number": "131",
+              "title": "Introduction to Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "133",
+              "title": "Child Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "134",
+              "title": "Social Work Practice Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "230",
+              "title": "Social Work Practice With Groups",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "236",
+              "title": "Introduction to Social Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Students must complete a total of 7 credits from the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "240",
+              "title": "Social Work Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "250",
+              "title": "Social Work Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "260A",
+              "title": "Social Work Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "260B",
+              "title": "Social Work Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "260C",
+              "title": "Social Work Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "260D",
+              "title": "Social Work Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "260E",
+              "title": "Social Work Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "260F",
+              "title": "Social Work Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "260G",
+              "title": "Social Work Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CASD",
+              "number": "123",
+              "title": "Stress Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Select 9 credits from the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "286",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "136",
+              "title": "An Introduction to the Study of Substance Abuse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "137",
+              "title": "Substance Abuse Services and Policy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "138",
+              "title": "Social Work With the Aged",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "139",
+              "title": "Overview of Substance Abuse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "235",
+              "title": "Co-Occuring disorders in Substance Abuse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "236",
+              "title": "Introduction to Social Welfare",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "General Education Requirements (minimum of 18 credits required)",
@@ -2890,22 +12105,81 @@
           "courses": []
         },
         {
-          "name": "English Composition (3 credits)",
-          "credits_required": 3,
+          "name": "English Composition (6 credits)",
+          "credits_required": 6,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Humanities (3 credits)",
           "credits_required": 3,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
-          "name": "Social Science (3 credits)",
-          "credits_required": 3,
+          "name": "Social Science (select a minimum of 12 credits from the following)",
+          "credits_required": 12,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "211",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "193",
+              "title": "Marriage and the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "294",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         },
         {
           "name": "Mathematics (3-4 credits)",
@@ -2913,16 +12187,30 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Successfully complete MATH-115 or higher or test out of MATH-120 or higher.",
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Credits to Fulfill General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "150",
+              "title": "The Human Body",
               "credits": null,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": "welding"
+      "matched_program_slug": null
     },
     {
       "title": "Accounting Certificate",
@@ -2932,7 +12220,92 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "101",
+              "title": "Applied Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "105",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "107",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "215",
+              "title": "Individual Income Tax Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "106",
+              "title": "Financial Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "181",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "accounting"
     },
     {
@@ -2950,9 +12323,44 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "DESN",
+              "number": "115",
+              "title": "Intro to Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "140",
+              "title": "Principles of Interpersonal Communication",
               "credits": null,
               "or_alternatives": []
             }
@@ -2962,17 +12370,6 @@
       "matched_program_slug": "art"
     },
     {
-      "title": "Business Management Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2180",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "business-administration"
-    },
-    {
       "title": "Automotive Alternative Fuels",
       "credential": "other",
       "program_code": null,
@@ -2980,18 +12377,71 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "automotive-technology"
-    },
-    {
-      "title": "Automotive Undercar Repair Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2172",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTO",
+              "number": "119",
+              "title": "Engine Theory and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "161",
+              "title": "Electrical Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "182",
+              "title": "Ignition and Fuel Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "191",
+              "title": "Automotive Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "262",
+              "title": "Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "265",
+              "title": "Introduction to Electric Vehicles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "283",
+              "title": "Advanced Engine Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "290",
+              "title": "Light Duty Diesel Repair",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "automotive-technology"
     },
     {
@@ -3002,8 +12452,189 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FRSC",
+              "number": "160",
+              "title": "Introduction to Forensic Pathology and the Morgue",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "161",
+              "title": "Occupational Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "165",
+              "title": "Introduction to Autopsy Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "166",
+              "title": "Autopsy Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "151",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "151L",
+              "title": "Human Anatomy and Physiology I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "152L",
+              "title": "Human Anatomy and Physiology II Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRSC",
+              "number": "100",
+              "title": "Survey of Forensic Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "210",
+              "title": "Forensic Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "161",
+              "title": "Introduction to Law Enforcement and the Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Undercar Repair Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2172",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUTO",
+              "number": "119",
+              "title": "Engine Theory and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "131",
+              "title": "Manual Transmission/Drive Axles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "141",
+              "title": "Suspension and Alignment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "151",
+              "title": "Brakes and Braking Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "161",
+              "title": "Electrical Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "182",
+              "title": "Ignition and Fuel Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "191",
+              "title": "Automotive Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUTO",
+              "number": "292",
+              "title": "Service Floor I Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
     },
     {
       "title": "CADD/CAM Certificate",
@@ -3015,33 +12646,43 @@
       "description": null,
       "requirement_groups": [
         {
-          "name": "Select from courses below to reach a program total of 30 credits:",
-          "credits_required": 30,
-          "choose_n": null,
-          "courses": []
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "CAD and Design - Mechanical Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2184",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [
-        {
           "name": "Occupational Specialty Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Any 200 level CADD course - select two courses / 8 Contact Hours",
-              "credits": 6,
+              "prefix": "CADD",
+              "number": "100",
+              "title": "Mechanical Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "120",
+              "title": "2D CADD Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "130",
+              "title": "Parametric Modeling Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "150",
+              "title": "Intro to Analysis CAM &amp; Sim. Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "160",
+              "title": "Fundamentals of Design",
+              "credits": null,
               "or_alternatives": []
             }
           ]
@@ -3050,7 +12691,78 @@
           "name": "Select from courses below to reach a program total of 30 credits:",
           "credits_required": 30,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "143",
+              "title": "Programmable Logic Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "144",
+              "title": "Programmable Logic Controllers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "144",
+              "title": "Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "246",
+              "title": "CNC Lathe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "247",
+              "title": "CNC Mill",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "249",
+              "title": "MasterCAM",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "170",
+              "title": "Modern Industrial Robotics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "171",
+              "title": "Modern Industrial Robotics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "120",
+              "title": "Introduction to Fab Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "143",
+              "title": "Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         }
       ],
       "matched_program_slug": null
@@ -3065,10 +12777,66 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "110",
+              "title": "Architectural Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "120",
+              "title": "2D CADD Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "130",
+              "title": "Parametric Modeling Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "172",
+              "title": "Architectural Detailing Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "261",
+              "title": "Bldg Design Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Select from courses below to reach a program total of 30 credits:",
           "credits_required": 30,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -3089,6 +12857,137 @@
       "matched_program_slug": null
     },
     {
+      "title": "Business Management Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2180",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "099",
+              "title": "Foundations of College Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGMT",
+              "number": "181",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "283",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "284",
+              "title": "Labor Relations for the Supervisor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "286",
+              "title": "Human Resources Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "106",
+              "title": "Financial Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "261",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "221",
+              "title": "Principles of Economics (Macroeconomics)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "181",
+              "title": "Applied Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
       "title": "Computer Networking Technology Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -3096,27 +12995,252 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Computer Repair Technician Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2194",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
       "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMC",
+              "number": "115",
+              "title": "A+ Core Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMC",
+              "number": "125",
+              "title": "A+ Operating System Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "120",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "144",
+              "title": "Network Infrastructure Configuration &amp; Implementation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "154",
+              "title": "Routing Protocol/Networking Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "164",
+              "title": "Client and Server Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "174",
+              "title": "Advanced Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "184",
+              "title": "Information Security in a Digital Age",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "130",
+              "title": "Introduction to Linux Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
         {
           "name": "Recommended Elective Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "COMI",
+              "number": "268",
+              "title": "Externship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "269",
+              "title": "Externship II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CAD and Design - Mechanical Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2184",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "100",
+              "title": "Mechanical Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "120",
+              "title": "2D CADD Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "130",
+              "title": "Parametric Modeling Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "140",
+              "title": "Mechanical Detailing Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "150",
+              "title": "Intro to Analysis CAM &amp; Sim. Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "160",
+              "title": "Fundamentals of Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
-              "title": "Any college level course",
+              "title": "Any 200 level CADD course - select two courses / 8 Contact Hours",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Select from courses below to reach a program total of 30 credits:",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "201",
+              "title": "Unigraphics Basic Modeling &amp; Drafting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "203",
+              "title": "Advanced Dimensioning &amp; Geometric Dimensioning and Tolerancing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "204",
+              "title": "CADD Product Design Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "205",
+              "title": "CADD Tool &amp; Design Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "206",
+              "title": "Product Data Management Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "110",
+              "title": "Architectural Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "202",
+              "title": "Catia Basic Modeling and Drafting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "150",
+              "title": "Material Systems &amp; Evaluation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "120",
+              "title": "Introduction to Fab Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
               "credits": null,
               "or_alternatives": []
             }
@@ -3133,28 +13257,6 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Computer Science Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2195",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "computer-science"
-    },
-    {
-      "title": "Computer Security & Controls Post Degree Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2269",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
       "requirement_groups": [
         {
           "name": "Occupational Specialty Courses",
@@ -3162,37 +13264,51 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "and",
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "or",
+              "prefix": "COMI",
+              "number": "261",
+              "title": "Database Concepts",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "or",
+              "prefix": "COMS",
+              "number": "170",
+              "title": "Introduction to Programming",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "or",
+              "prefix": "COMS",
+              "number": "171",
+              "title": "Introduction to C++",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "or",
+              "prefix": "COMS",
+              "number": "176",
+              "title": "Introduction to .NET programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "276",
+              "title": "Advanced .NET Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "280",
+              "title": "Adv Programming in C++",
               "credits": null,
               "or_alternatives": []
             }
@@ -3204,9 +13320,16 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Any college level course",
+              "prefix": "COMI",
+              "number": "268",
+              "title": "Externship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "269",
+              "title": "Externship II",
               "credits": null,
               "or_alternatives": []
             }
@@ -3223,7 +13346,560 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMC",
+              "number": "115",
+              "title": "A+ Core Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMC",
+              "number": "125",
+              "title": "A+ Operating System Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "120",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "144",
+              "title": "Network Infrastructure Configuration &amp; Implementation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "164",
+              "title": "Client and Server Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "174",
+              "title": "Advanced Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "184",
+              "title": "Information Security in a Digital Age",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "224",
+              "title": "Network Security Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "274",
+              "title": "Cybersecurity and Ethical Hacking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMI",
+              "number": "268",
+              "title": "Externship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "269",
+              "title": "Externship II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Repair Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2194",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMC",
+              "number": "115",
+              "title": "A+ Core Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMC",
+              "number": "125",
+              "title": "A+ Operating System Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "160",
+              "title": "Introduction to Computer Info Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "169",
+              "title": "Supporting End Users",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "120",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "144",
+              "title": "Network Infrastructure Configuration &amp; Implementation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "184",
+              "title": "Information Security in a Digital Age",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "130",
+              "title": "Introduction to Linux Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMI",
+              "number": "268",
+              "title": "Externship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "269",
+              "title": "Externship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any college level course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2195",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "160",
+              "title": "Introduction to Computer Info Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "120",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "130",
+              "title": "Introduction to Linux Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "170",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "171",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "176",
+              "title": "Introduction to .NET programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "276",
+              "title": "Advanced .NET Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "280",
+              "title": "Adv Programming in C++",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Support Services and Help Desk Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2197",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMC",
+              "number": "115",
+              "title": "A+ Core Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMC",
+              "number": "125",
+              "title": "A+ Operating System Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "160",
+              "title": "Introduction to Computer Info Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "169",
+              "title": "Supporting End Users",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "120",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "184",
+              "title": "Information Security in a Digital Age",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "130",
+              "title": "Introduction to Linux Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "170",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Security & Controls Post Degree Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2269",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMI",
+              "number": "261",
+              "title": "Database Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "264",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "144",
+              "title": "Network Infrastructure Configuration &amp; Implementation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "184",
+              "title": "Information Security in a Digital Age",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "120",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "170",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMC",
+              "number": "115",
+              "title": "A+ Core Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "130",
+              "title": "Introduction to Linux Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMC",
+              "number": "125",
+              "title": "A+ Operating System Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "154",
+              "title": "Routing Protocol/Networking Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "164",
+              "title": "Client and Server Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMN",
+              "number": "224",
+              "title": "Network Security Practices",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMI",
+              "number": "268",
+              "title": "Externship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "269",
+              "title": "Externship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any college level course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -3234,19 +13910,107 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CORR",
+              "number": "101",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "102",
+              "title": "Client Relations to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "103",
+              "title": "Legal Issues in Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "104",
+              "title": "Client Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "105",
+              "title": "Correctional Institutions/Facilities",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "200",
+              "title": "Survey of Human Communication Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition for Technical Fields I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "102",
+              "title": "Circuit Training for Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "106",
+              "title": "Physical Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "297",
+              "title": "Introduction to Criminology Correction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "criminal-justice"
-    },
-    {
-      "title": "Computer Support Services and Help Desk Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2197",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
     },
     {
       "title": "Cosmetology Certificate",
@@ -3256,7 +14020,99 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSMO",
+              "number": "100",
+              "title": "Basic Cosmetology Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "101",
+              "title": "Basic Cosmetology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "102",
+              "title": "Basic Cosmetology Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "103",
+              "title": "Basic Cosmetology Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "200",
+              "title": "Advanced Cosmetology Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "201",
+              "title": "Advanced Cosmetology Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "202",
+              "title": "Adv Cosmetology Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "203",
+              "title": "Advanced Cosmetology Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "204",
+              "title": "Advanced Cosmetology Theory III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "205",
+              "title": "Advanced Cosmetology Lab III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "206",
+              "title": "Advanced Cosmetology Theory IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "207",
+              "title": "Advanced Cosmetology Lab IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -3272,32 +14128,186 @@
           "name": "Select 15 credits from the following",
           "credits_required": 15,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "CORR",
+              "number": "101",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "151",
+              "title": "Introduction to Security Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "152",
+              "title": "Principles of Loss Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "161",
+              "title": "Introduction to Law Enforcement and the Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "162",
+              "title": "Administrative Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "163",
+              "title": "Patrol Administration Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "165",
+              "title": "Hwy Traffic Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "263",
+              "title": "Techniques of Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "264",
+              "title": "Court Testimony and Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "265",
+              "title": "Criminal Law and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "269",
+              "title": "Introduction to the Juvenile Justice System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "271",
+              "title": "Practicum in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Select 1 course from the following",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PEAC",
+              "number": "106",
+              "title": "Physical Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEAC",
+              "number": "193",
+              "title": "Self-Defense",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Select 3 courses from the following",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "211",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "181",
+              "title": "Applied Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "286",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "294",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "297",
+              "title": "Introduction to Criminology Correction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         }
       ],
       "matched_program_slug": "criminal-justice"
-    },
-    {
-      "title": "Early Childhood Education Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2212",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "early-childhood-education"
-    },
-    {
-      "title": "Dental Assisting Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2206",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
     },
     {
       "title": "Customer Energy Specialist Certificate",
@@ -3307,18 +14317,473 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "General Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Business",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "101",
+              "title": "Applied Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "202",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "261",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "100",
+              "title": "Mechanical Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "110",
+              "title": "Architectural Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "120",
+              "title": "2D CADD Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "172",
+              "title": "Architectural Detailing Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHSM",
+              "number": "222",
+              "title": "Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "281",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
-      "title": "Early Childhood Education Infant & Toddler Certificate",
+      "title": "Dental Assisting Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2213",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2206",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAST",
+              "number": "110",
+              "title": "Orientation to Dentistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "111",
+              "title": "Infection Control for Dental Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "112",
+              "title": "Dental and Oral Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "112L",
+              "title": "Dental &amp; Oral Anatomy Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "113",
+              "title": "Dental Office Emergencies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "115",
+              "title": "Nutrition &amp; Preventive Dentistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "116",
+              "title": "Dental Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "116L",
+              "title": "Dental Materials Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "117",
+              "title": "Operative Techniques I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "117C",
+              "title": "Operative Techniques I Clinic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "117L",
+              "title": "Operative Techniques I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "120",
+              "title": "Oral Pathology for Dental Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "121",
+              "title": "Dental Jurisprudence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "122",
+              "title": "Pharmacology for Dental Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "123",
+              "title": "Advanced Clinical Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "124",
+              "title": "Expanded Functions for Dental Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "124L",
+              "title": "Expanded Functions for Dental Assistants Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "125",
+              "title": "Operative Techniques II Clinic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "126",
+              "title": "Dental Specialities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "127",
+              "title": "Dental Business Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "130",
+              "title": "Operative Techniques Externship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAST",
+              "number": "130C",
+              "title": "Operative Techniques III Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHDA",
+              "number": "114",
+              "title": "Dental Radiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHDA",
+              "number": "114L",
+              "title": "Dental Radiography Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "150",
+              "title": "The Human Body",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEAL",
+              "number": "125",
+              "title": "Cardiopulmonary Resuscitation (CPR)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2212",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "103",
+              "title": "Professional Ethics Early Childhood Educ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "105",
+              "title": "School Age Development and Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "110",
+              "title": "Applied Child Development &amp; Family Engagement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "190",
+              "title": "Literacy and Numeracy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "199",
+              "title": "Guidance and Discipline",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "200",
+              "title": "Early Childhood Learning Environments",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "201",
+              "title": "Curriculum Planning in Early Childhood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "202",
+              "title": "Admin of Programs for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "203",
+              "title": "Learning Env: Infants and Toddlers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "205",
+              "title": "Field Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "210",
+              "title": "Child Observation &amp; Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "211",
+              "title": "Adapt Early Child Curricula - The Special Needs Child",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "105L",
+              "title": "School Age Development and Education Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "early-childhood-education"
     },
     {
@@ -3331,10 +14796,556 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "124",
+              "title": "Electrical Wiring Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "134",
+              "title": "Electronic Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "141",
+              "title": "Introduction to Semiconductors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "142",
+              "title": "Semiconductor Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "143",
+              "title": "Programmable Logic Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "144",
+              "title": "Programmable Logic Controllers II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Select a minimum of 12 credits from the following",
           "credits_required": 12,
           "choose_n": null,
-          "courses": []
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "138",
+              "title": "Control Panel Building",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "150",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "151",
+              "title": "Sizing of Commercial/Industrial Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "231",
+              "title": "Fundamentals of Labview",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "233",
+              "title": "Embedded Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "236",
+              "title": "Industrial Automation and Control",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education Infant & Toddler Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2213",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "103",
+              "title": "Professional Ethics Early Childhood Educ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "110",
+              "title": "Applied Child Development &amp; Family Engagement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "203",
+              "title": "Learning Env: Infants and Toddlers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "204",
+              "title": "Infant and Toddler Curriculum Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "206",
+              "title": "Infant &amp; Toddler Fieldwork Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "193",
+              "title": "Marriage and the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "285",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Electrical Technology for Apprentice Electricians Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2214",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "110",
+              "title": "Electrical Industry Orientation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "124",
+              "title": "Electrical Wiring Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "134",
+              "title": "Electronic Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "141",
+              "title": "Introduction to Semiconductors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "142",
+              "title": "Semiconductor Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "143",
+              "title": "Programmable Logic Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "144",
+              "title": "Programmable Logic Controllers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "140",
+              "title": "Electrical Principles of Fire Alarm and Safety Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "150",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "151",
+              "title": "Sizing of Commercial/Industrial Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "155",
+              "title": "Electric Motors Transformers and Power",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TECH",
+              "number": "102",
+              "title": "Industrial &amp; Construction Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Higher Mathematics course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurship Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2217",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENTR",
+              "number": "120",
+              "title": "Entrepreneurial Mindset",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "130",
+              "title": "Opportunity Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "140",
+              "title": "Business Professional Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "200",
+              "title": "Entrepreneurial Co-Op",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "220",
+              "title": "Financial Management for Small Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "230",
+              "title": "Entrepreneurial Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "250",
+              "title": "Business Plan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENTR",
+              "number": "290",
+              "title": "Entrepreneurial Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "101",
+              "title": "Applied Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "262",
+              "title": "Business Law II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "257",
+              "title": "Consumer Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Esthetics Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2198",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSMO",
+              "number": "110",
+              "title": "Esthetics Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "111A",
+              "title": "Esthetics Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "111B",
+              "title": "Esthetics Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "112",
+              "title": "Esthetics Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "113A",
+              "title": "Esthetics Lab III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "113B",
+              "title": "Esthetics Lab IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "106",
+              "title": "Financial Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
         }
       ],
       "matched_program_slug": null
@@ -3349,6 +15360,20 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "General Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Group I - Humanities - Select a minimum of 3 credits",
           "credits_required": 3,
           "choose_n": null,
@@ -3358,6 +15383,118 @@
               "number": "XXX",
               "title": "Any ARBC course / 4 Contact Hours",
               "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "210",
+              "title": "Persuasion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "231",
+              "title": "Discussion Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "233",
+              "title": "Oral Interpretation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "205",
+              "title": "Creative Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "210",
+              "title": "Childrens Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "220",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "221",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "222",
+              "title": "Science Fiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "223",
+              "title": "Black American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "225",
+              "title": "Poetry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "227",
+              "title": "Fiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "231",
+              "title": "American Literature to 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "232",
+              "title": "American Literature 1865 to present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "242",
+              "title": "British &amp; Irish Literature 1798 to Present",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "181",
+              "title": "Introduction to Film",
+              "credits": null,
               "or_alternatives": []
             },
             {
@@ -3389,10 +15526,87 @@
               "or_alternatives": []
             },
             {
+              "prefix": "PHOT",
+              "number": "188",
+              "title": "History of Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Any RUSN course / 4 Contact Hours",
               "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "103",
+              "title": "American Sign Language III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "204",
+              "title": "American Sign Language IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SLIE",
+              "number": "205",
+              "title": "American Sign Language V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "181",
+              "title": "Elementary Spanish",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "182",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "281",
+              "title": "Intermediate Spanish",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "282",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "295",
+              "title": "Spanish for Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "298",
+              "title": "Intro to Span/Amer Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "110",
+              "title": "Theatre Appreciation",
+              "credits": null,
               "or_alternatives": []
             }
           ]
@@ -3477,58 +15691,120 @@
       "matched_program_slug": "liberal-arts"
     },
     {
-      "title": "Entrepreneurship Certificate",
+      "title": "Instructor Certificate in Cosmetology Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2217",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Electrical Technology for Apprentice Electricians Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2214",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2274",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
       "requirement_groups": [
         {
-          "name": "Related Requirement Courses",
+          "name": "Occupational Specialty Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "or",
+              "prefix": "CSMO",
+              "number": "210",
+              "title": "CSMO/Nailtech/Esthetic Instructor Theory I",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Higher Mathematics course",
+              "prefix": "CSMO",
+              "number": "211",
+              "title": "CSMO/Nailtech/Esthetics Instructor Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "212",
+              "title": "CSMO/Nailtech/Esthetic Instructor Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "213",
+              "title": "CSMO/Nailtech/Esthetics Instructor Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "216",
+              "title": "Cosmetology Instructor Lab III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "106",
+              "title": "Financial Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "181",
+              "title": "Applied Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
               "credits": null,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Esthetics Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2198",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
       "matched_program_slug": null
     },
     {
@@ -3539,30 +15815,128 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DESN",
+              "number": "270",
+              "title": "Design Portfolio Prep",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "271",
+              "title": "Design Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DESN",
+              "number": "120",
+              "title": "Digital Imaging I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "121",
+              "title": "Digital Imaging II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "130",
+              "title": "Type I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "210",
+              "title": "Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "211",
+              "title": "Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "212",
+              "title": "Design III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "230",
+              "title": "Type II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "240",
+              "title": "Experience Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "100",
+              "title": "Intro to Media Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "253",
+              "title": "Advertising",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "180",
+              "title": "Basic Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "182",
+              "title": "Introduction to Light and Color",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "art"
-    },
-    {
-      "title": "Instructor Certificate in Cosmetology Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2274",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Instructor Certificate in Esthetics Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2273",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
     },
     {
       "title": "Heating, Ventilation, Air Conditioning & Refrigeration Technology Certificate",
@@ -3572,7 +15946,188 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HVAC",
+              "number": "140",
+              "title": "Basic Mechanical Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "141",
+              "title": "Air Condition &amp; Refrigeration Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "142",
+              "title": "Heating Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "143",
+              "title": "Sealed System Installation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "144",
+              "title": "Air Conditioning Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "145",
+              "title": "Duct System Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Select 5 or more credits from the following",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "110",
+              "title": "Architectural Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVAC",
+              "number": "147",
+              "title": "Refrigerant Handling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "143",
+              "title": "Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Tool Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2227",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CADD",
+              "number": "100",
+              "title": "Mechanical Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "144",
+              "title": "Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "150",
+              "title": "Material Systems &amp; Evaluation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "151",
+              "title": "Physical Metallurgy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "210",
+              "title": "Advanced Machining for Tooling and Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "260",
+              "title": "Advanced CNC Setup, Programming &amp; Operation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "246",
+              "title": "CNC Lathe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "247",
+              "title": "CNC Mill",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "102",
+              "title": "Industrial &amp; Construction Safety",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirements Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MATH",
+              "number": "116",
+              "title": "Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -3583,29 +16138,216 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSMO",
+              "number": "210",
+              "title": "CSMO/Nailtech/Esthetic Instructor Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "211",
+              "title": "CSMO/Nailtech/Esthetics Instructor Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "212",
+              "title": "CSMO/Nailtech/Esthetic Instructor Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "213",
+              "title": "CSMO/Nailtech/Esthetics Instructor Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "106",
+              "title": "Financial Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "181",
+              "title": "Applied Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
-      "title": "Marketing Certificate",
+      "title": "Instructor Certificate in Esthetics Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2230",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2273",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "business-administration"
-    },
-    {
-      "title": "Machine Tool Technology Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2227",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSMO",
+              "number": "210",
+              "title": "CSMO/Nailtech/Esthetic Instructor Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "211",
+              "title": "CSMO/Nailtech/Esthetics Instructor Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "212",
+              "title": "CSMO/Nailtech/Esthetic Instructor Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "213",
+              "title": "CSMO/Nailtech/Esthetics Instructor Lab II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "106",
+              "title": "Financial Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "181",
+              "title": "Applied Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "191",
+              "title": "Introductory Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -3623,6 +16365,41 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "DESN",
+              "number": "100",
+              "title": "Design Careers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "115",
+              "title": "Intro to Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "120",
+              "title": "Digital Imaging I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "121",
+              "title": "Digital Imaging II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DESN",
+              "number": "130",
+              "title": "Type I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Choose one of the following:",
@@ -3635,6 +16412,27 @@
               "title": "Choose one of the following:",
               "credits": null,
               "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "100",
+              "title": "Intro to Media Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "253",
+              "title": "Advertising",
+              "credits": null,
+              "or_alternatives": []
             }
           ]
         },
@@ -3644,9 +16442,30 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "131",
+              "title": "Fundamentals of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "140",
+              "title": "Principles of Interpersonal Communication",
               "credits": null,
               "or_alternatives": []
             }
@@ -3663,19 +16482,203 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "124",
+              "title": "Electrical Wiring Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "134",
+              "title": "Electronic Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "141",
+              "title": "Introduction to Semiconductors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "142",
+              "title": "Semiconductor Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "143",
+              "title": "Programmable Logic Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "144",
+              "title": "Programmable Logic Controllers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "155",
+              "title": "Electric Motors Transformers and Power",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "170",
+              "title": "Modern Industrial Robotics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "171",
+              "title": "Modern Industrial Robotics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "236",
+              "title": "Industrial Automation and Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "120",
+              "title": "Mechanical Components and Drives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MECH",
+              "number": "130",
+              "title": "Pneumatic &amp; Hydraulic Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
-      "title": "Media Arts & Entertainment Technology Production Fundamentals Certificate",
+      "title": "Marketing Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2233",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2230",
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
+      "requirement_groups": [
+        {
+          "name": "General Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGMT",
+              "number": "181",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "185",
+              "title": "Retail Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "108",
+              "title": "Sales",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "150",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKTG",
+              "number": "253",
+              "title": "Advertising",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "106",
+              "title": "Financial Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "261",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
     },
     {
       "title": "Nail Technology",
@@ -3685,7 +16688,92 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSMO",
+              "number": "104",
+              "title": "Nail Technology Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "105A",
+              "title": "Nail Technology Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "105B",
+              "title": "Nail Technology Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "106",
+              "title": "Nail Technology Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "107A",
+              "title": "Nail Technology Lab III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSMO",
+              "number": "107B",
+              "title": "Nail Technology Lab IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "106",
+              "title": "Financial Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGMT",
+              "number": "183",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -3715,17 +16803,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Professional Baking Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2262",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
       "title": "Photography Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -3735,14 +16812,84 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHOT",
+              "number": "180",
+              "title": "Basic Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "182",
+              "title": "Introduction to Light and Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "183",
+              "title": "Intro to Commercial Studio Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "186",
+              "title": "Careers in Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "190",
+              "title": "Introduction to Digital Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "192",
+              "title": "Advanced Digital Imaging",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Related Requirement Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "MAET",
+              "number": "100",
+              "title": "Intro to Media Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Select 2 courses from the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "210",
+              "title": "Advanced Studio Lighting Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "211",
+              "title": "Commercial Portraiture",
               "credits": null,
               "or_alternatives": []
             },
@@ -3759,6 +16906,198 @@
       "matched_program_slug": null
     },
     {
+      "title": "Media Arts & Entertainment Technology Production Fundamentals Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2233",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAET",
+              "number": "100",
+              "title": "Intro to Media Production",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DESN",
+              "number": "115",
+              "title": "Intro to Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "110",
+              "title": "Media History and Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "120",
+              "title": "Media Aesthetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "140",
+              "title": "Podcast Design &amp; Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "150",
+              "title": "News Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "180",
+              "title": "Intro to Screenwriting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "210",
+              "title": "Cinema Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "250",
+              "title": "Documentary Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAET",
+              "number": "260",
+              "title": "Media Production Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHOT",
+              "number": "180",
+              "title": "Basic Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THTR",
+              "number": "120",
+              "title": "Acting I - Fundamentals of Acting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Baking Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2262",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAKE",
+              "number": "101",
+              "title": "Introduction to Baking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "102",
+              "title": "Bake Shop I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "103",
+              "title": "Basic Cake Decorating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "113",
+              "title": "Artisan Breads",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "114",
+              "title": "Modern Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "115",
+              "title": "Pastry Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAKE",
+              "number": "206",
+              "title": "Bake Shop II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "100",
+              "title": "Orientation to Food Services",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Professional Cooking Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -3766,7 +17105,78 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "100",
+              "title": "Orientation to Food Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "101",
+              "title": "Culinary Knife Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "105",
+              "title": "Intro to Professional Cookery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "106",
+              "title": "Professional Cookery I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "111",
+              "title": "Garde Manger I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "115",
+              "title": "Nutrition and Menu Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "205",
+              "title": "International Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "207",
+              "title": "Garde Manger II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "210",
+              "title": "Food and Wine Pairing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -3779,10 +17189,66 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "170",
+              "title": "Modern Industrial Robotics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "171",
+              "title": "Modern Industrial Robotics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "143",
+              "title": "Programmable Logic Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "144",
+              "title": "Programmable Logic Controllers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "236",
+              "title": "Industrial Automation and Control",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Related Requirement Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "COMS",
+              "number": "171",
+              "title": "Introduction to C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "231",
+              "title": "Fundamentals of Labview",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -3796,17 +17262,6 @@
       "matched_program_slug": null
     },
     {
-      "title": "Web Developer Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2250",
-      "total_credits": null,
-      "gpa_minimum": 2,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
       "title": "Substance Abuse Services Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -3814,7 +17269,148 @@
       "total_credits": null,
       "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOCW",
+              "number": "131",
+              "title": "Introduction to Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "134",
+              "title": "Social Work Practice Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "136",
+              "title": "An Introduction to the Study of Substance Abuse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "137",
+              "title": "Substance Abuse Services and Policy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "139",
+              "title": "Overview of Substance Abuse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "230",
+              "title": "Social Work Practice With Groups",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "235",
+              "title": "Co-Occuring disorders in Substance Abuse",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Option 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOCY",
+              "number": "193",
+              "title": "Marriage and the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "236",
+              "title": "Introduction to Social Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCW",
+              "number": "238",
+              "title": "Introduction to Community Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Option 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "281",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "286",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "290",
+              "title": "Psychology of Adolescence",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Option 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOCY",
+              "number": "193",
+              "title": "Marriage and the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "161",
+              "title": "Introduction to Law Enforcement and the Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJU",
+              "number": "269",
+              "title": "Introduction to the Juvenile Justice System",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -3827,14 +17423,84 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WELD",
+              "number": "143",
+              "title": "Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "164",
+              "title": "Base Metal Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "166",
+              "title": "Shielded Metal Arc Welding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "168",
+              "title": "Gas Tungsten Arc Welding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "170",
+              "title": "Gas Metal Arc Welding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WELD",
+              "number": "174",
+              "title": "Flux Cored Arc Welding I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Related Requirement Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "MATH",
+              "number": "115",
+              "title": "Foundations of Mathematics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Students can test out by placing into MATH-130 or higher on the placement test.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CADD",
+              "number": "100",
+              "title": "Mechanical Blueprint Reading w/CADD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
               "credits": null,
               "or_alternatives": []
             },
@@ -3851,15 +17517,107 @@
       "matched_program_slug": "welding"
     },
     {
-      "title": "Child Development Associate Credential",
-      "credential": "AA",
+      "title": "Web Developer Certificate",
+      "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2161",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2250",
       "total_credits": null,
-      "gpa_minimum": null,
+      "gpa_minimum": 2,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "early-childhood-education"
+      "requirement_groups": [
+        {
+          "name": "Occupational Specialty Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMG",
+              "number": "153",
+              "title": "Computers-A Practical Approach",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "261",
+              "title": "Database Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "170",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "176",
+              "title": "Introduction to .NET programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMS",
+              "number": "276",
+              "title": "Advanced .NET Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMW",
+              "number": "100",
+              "title": "Introduction to Web Page Creation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMW",
+              "number": "282",
+              "title": "Dynamic Web Pages",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Related Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMI",
+              "number": "268",
+              "title": "Externship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMI",
+              "number": "269",
+              "title": "Externship II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
     },
     {
       "title": "Apprentice Preparation",
@@ -3880,19 +17638,119 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Corrections Officer Academic Program",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CORR",
+              "number": "101",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "102",
+              "title": "Client Relations to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "103",
+              "title": "Legal Issues in Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "104",
+              "title": "Client Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CORR",
+              "number": "105",
+              "title": "Correctional Institutions/Facilities",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "criminal-justice"
     },
     {
-      "title": "Phlebotomy",
-      "credential": "other",
+      "title": "Child Development Associate Credential",
+      "credential": "AA",
       "program_code": null,
-      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2166",
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2161",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
+      "requirement_groups": [
+        {
+          "name": "Infant/Toddler Endorsement (under 2-1/2 years)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "103",
+              "title": "Professional Ethics Early Childhood Educ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "110",
+              "title": "Applied Child Development &amp; Family Engagement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "203",
+              "title": "Learning Env: Infants and Toddlers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Preschool Endorsement (2-1/2 - 5 years)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "103",
+              "title": "Professional Ethics Early Childhood Educ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "110",
+              "title": "Applied Child Development &amp; Family Engagement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "201",
+              "title": "Curriculum Planning in Early Childhood",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
     },
     {
       "title": "Health Unit Coordinator - Ward Clerk",
@@ -3903,6 +17761,46 @@
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mcc.edu/preview_program.php?catoid=18&poid=2166",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Specific Requirement Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHLT",
+              "number": "130",
+              "title": "Phlebotomy Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHLT",
+              "number": "130C",
+              "title": "Phlebotomy Technician - Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHLT",
+              "number": "130L",
+              "title": "Phlebotomy Technician - Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     }
   ]

--- a/data/nc/DEFERRED-programs.md
+++ b/data/nc/DEFERRED-programs.md
@@ -4,12 +4,12 @@ Programs rollout for North Carolina (NCCCS, 58 colleges). Catalog platform per
 college is fingerprinted by `scripts/nc/discover-catalogs.ts` →
 `data/nc/catalog-discovery.json`, then scraped by the matching platform wrapper.
 
-## Shipped — 17 colleges, 2,520 programs scraped; **1,803 plannable across 16 colleges**
+## Shipped — 17 colleges, 2,520 programs scraped; **1,910 plannable across 16 colleges**
 
 Verified via `countRealCourses >= PLAN_MIN_COURSES`. The Acalog parser fix on
-2026-06-04 unlocked **gaston (0 → 96)** and **guilford-technical (0 → 224)**; surry
-moved from 0 → 1 plannable (most surry programs still have a different requirement
-structure the parser doesn't reach — see "Deferred" below).
+2026-06-04 unlocked **gaston (0 → 96)** and **guilford-technical (0 → 224)**; a
+follow-up regex fix (optional hyphen between prefix and number) then unlocked
+**surry (1 → 108)** — see "Deferred" below.
 
 | Platform | Colleges |
 |---|---|
@@ -26,9 +26,11 @@ Success (1 Credit Hour)`). The fix relaxes the regex and also tries `parseCourse
 on `acalog-adhoc-list-item` text before falling back to ELEC. gaston (0 → 96) and
 guilford-technical (0 → 224) now plan cleanly.
 
-**surry remains mostly 0 plannable (1/169).** Most surry programs use a third structure
-the parser doesn't yet reach — investigation deferred. The cross-state effect is small
-since surry's catalog is unusual.
+**surry — RESOLVED 2026-06-04 (1 → 108 plannable).** surry's course codes are inline in
+`aria-label`s but use a nbsp-hyphen-nbsp separator between prefix and number (`WBL - 110`);
+`parseCourseFromLabel` in `scripts/lib/scrape-acalog-programs.ts` now accepts an optional
+hyphen there. The earlier "third structure / preview_course follow" diagnosis was wrong —
+the codes were never behind links.
 
 ## Deferred gaps (real catalogs, but the generic scrapers don't yet handle them)
 

--- a/data/nc/programs/surry.json
+++ b/data/nc/programs/surry.json
@@ -2,7 +2,7 @@
   "college_slug": "surry",
   "catalog_year": "",
   "catalog_url": "https://catalog.surry.edu",
-  "scraped_at": "2026-06-04T20:17:09.680Z",
+  "scraped_at": "2026-06-05T00:41:58.790Z",
   "programs": [
     {
       "title": "Accounting and Finance Degree",
@@ -12,8 +12,372 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "220",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "225",
+              "title": "Cost Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "151",
+              "title": "Survey of Economics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ECO",
+                  "number": "251",
+                  "title": "Principles of Microeconomics"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "225",
+              "title": "Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Criminal Justice Technology Degree",
+      "credential": "other",
+      "program_code": "A55180",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1307",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Two Semesters",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "141",
+              "title": "Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "213",
+              "title": "Substance Abuse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "232",
+              "title": "Civil Liability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "231",
+              "title": "Forensic Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematical Measurement and Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Hum. /Fine Arts - Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Information Technology Degree",
+      "credential": "other",
+      "program_code": "A25590",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1217",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "People Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "126",
+              "title": "Switching and Routing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NOS",
+              "number": "110",
+              "title": "Operating Systems Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "134",
+              "title": "C++ Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "151",
+              "title": "JAVA Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "120",
+              "title": "Hardware/Software Support",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Digital Media Technology Degree",
+      "credential": "other",
+      "program_code": "A25210A",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1210",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DME",
+              "number": "285",
+              "title": "Systems Project",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "WBL",
+                  "number": "111",
+                  "title": "Work-Based Learning I"
+                }
+              ]
+            },
+            {
+              "prefix": "WBL",
+              "number": "121",
+              "title": "Work-Based Learning II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "142",
+              "title": "Graphic Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTI",
+              "number": "110",
+              "title": "IT Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Social Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GRD",
+              "number": "121",
+              "title": "Drawing Fundamentals I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "210",
+              "title": "User Interface Design Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
     },
     {
       "title": "Associate in Arts Degree - College Transfer",
@@ -25,14 +389,1972 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts and Communications",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature Requirement",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Requirement",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "167",
+              "title": "Discrete Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Math",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Precalculus Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "263",
+              "title": "Brief Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "273",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Natural Science",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Introductory Botany",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "130",
+              "title": "Introductory Zoology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "140",
+              "title": "Environmental Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "131",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "132",
+              "title": "Organic and Biochemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "252",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "126",
+              "title": "Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "151",
+              "title": "Survey of Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Literature-Based Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "131",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "World Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "262",
+              "title": "World Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "110",
+              "title": "Technology and Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "120",
+              "title": "Cultural Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "122",
+              "title": "Southern Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "130",
+              "title": "Myth in Human Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Human Values and Meaning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "210",
+              "title": "History of Rock Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "239",
+              "title": "Psychology of Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "281",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "110",
+              "title": "World Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "211",
+              "title": "Introduction to Old Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "212",
+              "title": "Introduction to New Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "221",
+              "title": "Religion in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "213",
+              "title": "Sociology of the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "225",
+              "title": "Social Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "230",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "211",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "212",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Elective/Pre-Major Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Principles of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "121",
+              "title": "Principles of Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "122",
+              "title": "Three-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "132",
+              "title": "Drawing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "140",
+              "title": "Basic Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "214",
+              "title": "Portfolio and Resume",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "215",
+              "title": "Visual Art Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "240",
+              "title": "Painting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "241",
+              "title": "Painting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "244",
+              "title": "Watercolor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "264",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "281",
+              "title": "Sculpture I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "283",
+              "title": "Ceramics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "284",
+              "title": "Ceramics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "285",
+              "title": "Ceramics III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "286",
+              "title": "Ceramics IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Field Biology Minicourse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Ecology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "146",
+              "title": "Regional Natural History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "155",
+              "title": "Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "163",
+              "title": "Basic Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "168",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "169",
+              "title": "Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Genetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "275",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "137",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "111",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "113",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "121",
+              "title": "Law Enforcement Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "141",
+              "title": "Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "212",
+              "title": "Ethics &amp; Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "134",
+              "title": "C++ Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "139",
+              "title": "Visual BASIC Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "151",
+              "title": "JAVA Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "144",
+              "title": "Child Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "145",
+              "title": "Child Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "221",
+              "title": "Children With Exceptionalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "150",
+              "title": "Intro to Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "125",
+              "title": "Creative Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "126",
+              "title": "Creative Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272",
+              "title": "Southern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEA",
+              "number": "110",
+              "title": "Personal Health/Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "145",
+              "title": "The Second World War",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "163",
+              "title": "The World Since 1945",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "221",
+              "title": "African-American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "226",
+              "title": "The Civil War",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "227",
+              "title": "Native American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "237",
+              "title": "The American Revolution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "262",
+              "title": "Middle East History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "123",
+              "title": "Appalachian Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "180",
+              "title": "International Cultural Exploration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "230",
+              "title": "Leadership Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JOU",
+              "number": "110",
+              "title": "Introduction to Journalism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "280",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "285",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "PED Any Physical Education Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "Chorus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Chorus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "231",
+              "title": "Forensic Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "243",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "263",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "141",
+              "title": "Culture and Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "221",
+              "title": "Spanish Conversation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "231",
+              "title": "Reading and Composition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Arts in Teacher Preparation Degree - College Transfer",
+      "credential": "AA",
+      "program_code": "A1010T",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1184",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "187",
+              "title": "Teaching and Learning for All",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "279",
+              "title": "Literacy Development and Instruction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Teacher Licensure Preparation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts and Communications",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature Requirement",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "225",
+              "title": "Social Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Introductory Botany",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "130",
+              "title": "Introductory Zoology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "140",
+              "title": "Environmental Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "131",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "132",
+              "title": "Organic and Biochemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "126",
+              "title": "Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "151",
+              "title": "Survey of Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Literature-Based Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "131",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "World Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "262",
+              "title": "World Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "110",
+              "title": "Technology and Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "120",
+              "title": "Cultural Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "122",
+              "title": "Southern Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "130",
+              "title": "Myth in Human Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Human Values and Meaning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Precalculus Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "263",
+              "title": "Brief Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "273",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "Chorus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Chorus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "210",
+              "title": "History of Rock Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "252",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "239",
+              "title": "Psychology of Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "281",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "110",
+              "title": "World Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "211",
+              "title": "Introduction to Old Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "212",
+              "title": "Introduction to New Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "221",
+              "title": "Religion in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "213",
+              "title": "Sociology of the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "230",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "211",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "212",
+              "title": "Intermediate Spanish II",
               "credits": null,
               "or_alternatives": []
             }
@@ -56,9 +2378,85 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ACC",
+              "number": "129",
+              "title": "Individual Income Taxes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "225",
+              "title": "Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "260",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Program Elective (or WBL) - See Choices Below **",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "153",
+              "title": "Office Finance Solutions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "130",
+              "title": "Spreadsheet",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "151",
+              "title": "Survey of Economics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ECO",
+                  "number": "251",
+                  "title": "Principles of Microeconomics"
+                }
+              ]
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
               "credits": null,
               "or_alternatives": []
             }
@@ -70,9 +2468,44 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Principles of Financial Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "220",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "People Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "119",
+              "title": "Survey of Artificial Intelligence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "CIS",
               "number": "3119",
               "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
               "credits": null,
               "or_alternatives": []
             }
@@ -82,60 +2515,51 @@
       "matched_program_slug": "business-administration"
     },
     {
-      "title": "Associate in Arts in Teacher Preparation Degree - College Transfer",
-      "credential": "AA",
-      "program_code": "A1010T",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1184",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Criminal Justice Technology Degree",
-      "credential": "other",
-      "program_code": "A55180",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1307",
+      "title": "Bookkeeping Certificate",
+      "credential": "certificate",
+      "program_code": "C25800A",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1199",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [
         {
-          "name": "Two Semesters",
+          "name": "Fall Semester",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Hum. /Fine Arts - Elective",
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Principles of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
               "credits": null,
               "or_alternatives": []
             }
           ]
-        }
-      ],
-      "matched_program_slug": "criminal-justice"
-    },
-    {
-      "title": "Digital Media Technology Degree",
-      "credential": "other",
-      "program_code": "A25210A",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1210",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
+        },
         {
           "name": "Spring Semester",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Elective - Social Science",
+              "prefix": "ACC",
+              "number": "121",
+              "title": "Principles of Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "153",
+              "title": "Office Finance Solutions",
               "credits": null,
               "or_alternatives": []
             }
@@ -143,17 +2567,6 @@
         }
       ],
       "matched_program_slug": null
-    },
-    {
-      "title": "Information Technology Degree",
-      "credential": "other",
-      "program_code": "A25590",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1217",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "computer-science"
     },
     {
       "title": "Accounting and Finance Certificate",
@@ -163,7 +2576,50 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Principles of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "121",
+              "title": "Principles of Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "129",
+              "title": "Individual Income Taxes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "accounting"
     },
     {
@@ -176,31 +2632,103 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "260",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "247",
+              "title": "Procedure Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "248",
+              "title": "Diagnostic Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "289",
+              "title": "Office Administration Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "114",
+                  "title": "Professional Research &amp; Reporting"
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "Fall",
           "credits_required": null,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "121",
+              "title": "Business Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "280",
+              "title": "Electronic Health Records",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Humanities/Fine Arts Elective - See choices below*",
               "credits": null,
               "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematical Measurement and Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "111",
+              "title": "Work-Based Learning I",
+              "credits": null,
+              "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Bookkeeping Certificate",
-      "credential": "certificate",
-      "program_code": "C25800A",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1199",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
       "matched_program_slug": null
     },
     {
@@ -211,7 +2739,43 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Principles of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "business-administration"
     },
     {
@@ -222,7 +2786,57 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DME",
+              "number": "115",
+              "title": "Graphic Design Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "141",
+              "title": "Graphic Design I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "264",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "215",
+              "title": "Advanced Graphic Design Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "142",
+              "title": "Graphic Design II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -233,8 +2847,105 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DME",
+              "number": "110",
+              "title": "Introduction to Digital Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "115",
+              "title": "Graphic Design Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "120",
+              "title": "Introduction to Multimedia",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "130",
+              "title": "Digital Animation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "art"
+    },
+    {
+      "title": "Information Technology Certificate",
+      "credential": "certificate",
+      "program_code": "C25590A",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1213",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTI",
+              "number": "110",
+              "title": "IT Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTI",
+              "number": "120",
+              "title": "Network and Security Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "115",
+              "title": "Information Systems Business Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
     },
     {
       "title": "Multimedia Certificate",
@@ -244,7 +2955,57 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Three Semesters",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DME",
+              "number": "110",
+              "title": "Introduction to Digital Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "115",
+              "title": "Graphic Design Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "120",
+              "title": "Introduction to Multimedia",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "130",
+              "title": "Digital Animation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "140",
+              "title": "Introduction to Audio/Video Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "260",
+              "title": "Emerging Technologies in Digital Media",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -255,19 +3016,65 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "115",
+              "title": "Graphic Design Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DME",
+              "number": "120",
+              "title": "Introduction to Multimedia",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "140",
+              "title": "Introduction to Audio/Video Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "People Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "business-administration"
-    },
-    {
-      "title": "Information Technology Certificate",
-      "credential": "certificate",
-      "program_code": "C25590A",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1213",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "computer-science"
     },
     {
       "title": "Network Management Certificate",
@@ -277,18 +3084,118 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTI",
+              "number": "120",
+              "title": "Network and Security Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "125",
+              "title": "Introduction to Networks",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NET",
+              "number": "126",
+              "title": "Switching and Routing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEC",
+              "number": "110",
+              "title": "Security Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "business-administration"
     },
     {
-      "title": "Patient Services Representative Certificate",
+      "title": "Medical Billing and Insurance Certificate",
       "credential": "certificate",
-      "program_code": "C25310B",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1226",
+      "program_code": "C25310A",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1225",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MED",
+              "number": "121",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "148",
+              "title": "Medical Insurance and Billing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "134",
+              "title": "Text Entry &amp; Formatting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MED",
+              "number": "122",
+              "title": "Medical Terminology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "247",
+              "title": "Procedure Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "248",
+              "title": "Diagnostic Coding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -299,18 +3206,43 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Medical Billing and Insurance Certificate",
-      "credential": "certificate",
-      "program_code": "C25310A",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1225",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "134",
+              "title": "C++ Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "151",
+              "title": "JAVA Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "121",
+              "title": "Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DBA",
+              "number": "110",
+              "title": "Database Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -321,7 +3253,125 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OST",
+              "number": "137",
+              "title": "Office Applications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "121",
+              "title": "Business Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "134",
+              "title": "Text Entry &amp; Formatting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "People Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "286",
+              "title": "Professional Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Patient Services Representative Certificate",
+      "credential": "certificate",
+      "program_code": "C25310B",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1226",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MED",
+              "number": "121",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "148",
+              "title": "Medical Insurance and Billing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "121",
+              "title": "Business Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OST",
+              "number": "134",
+              "title": "Text Entry &amp; Formatting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "286",
+              "title": "Professional Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "122",
+              "title": "Medical Terminology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -332,7 +3382,43 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OST",
+              "number": "134",
+              "title": "Text Entry &amp; Formatting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "121",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "148",
+              "title": "Medical Insurance and Billing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "286",
+              "title": "Professional Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -343,29 +3429,111 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "111",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "113",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "231",
+              "title": "Constitutional Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "131",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "criminal-justice"
     },
     {
-      "title": "Early Childhood Education Certificate",
+      "title": "Community Spanish Interpreter Certificate",
       "credential": "certificate",
-      "program_code": "C55220",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1321",
+      "program_code": "C55370",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1317",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "early-childhood-education"
-    },
-    {
-      "title": "Community Spanish Medical Interpreter Certificate",
-      "credential": "certificate",
-      "program_code": "C55370A",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1318",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPA",
+              "number": "141",
+              "title": "Culture and Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPI",
+              "number": "113",
+              "title": "Intro. to Spanish Inter.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPI",
+              "number": "114",
+              "title": "Ana.Skills Spanish Inter.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPI",
+              "number": "213",
+              "title": "Review of Grammar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPI",
+              "number": "214",
+              "title": "Intro. to Translation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPI",
+              "number": "245",
+              "title": "Community Interpreting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -376,8 +3544,105 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "119",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "153",
+              "title": "Health, Safety and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Child, Family, and Community",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "144",
+              "title": "Child Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "234",
+              "title": "Infants, Toddlers, and Twos",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education Certificate",
+      "credential": "certificate",
+      "program_code": "C55220",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1321",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "119",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "153",
+              "title": "Health, Safety and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Child, Family, and Community",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "145",
+              "title": "Child Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "146",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
     },
     {
       "title": "Early Childhood Administration Certificate",
@@ -387,18 +3652,657 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "119",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "153",
+              "title": "Health, Safety and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "261",
+              "title": "Early Childhood Administration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Child, Family, and Community",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "262",
+              "title": "Early Childhood Administration II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "early-childhood-education"
     },
     {
-      "title": "Community Spanish Interpreter Certificate",
-      "credential": "certificate",
-      "program_code": "C55370",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1317",
+      "title": "Associate in General Education Degree",
+      "credential": "AA",
+      "program_code": "A10300",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1186",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and one of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Literature-Based Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts and Communications",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "116",
+              "title": "Survey of American Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "126",
+              "title": "Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "131",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "World Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "262",
+              "title": "World Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "110",
+              "title": "Technology and Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "120",
+              "title": "Cultural Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "122",
+              "title": "Southern Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "130",
+              "title": "Myth in Human Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Human Values and Meaning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "210",
+              "title": "History of Rock Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "110",
+              "title": "World Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "211",
+              "title": "Introduction to Old Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "212",
+              "title": "Introduction to New Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "221",
+              "title": "Religion in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "141",
+              "title": "Culture and Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "211",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "212",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "151",
+              "title": "Survey of Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "262",
+              "title": "Middle East History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "239",
+              "title": "Psychology of Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "281",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "213",
+              "title": "Sociology of the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "230",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences/Mathematics",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Introductory Botany",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "130",
+              "title": "Introductory Zoology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "140",
+              "title": "Environmental Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "131",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "132",
+              "title": "Organic and Biochemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Precalculus Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "263",
+              "title": "Brief Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "272",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "273",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110A",
+              "title": "Conceptual Physics Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "252",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -409,7 +4313,71 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "1st Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPA",
+              "number": "211",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "212",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPA",
+              "number": "141",
+              "title": "Culture and Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "221",
+              "title": "Spanish Conversation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -422,35 +4390,1036 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts and Communications",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature Requirement",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Requirement",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "167",
+              "title": "Discrete Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Art Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "122",
+              "title": "Three-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "215",
+              "title": "Visual Art Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Elective Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "HIS - 111 World Civilizations I",
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Principles of Financial Accounting",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "HIS - 112 World Civilizations II",
+              "prefix": "ACC",
+              "number": "121",
+              "title": "Principles of Managerial Accounting",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "HIS - 131 American History I",
+              "prefix": "ART",
+              "number": "132",
+              "title": "Drawing II",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "HIS - 132 American History II",
+              "prefix": "ART",
+              "number": "140",
+              "title": "Basic Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "214",
+              "title": "Portfolio and Resume",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "240",
+              "title": "Painting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "241",
+              "title": "Painting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "244",
+              "title": "Watercolor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "264",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "281",
+              "title": "Sculpture I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "283",
+              "title": "Ceramics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "284",
+              "title": "Ceramics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "285",
+              "title": "Ceramics III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "286",
+              "title": "Ceramics IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Introductory Botany",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "130",
+              "title": "Introductory Zoology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "140",
+              "title": "Environmental Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Field Biology Minicourse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Ecology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "146",
+              "title": "Regional Natural History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "163",
+              "title": "Basic Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "168",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "169",
+              "title": "Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Genetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "275",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "137",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "131",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "132",
+              "title": "Organic and Biochemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "111",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "113",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "121",
+              "title": "Law Enforcement Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "141",
+              "title": "Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "212",
+              "title": "Ethics &amp; Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "134",
+              "title": "C++ Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "139",
+              "title": "Visual BASIC Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "151",
+              "title": "JAVA Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "126",
+              "title": "Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "151",
+              "title": "Survey of Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Literature-Based Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "125",
+              "title": "Creative Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "126",
+              "title": "Creative Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "131",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "World Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "262",
+              "title": "World Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272",
+              "title": "Southern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEA",
+              "number": "110",
+              "title": "Personal Health/Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "145",
+              "title": "The Second World War",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "163",
+              "title": "The World Since 1945",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "221",
+              "title": "African-American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "226",
+              "title": "The Civil War",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "227",
+              "title": "Native American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "237",
+              "title": "The American Revolution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "262",
+              "title": "Middle East History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "110",
+              "title": "Technology and Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "120",
+              "title": "Cultural Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "122",
+              "title": "Southern Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "123",
+              "title": "Appalachian Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "130",
+              "title": "Myth in Human Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "180",
+              "title": "International Cultural Exploration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Human Values and Meaning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "230",
+              "title": "Leadership Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JOU",
+              "number": "110",
+              "title": "Introduction to Journalism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Precalculus Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "263",
+              "title": "Brief Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "272",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "273",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "280",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "285",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "Chorus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Chorus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "210",
+              "title": "History of Rock Music",
               "credits": null,
               "or_alternatives": []
             },
@@ -458,6 +5427,216 @@
               "prefix": "ELEC",
               "number": "XXX",
               "title": "PED Any Physical Education Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "252",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "231",
+              "title": "Forensic Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "239",
+              "title": "Psychology of Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "243",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "263",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "281",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "110",
+              "title": "World Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "211",
+              "title": "Introduction to Old Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "212",
+              "title": "Introduction to New Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "221",
+              "title": "Religion in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "213",
+              "title": "Sociology of the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "225",
+              "title": "Social Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "230",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "141",
+              "title": "Culture and Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "211",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "212",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "221",
+              "title": "Spanish Conversation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "231",
+              "title": "Reading and Composition",
               "credits": null,
               "or_alternatives": []
             }
@@ -476,14 +5655,1260 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts and Communications",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature Requirement",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Requirement",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "167",
+              "title": "Discrete Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Precalculus Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Precalculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "263",
+              "title": "Brief Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "272",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "252",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Introductory Botany",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "130",
+              "title": "Introductory Zoology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "140",
+              "title": "Environmental Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "131",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "132",
+              "title": "Organic and Biochemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Precalculus Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "263",
+              "title": "Brief Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "272",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "273",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "252",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "126",
+              "title": "Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "151",
+              "title": "Survey of Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "150",
+              "title": "Intro to Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Literature-Based Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "131",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "World Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "262",
+              "title": "World Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "110",
+              "title": "Technology and Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "120",
+              "title": "Cultural Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "122",
+              "title": "Southern Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "130",
+              "title": "Myth in Human Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Human Values and Meaning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "210",
+              "title": "History of Rock Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "239",
+              "title": "Psychology of Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "281",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "110",
+              "title": "World Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "211",
+              "title": "Introduction to Old Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "212",
+              "title": "Introduction to New Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "221",
+              "title": "Religion in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "213",
+              "title": "Sociology of the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "225",
+              "title": "Social Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "230",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "211",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "212",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math/Science Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "143",
+              "title": "Field Biology Minicourse",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Ecology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "146",
+              "title": "Regional Natural History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "155",
+              "title": "Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "163",
+              "title": "Basic Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "168",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "169",
+              "title": "Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Genetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "275",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Precalculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "280",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "285",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Select 6 Hours From Any of the Previous Course Listings and/or From the Following.",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Principles of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "121",
+              "title": "Principles of Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "122",
+              "title": "Three-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "132",
+              "title": "Drawing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "140",
+              "title": "Basic Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "214",
+              "title": "Portfolio and Resume",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "215",
+              "title": "Visual Art Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "240",
+              "title": "Painting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "241",
+              "title": "Painting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "244",
+              "title": "Watercolor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "264",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "281",
+              "title": "Sculpture I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "283",
+              "title": "Ceramics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "284",
+              "title": "Ceramics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "285",
+              "title": "Ceramics III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "286",
+              "title": "Ceramics IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "137",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "111",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "113",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "121",
+              "title": "Law Enforcement Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "141",
+              "title": "Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "212",
+              "title": "Ethics &amp; Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "134",
+              "title": "C++ Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "139",
+              "title": "Visual BASIC Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "151",
+              "title": "JAVA Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "170",
+              "title": "Engineering Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "144",
+              "title": "Child Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "145",
+              "title": "Child Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "221",
+              "title": "Children With Exceptionalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "150",
+              "title": "Intro to Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "212",
+              "title": "Logic System Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "220",
+              "title": "Engineering Statics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "125",
+              "title": "Creative Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "126",
+              "title": "Creative Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272",
+              "title": "Southern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEA",
+              "number": "110",
+              "title": "Personal Health/Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "145",
+              "title": "The Second World War",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "163",
+              "title": "The World Since 1945",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "221",
+              "title": "African-American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "226",
+              "title": "The Civil War",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "227",
+              "title": "Native American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "237",
+              "title": "The American Revolution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "262",
+              "title": "Middle East History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "123",
+              "title": "Appalachian Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "180",
+              "title": "International Cultural Exploration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "230",
+              "title": "Leadership Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JOU",
+              "number": "110",
+              "title": "Introduction to Journalism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "PED Any Physical Education Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "Chorus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Chorus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "231",
+              "title": "Forensic Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "243",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "263",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "141",
+              "title": "Culture and Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "221",
+              "title": "Spanish Conversation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "231",
+              "title": "Reading and Composition",
               "credits": null,
               "or_alternatives": []
             }
@@ -493,23 +6918,826 @@
       "matched_program_slug": null
     },
     {
-      "title": "Associate in General Education Degree",
-      "credential": "AA",
-      "program_code": "A10300",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1186",
+      "title": "Community Spanish Medical Interpreter Certificate",
+      "credential": "certificate",
+      "program_code": "C55370A",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1318",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPA",
+              "number": "141",
+              "title": "Culture and Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPI",
+              "number": "113",
+              "title": "Intro. to Spanish Inter.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPI",
+              "number": "114",
+              "title": "Ana.Skills Spanish Inter.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPI",
+              "number": "213",
+              "title": "Review of Grammar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPI",
+              "number": "221",
+              "title": "Consecutive Interp I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPI",
+              "number": "243",
+              "title": "Medical Interpreting I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Science in Teacher Preparation Degree - College Transfer",
+      "credential": "AA",
+      "program_code": "A1040T",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1185",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "187",
+              "title": "Teaching and Learning for All",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "279",
+              "title": "Literacy Development and Instruction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Teacher Licensure Preparation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
         {
           "name": "English Composition",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts and Communications",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature Requirement",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Precalculus Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "263",
+              "title": "Brief Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "272",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "252",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "225",
+              "title": "Social Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Introductory Botany",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "130",
+              "title": "Introductory Zoology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "140",
+              "title": "Environmental Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "131",
+              "title": "Introduction to Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "132",
+              "title": "Organic and Biochemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "126",
+              "title": "Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "151",
+              "title": "Survey of Economics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Literature-Based Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "131",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "World Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "262",
+              "title": "World Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "110",
+              "title": "Technology and Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "120",
+              "title": "Cultural Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "122",
+              "title": "Southern Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "130",
+              "title": "Myth in Human Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Human Values and Meaning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Precalculus Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "263",
+              "title": "Brief Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "272",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "273",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "Chorus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Chorus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "210",
+              "title": "History of Rock Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "252",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
-              "title": "and one of the following:",
+              "title": "*Courses may also be selected from the UGETC within the CAA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "239",
+              "title": "Psychology of Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "281",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "110",
+              "title": "World Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "211",
+              "title": "Introduction to Old Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "212",
+              "title": "Introduction to New Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "221",
+              "title": "Religion in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "213",
+              "title": "Sociology of the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "230",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "211",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "212",
+              "title": "Intermediate Spanish II",
               "credits": null,
               "or_alternatives": []
             }
@@ -526,27 +7754,908 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communication/Humanities/Fine Arts",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Science",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "225",
+              "title": "Social Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "187",
+              "title": "Teaching and Learning for All",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
-      "title": "Associate in Science in Teacher Preparation Degree - College Transfer",
+      "title": "Associate in Arts Pathway",
       "credential": "AA",
-      "program_code": "A1040T",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1185",
+      "program_code": "P1012C",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1176",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [
         {
-          "name": "General Education Courses",
+          "name": "English Composition",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "*Courses may also be selected from the UGETC within the CAA",
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communication/Humanities/Fine Arts",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Science",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate in Science in Teacher Preparation Pathway",
+      "credential": "AA",
+      "program_code": "P1042T",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1180",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communication/Humanities/Fine Arts",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Precalculus Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "263",
+              "title": "Brief Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "272",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Science",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "225",
+              "title": "Social Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "187",
+              "title": "Teaching and Learning for All",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
               "credits": null,
               "or_alternatives": []
             }
@@ -565,6 +8674,216 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications/Humanities/Fine Arts",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Precalculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "272",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Science",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "252",
+              "title": "General Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Engineering",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EGR",
+              "number": "150",
+              "title": "Intro to Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "170",
+              "title": "Engineering Graphics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Pre-requisite General Education Hours (0-8 Credit Hours)",
           "credits_required": 0,
           "choose_n": null,
@@ -580,28 +8899,6 @@
       "matched_program_slug": "engineering"
     },
     {
-      "title": "Associate in Arts Pathway",
-      "credential": "AA",
-      "program_code": "P1012C",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1176",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Associate in Science in Teacher Preparation Pathway",
-      "credential": "AA",
-      "program_code": "P1042T",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1180",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
       "title": "Associate in Fine Arts Pathway",
       "credential": "AA",
       "program_code": "P1062C",
@@ -609,18 +8906,440 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communication/Humanities/Fine Arts",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Science",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Art",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "art"
     },
     {
-      "title": "Associate in Science Pathway",
-      "credential": "AA",
-      "program_code": "P1042C",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1178",
+      "title": "Career and College Promise Career and College Ready Pathway Leading to either a CCP Transfer Pathway or CTE Pathway",
+      "credential": "other",
+      "program_code": "P9099A",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1431",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "045",
+              "title": "English Skills Support",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "045",
+              "title": "Math Skills Support",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English Composition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Workplace Writing Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematical Measurement and Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Algebra/Trigonometry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Career and Work-based Learning",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "111",
+              "title": "Work-Based Learning I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTE",
+              "number": "110",
+              "title": "Pathways to Employment-Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTE",
+              "number": "114",
+              "title": "Pathway to Employment - Engineering Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -638,6 +9357,62 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "PTE",
+              "number": "114",
+              "title": "Pathway to Employment - Engineering Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "212",
+              "title": "Advanced Comfort Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "250",
+              "title": "HVAC Systems Diagnostics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "120",
+              "title": "HVACR Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "211",
+              "title": "Residential System Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "118",
+              "title": "Interpersonal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Humanities/Fine Arts - Elective",
@@ -650,81 +9425,296 @@
       "matched_program_slug": null
     },
     {
-      "title": "Career and College Promise Career and College Ready Pathway Leading to either a CCP Transfer Pathway or CTE Pathway",
-      "credential": "other",
-      "program_code": "P9099A",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1431",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Associate Degree Nursing LPN-ADN",
+      "title": "Associate in Science Pathway",
       "credential": "AA",
-      "program_code": "A45110BR",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1294",
+      "program_code": "P1042C",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1178",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [
         {
-          "name": "Pre-Admission",
+          "name": "English Composition",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Courses listed below are to be completed after admission to Nursing Program.",
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
               "credits": null,
               "or_alternatives": []
             }
           ]
         },
         {
-          "name": "Fall Semester",
+          "name": "Communication/Humanities/Fine Arts",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Humanities/Fine Arts Elective - See Choices Below *",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "nursing"
-    },
-    {
-      "title": "Computer-Integrated Machining Degree",
-      "credential": "other",
-      "program_code": "A50210",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1252",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Humanities/Fine Arts Elective *",
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Social Science - Elective *",
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Precalculus Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "263",
+              "title": "Brief Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "272",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Science",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
               "credits": null,
               "or_alternatives": []
             }
@@ -732,32 +9722,6 @@
         }
       ],
       "matched_program_slug": null
-    },
-    {
-      "title": "Associate Degree Nursing",
-      "credential": "AA",
-      "program_code": "A45110",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1292",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "2nd Spring Semester",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Humanities/Fine Arts Elective - See Choices Below *",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "nursing"
     },
     {
       "title": "Automotive Systems Technology Degree",
@@ -774,9 +9738,86 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "221",
+              "title": "Automatic Transmissions/Transaxles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "221A",
+              "title": "Automatic Transmissions/Transaxles Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "231",
+              "title": "Manual Transmissions/Transaxles/Drive Trains",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "231A",
+              "title": "Manual Transmissions/Transaxles/Drive Trains Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "118",
+              "title": "Interpersonal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "145",
+              "title": "Advanced Transportation Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Humanities/Fine Arts Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "181",
+              "title": "Engine Performance 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "183",
+              "title": "Engine Performance 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "213",
+              "title": "Automotive Servicing II",
               "credits": null,
               "or_alternatives": []
             }
@@ -784,6 +9825,428 @@
         }
       ],
       "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Associate Degree Nursing",
+      "credential": "AA",
+      "program_code": "A45110",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1292",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "168",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "111",
+              "title": "Introduction to Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "117",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "169",
+              "title": "Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Health-Illness Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Family Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "114",
+                  "title": "Professional Research &amp; Reporting"
+                }
+              ]
+            },
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Holistic Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Health Care Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "212",
+              "title": "Health System Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities/Fine Arts Elective - See Choices Below *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "213",
+              "title": "Complex Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "*Humanities/Fine Arts Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Associate Degree Nursing LPN-ADN",
+      "credential": "AA",
+      "program_code": "A45110BR",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1294",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-Admission",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "168",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Pre-Admission",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "169",
+              "title": "Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Courses listed below are to be completed after admission to Nursing Program.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "117",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "214",
+              "title": "Nsg Transition Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Health Care Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "212",
+              "title": "Health System Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities/Fine Arts Elective - See Choices Below *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "*Humanities/Fine Arts Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "213",
+              "title": "Complex Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
     },
     {
       "title": "Construction Management Technology Degree",
@@ -795,14 +10258,195 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "1st Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "111",
+              "title": "Carpentry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematical Measurement and Literacy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "112",
+              "title": "Construction Materials &amp; Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "230",
+              "title": "Construction Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "120",
+              "title": "Codes and Inspections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Workplace Writing Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTE",
+              "number": "110",
+              "title": "Pathways to Employment-Construction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "139",
+              "title": "Entrepreneurship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "210",
+              "title": "Construction Management Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "212",
+              "title": "Total Safety Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "113",
+              "title": "Residential Wiring I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "120",
+              "title": "Spanish for the Workplace",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "2nd Spring Semester",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Principles of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "132",
+              "title": "Specifications &amp; Contracts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "110",
+              "title": "Technology and Society",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "HUM",
+                  "number": "115",
+                  "title": "Critical Thinking"
+                }
+              ]
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Take one course: ECO, SOC, or PSY",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SST",
+              "number": "140",
+              "title": "Green Building and Design Concepts",
               "credits": null,
               "or_alternatives": []
             }
@@ -810,6 +10454,108 @@
         }
       ],
       "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Computer-Integrated Machining Degree",
+      "credential": "other",
+      "program_code": "A50210",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1252",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "115",
+                  "title": "Oral Communication"
+                }
+              ]
+            },
+            {
+              "prefix": "MAC",
+              "number": "152",
+              "title": "Advanced Machining Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "214",
+              "title": "Machining Technology IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "222",
+              "title": "Advanced CNC Turning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATR",
+              "number": "212",
+              "title": "Industrial Robots",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities/Fine Arts Elective *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISC",
+              "number": "112",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "224",
+              "title": "Advanced CNC Milling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science - Elective *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "113",
+              "title": "Machining Technology III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
     },
     {
       "title": "Cosmetology Degree",
@@ -821,14 +10567,168 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "1st Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Cosmetology Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Salon I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Workplace Writing Essentials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "Cosmetology Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Salon II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "119",
+              "title": "Esthetics Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematical Measurement and Literacy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Cosmetology Concepts III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Salon III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "Cosmetology Concepts IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "Salon IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "223",
+              "title": "Contemp Hair Coloring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "2nd Spring Semester",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "People Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "260",
+              "title": "Design Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Humanities/Fine Arts - Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "118",
+              "title": "Interpersonal Psychology",
               "credits": null,
               "or_alternatives": []
             }
@@ -852,6 +10752,41 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "251",
+              "title": "Exploration Activities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "OR",
@@ -859,9 +10794,288 @@
               "or_alternatives": []
             },
             {
+              "prefix": "EDU",
+              "number": "259",
+              "title": "Curriculum Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "280",
+              "title": "Language and Literacy Experiences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "221",
+              "title": "Children With Exceptionalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "284",
+              "title": "Early Childhood Capstone Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Humanities Elective - See Choices Below",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "243",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities Electives:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MUS",
+                  "number": "110",
+                  "title": "Music Appreciation"
+                },
+                {
+                  "prefix": "PHI",
+                  "number": "240",
+                  "title": "Introduction to Ethics"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education Degree - Transfer - Birth Kindergarten Licensure",
+      "credential": "other",
+      "program_code": "A55220L",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1326",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "119",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "144",
+              "title": "Child Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "153",
+              "title": "Health, Safety and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Child, Family, and Community",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "145",
+              "title": "Child Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "146",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "151",
+              "title": "Creative Activities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "234",
+              "title": "Infants, Toddlers, and Twos",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "171",
+                  "title": "Precalculus Algebra"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "2nd Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BIO",
+                  "number": "110",
+                  "title": "Principles of Biology"
+                }
+              ]
+            },
+            {
+              "prefix": "EDU",
+              "number": "221",
+              "title": "Children With Exceptionalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "280",
+              "title": "Language and Literacy Experiences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective - See choices below",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "PHY",
+                  "number": "110",
+                  "title": "Conceptual Physics"
+                }
+              ]
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Teacher Licensure Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "284",
+              "title": "Early Childhood Capstone Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science - Elective *",
               "credits": null,
               "or_alternatives": []
             }
@@ -880,47 +11094,152 @@
       "description": null,
       "requirement_groups": [
         {
-          "name": "2nd Spring Semester",
+          "name": "1st Fall Semester",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Social Science - Elective *",
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Humanities Elective - See choices below",
+              "prefix": "EDU",
+              "number": "119",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "144",
+              "title": "Child Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "153",
+              "title": "Health, Safety and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
               "credits": null,
               "or_alternatives": []
             }
           ]
-        }
-      ],
-      "matched_program_slug": "early-childhood-education"
-    },
-    {
-      "title": "Early Childhood Education Degree - Transfer - Birth Kindergarten Licensure",
-      "credential": "other",
-      "program_code": "A55220L",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1326",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
+        },
+        {
+          "name": "1st Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Child, Family, and Community",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "145",
+              "title": "Child Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "146",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "151",
+              "title": "Creative Activities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "234",
+              "title": "Infants, Toddlers, and Twos",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "171",
+                  "title": "Precalculus Algebra"
+                }
+              ]
+            }
+          ]
+        },
         {
           "name": "2nd Fall Semester",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Humanities Elective - See choices below",
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BIO",
+                  "number": "110",
+                  "title": "Principles of Biology"
+                }
+              ]
+            },
+            {
+              "prefix": "EDU",
+              "number": "221",
+              "title": "Children With Exceptionalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "261",
+              "title": "Early Childhood Administration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "280",
+              "title": "Language and Literacy Experiences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
               "credits": null,
               "or_alternatives": []
             }
@@ -932,9 +11251,50 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "PHY",
+                  "number": "110",
+                  "title": "Conceptual Physics"
+                }
+              ]
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "262",
+              "title": "Early Childhood Administration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "284",
+              "title": "Early Childhood Capstone Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Social Science - Elective *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective - See choices below",
               "credits": null,
               "or_alternatives": []
             }
@@ -958,6 +11318,27 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ELC",
+              "number": "220",
+              "title": "Photovoltaic System Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTE",
+              "number": "114",
+              "title": "Pathway to Employment - Engineering Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "128",
+              "title": "Introduction to Programmable Logic Controller",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Humanities/Fine Arts Elective",
@@ -965,9 +11346,29 @@
               "or_alternatives": []
             },
             {
+              "prefix": "ELC",
+              "number": "221",
+              "title": "Adv PV Sys Designs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ENG",
-              "number": "114",
-              "title": "Professional Research &amp; Reporting",
+              "number": "115",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "114",
+                  "title": "Professional Research &amp; Reporting"
+                }
+              ]
+            },
+            {
+              "prefix": "ELC",
+              "number": "228",
+              "title": "Programmable Logic Controllers Applications",
               "credits": null,
               "or_alternatives": []
             },
@@ -975,6 +11376,13 @@
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Social Science Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALT",
+              "number": "120",
+              "title": "Renewable Energy Technology",
               "credits": null,
               "or_alternatives": []
             }
@@ -991,7 +11399,78 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "168",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "280",
+              "title": "EMS Bridging Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "169",
+              "title": "Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -1009,9 +11488,79 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Humanities/Fine Arts - Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematical Measurement and Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "113",
+              "title": "Juvenile Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "131",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "212",
+              "title": "Ethics &amp; Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "221",
+              "title": "Investigative Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "232",
+              "title": "Civil Liability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "231",
+              "title": "Forensic Psychology",
               "credits": null,
               "or_alternatives": []
             }
@@ -1035,11 +11584,56 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Humanities/Fine Arts Elective",
               "credits": null,
               "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "128",
+              "title": "Introduction to Programmable Logic Controller",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "115",
+                  "title": "Oral Communication"
+                }
+              ]
+            },
+            {
+              "prefix": "MAC",
+              "number": "121",
+              "title": "Introduction to CNC",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ELN",
+                  "number": "152",
+                  "title": "Fabrication Techniques"
+                },
+                {
+                  "prefix": "WLD",
+                  "number": "112",
+                  "title": "Basic Welding Processes"
+                }
+              ]
             },
             {
               "prefix": "ELEC",
@@ -1049,9 +11643,37 @@
               "or_alternatives": []
             },
             {
+              "prefix": "ATR",
+              "number": "212",
+              "title": "Industrial Robots",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "WBL",
               "number": "111",
               "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "228",
+              "title": "Programmable Logic Controllers Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "130",
+              "title": "Mechanisms",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "College Physics I",
               "credits": null,
               "or_alternatives": []
             }
@@ -1075,9 +11697,92 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "BUS",
+              "number": "260",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "153",
+              "title": "Office Finance Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "289",
+              "title": "Office Administration Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Oral Communication",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "114",
+                  "title": "Professional Research &amp; Reporting"
+                }
+              ]
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Humanities/Fine Arts - Elective *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "137",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematical Measurement and Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "111",
+              "title": "Work-Based Learning I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
               "credits": null,
               "or_alternatives": []
             }
@@ -1096,14 +11801,196 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "1st Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MED",
+              "number": "121",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "168",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "110",
+              "title": "Intro to Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "130",
+              "title": "Physical Therapy Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "170",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "169",
+              "title": "Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "120",
+              "title": "Functional Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "140",
+              "title": "Therapeutic Exercise",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "150",
+              "title": "Physical Therapy Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "180",
+              "title": "PTA Clinical Ed Intro",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "212",
+              "title": "Health Care/Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "252",
+              "title": "Geriatrics for the PTA",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "254",
+              "title": "Pediatrics for the PTA",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "2nd Fall Semester",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Humanities/Fine Arts - Elective *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "160",
+              "title": "Physical Therapy Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "222",
+              "title": "Professional Interactions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "240",
+              "title": "Physical Therapy Procedures IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "270",
+              "title": "PTA Topics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "280",
+              "title": "PTA Issues I",
               "credits": null,
               "or_alternatives": []
             }
@@ -1126,6 +12013,62 @@
           "credits_required": null,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "VEN",
+              "number": "283",
+              "title": "Wine Production and Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "284",
+              "title": "Wine Design and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "286",
+              "title": "Wine Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "288",
+              "title": "Wine Finishing and Packaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "137",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "139",
+              "title": "Entrepreneurship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Professional Research &amp; Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "118",
+              "title": "Interpersonal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -1153,6 +12096,41 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "Transfer and Career Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "168",
+              "title": "Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "MAT",
               "number": "171",
               "title": "Precalculus Algebra",
@@ -1167,9 +12145,44 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "BIO",
+              "number": "169",
+              "title": "Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "HIS",
               "number": "112",
               "title": "World Civilizations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEA",
+              "number": "110",
+              "title": "Personal Health/Wellness",
               "credits": null,
               "or_alternatives": []
             },
@@ -1187,6 +12200,13 @@
           "credits_required": null,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing and Research in the Disciplines",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ENG",
               "number": "114",
@@ -1216,9 +12236,114 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "NUR",
+              "number": "111",
+              "title": "Introduction to Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "117",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "WCU - UL Perspectives, Taken at WCU Online (Check WCU catalog)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring - Sophomore Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Health-Illness Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "113",
+              "title": "Family Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer - Sophomore Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Holistic Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "YEAR THREE Fall - Junior Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "World Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Health Care Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "212",
+              "title": "Health System Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring - Junior Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "213",
+              "title": "Complex Health Concepts",
               "credits": null,
               "or_alternatives": []
             }
@@ -1235,7 +12360,64 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "120",
+              "title": "Hardware/Software Support",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "People Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NOS",
+              "number": "110",
+              "title": "Operating Systems Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "155",
+              "title": "Tech Support Functions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -1248,6 +12430,48 @@
       "description": null,
       "requirement_groups": [
         {
+          "name": "Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Principles of Financial Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "130",
+              "title": "Spreadsheet",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
           "name": "Spring",
           "credits_required": null,
           "choose_n": null,
@@ -1258,22 +12482,32 @@
               "title": "Humanities/Fine Arts - Elective *",
               "credits": null,
               "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "153",
+              "title": "Office Finance Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Personal Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "260",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
             }
           ]
         }
       ],
       "matched_program_slug": "accounting"
-    },
-    {
-      "title": "Business Administration Diploma",
-      "credential": "diploma",
-      "program_code": "D25120",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1204",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "business-administration"
     },
     {
       "title": "Automotive Systems Technology Diploma",
@@ -1283,7 +12517,85 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "116",
+              "title": "Engine Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "116A",
+              "title": "Engine Repair Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematical Measurement and Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "113",
+              "title": "Automotive Servicing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "140",
+              "title": "Transportation Climate Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "140A",
+              "title": "Transportation Climate Control Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Workplace Writing Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "141",
+              "title": "Suspension &amp; Steering Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "141A",
+              "title": "Suspension &amp; Steering Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "163",
+              "title": "Advanced Automotive Electricity",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "automotive-technology"
     },
     {
@@ -1294,18 +12606,220 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematical Measurement and Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "114",
+              "title": "Heat Pump Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "113",
+              "title": "Comfort Cooling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "213",
+              "title": "HVACR Building Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "215",
+              "title": "Commercial HVAC Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "133",
+              "title": "HVAC Servicing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "117",
+              "title": "Motors and Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Applied Communications I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "110",
+                  "title": "Workplace Writing Essentials"
+                }
+              ]
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
-      "title": "Computer-Integrated Machining Diploma",
+      "title": "Business Administration Diploma",
       "credential": "diploma",
-      "program_code": "D50210",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1251",
+      "program_code": "D25120",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1204",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Personal Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "121",
+              "title": "Business Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "121",
+              "title": "Principles of Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "137",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "139",
+              "title": "Entrepreneurship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Construction Technology: Carpentry Diploma",
+      "credential": "diploma",
+      "program_code": "D35180",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1255",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Workplace Writing Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematical Measurement and Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "112",
+              "title": "Carpentry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "115",
+              "title": "Residential Planning/Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "113",
+              "title": "Carpentry III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -1323,9 +12837,255 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ACA",
+                  "number": "122",
+                  "title": "Transfer and Career Success"
+                }
+              ]
+            },
+            {
+              "prefix": "SPA",
+              "number": "221",
+              "title": "Spanish Conversation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "231",
+              "title": "Reading and Composition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Humanities/Fine Arts Elective - See Choices Below *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities Electives:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "120",
+              "title": "Cultural Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer-Integrated Machining Diploma",
+      "credential": "diploma",
+      "program_code": "D50210",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1251",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "110",
+                  "title": "Workplace Writing Essentials"
+                }
+              ]
+            },
+            {
+              "prefix": "MAC",
+              "number": "151",
+              "title": "Machining Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "112",
+              "title": "Machining Technology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "231",
+              "title": "Computer-Aided Manufacturing I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cosmetology Diploma",
+      "credential": "diploma",
+      "program_code": "D55140",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1312",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Cosmetology Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Salon I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Workplace Writing Essentials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "Cosmetology Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Salon II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "118",
+              "title": "Interpersonal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Cosmetology Concepts III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Salon III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "Cosmetology Concepts IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "Salon IV",
               "credits": null,
               "or_alternatives": []
             }
@@ -1349,9 +13109,72 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "CJC",
+              "number": "112",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "132",
+              "title": "Court Procedure &amp; Evidence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "212",
+              "title": "Ethics &amp; Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "221",
+              "title": "Investigative Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "121",
+              "title": "Law Enforcement Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "213",
+              "title": "Sociology of the Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Social Problems",
               "credits": null,
               "or_alternatives": []
             }
@@ -1359,17 +13182,6 @@
         }
       ],
       "matched_program_slug": "criminal-justice"
-    },
-    {
-      "title": "Construction Technology: Carpentry Diploma",
-      "credential": "diploma",
-      "program_code": "D35180",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1255",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
     },
     {
       "title": "Digital Media Technology Diploma",
@@ -1386,9 +13198,72 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "DME",
+              "number": "140",
+              "title": "Introduction to Audio/Video Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "215",
+              "title": "Advanced Graphic Design Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "260",
+              "title": "Emerging Technologies in Digital Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "119",
+              "title": "Survey of Artificial Intelligence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "CIS",
               "number": "3119",
               "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "141",
+              "title": "Graphic Design I",
               "credits": null,
               "or_alternatives": []
             }
@@ -1412,9 +13287,43 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematical Measurement and Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "117",
+              "title": "Motors and Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ENG",
-              "number": "111",
-              "title": "Writing and Inquiry",
+              "number": "110",
+              "title": "Workplace Writing Essentials",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "111",
+                  "title": "Writing and Inquiry"
+                }
+              ]
+            },
+            {
+              "prefix": "ELC",
+              "number": "121",
+              "title": "Electrical Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "119",
+              "title": "NEC Calculations",
               "credits": null,
               "or_alternatives": []
             },
@@ -1424,6 +13333,27 @@
               "title": "Choose up to 2 classes based on courses completed in certificates",
               "credits": null,
               "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "113",
+              "title": "Residential Wiring I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "114",
+              "title": "Commercial Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "115",
+              "title": "Industrial Wiring",
+              "credits": null,
+              "or_alternatives": []
             }
           ]
         }
@@ -1431,15 +13361,261 @@
       "matched_program_slug": null
     },
     {
-      "title": "Cosmetology Diploma",
+      "title": "Early Childhood Education Diploma",
       "credential": "diploma",
-      "program_code": "D55140",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1312",
+      "program_code": "D55220",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1324",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "One Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "144",
+              "title": "Child Development I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "145",
+              "title": "Child Development II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "151",
+              "title": "Creative Activities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "234",
+              "title": "Infants, Toddlers, and Twos",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "146",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "251",
+              "title": "Exploration Activities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "259",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Forensic Science Diploma",
+      "credential": "diploma",
+      "program_code": "D5518C",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1309",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "One Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "111",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "132",
+              "title": "Court Procedure &amp; Evidence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "231",
+              "title": "Constitutional Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "112",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics Engineering Technology Diploma",
+      "credential": "diploma",
+      "program_code": "D40350",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1273",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "213",
+              "title": "Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Workplace Writing Essentials",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "111",
+                  "title": "Writing and Inquiry"
+                }
+              ]
+            },
+            {
+              "prefix": "MNT",
+              "number": "110",
+              "title": "Introduction to Maintenance Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "115",
+              "title": "Industrial Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "117",
+              "title": "Motors and Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "111",
+              "title": "Machine Processes I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ELN",
+                  "number": "133",
+                  "title": "Digital Electronics"
+                }
+              ]
+            },
+            {
+              "prefix": "PCI",
+              "number": "162",
+              "title": "Instrumentation Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "154",
+              "title": "Intro to Solid Modeling",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "DFT",
+                  "number": "170",
+                  "title": "Engineering Graphics"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
     },
     {
       "title": "Information Technology Diploma",
@@ -1456,9 +13632,37 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "SEC",
+              "number": "110",
+              "title": "Security Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "119",
+              "title": "Survey of Artificial Intelligence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "CIS",
               "number": "3119",
               "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "121",
+              "title": "Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "155",
+              "title": "Tech Support Functions",
               "credits": null,
               "or_alternatives": []
             }
@@ -1470,9 +13674,65 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "DBA",
+              "number": "110",
+              "title": "Database Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Humanities/Fine Arts Elective - See Choices Below*",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "125",
+              "title": "Introduction to Networks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "114",
+              "title": "Survey of Cybersecurity Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "*Humanities/Fine Arts Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "REL",
+              "number": "110",
+              "title": "World Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "110",
+              "title": "Technology and Society",
               "credits": null,
               "or_alternatives": []
             }
@@ -1501,6 +13761,69 @@
               "title": "Social/Behavioral Science - Elective",
               "credits": null,
               "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "136",
+              "title": "Word Processing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "122",
+              "title": "Medical Terminology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Workplace Writing Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OST",
+              "number": "137",
+              "title": "Office Applications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "149",
+              "title": "Medical Legal Issues",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "164",
+              "title": "Office Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "243",
+              "title": "Med Office Simulation",
+              "credits": null,
+              "or_alternatives": []
             }
           ]
         }
@@ -1508,55 +13831,408 @@
       "matched_program_slug": null
     },
     {
-      "title": "Early Childhood Education Diploma",
+      "title": "Viticulture and Enology Diploma",
       "credential": "diploma",
-      "program_code": "D55220",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1324",
+      "program_code": "D15430",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1196",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [
         {
-          "name": "One Semester",
+          "name": "Fall Semester",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "EDU",
-              "number": "145",
-              "title": "Child Development II",
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "EDU",
-              "number": "146",
-              "title": "Child Guidance",
+              "prefix": "SPA",
+              "number": "120",
+              "title": "Spanish for the Workplace",
               "credits": null,
               "or_alternatives": []
             },
             {
-              "prefix": "EDU",
-              "number": "259",
+              "prefix": "VEN",
+              "number": "132",
+              "title": "Wines of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "133",
+              "title": "Introduction to Winemaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "134",
+              "title": "Grape Harvest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "135",
+              "title": "Intro to Viticulture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "238",
+              "title": "Grape Pests, Diseases, and Disorders",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "138",
+              "title": "Vineyard Establishment and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "139",
+              "title": "Grape and Wine Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "111",
               "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "285",
+              "title": "Winery Operations",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "VEN",
+                  "number": "287",
+                  "title": "Vineyard Operations"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "**Program Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "130",
+              "title": "Fundamentals of Viticulture and Enology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "131",
+              "title": "Wine Tasting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "181",
+              "title": "Tasting Room Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "182",
+              "title": "Tasting Room Operations Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "188",
+              "title": "Wine Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "189",
+              "title": "Wine Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "285",
+              "title": "Winery Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "287",
+              "title": "Vineyard Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "111",
+              "title": "Work-Based Learning I",
               "credits": null,
               "or_alternatives": []
             }
           ]
         }
       ],
-      "matched_program_slug": "early-childhood-education"
+      "matched_program_slug": null
     },
     {
-      "title": "Forensic Science Diploma",
+      "title": "Practical Nursing Diploma",
       "credential": "diploma",
-      "program_code": "D5518C",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1309",
+      "program_code": "D45660",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1290",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "163",
+              "title": "Basic Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "101",
+              "title": "Practical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "117",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "102",
+              "title": "Practical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "103",
+              "title": "Practical Nursing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Air Conditioning, Heating, and Refrigeration Technology Certificate",
+      "credential": "certificate",
+      "program_code": "C35100",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1236",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHR",
+              "number": "110",
+              "title": "Introduction to Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "160",
+              "title": "Refrigerant Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "112",
+              "title": "DC/AC Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "125",
+              "title": "Diagrams and Schematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "112",
+              "title": "Heating Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Systems Technology Certificate",
+      "credential": "certificate",
+      "program_code": "C60160",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1241",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "151",
+              "title": "Brake Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "151A",
+              "title": "Brakes Systems Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "110",
+              "title": "Introduction to Transport Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "120",
+              "title": "Basic Transportation Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "130",
+              "title": "Intro to Sustainable Transp.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
     },
     {
       "title": "Welding Technology Diploma",
@@ -1573,6 +14249,41 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Mathematical Measurement and Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Applied Communications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "110",
+              "title": "Introduction to CAD/CAM",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "111",
+              "title": "Machine Processes I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "116",
+              "title": "SMAW (stick) Plate/Pipe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Courses in parenthesis are the WTCE (non-credit) course equivalent of the curriculum course. College Curriculum credit can be awarded for the following: WLD 3106Z for WLD 116",
@@ -1580,9 +14291,57 @@
               "or_alternatives": []
             },
             {
+              "prefix": "WLD",
+              "number": "3106Z",
+              "title": "Welding (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Welding Metallurgy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISC",
+              "number": "112",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "261",
+              "title": "Certification Practices",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "WBL",
+                  "number": "112",
+                  "title": "Work-Based Learning I"
+                }
+              ]
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "111",
+              "title": "Work-Based Learning I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "265",
+              "title": "Automated Welding/Cutting",
               "credits": null,
               "or_alternatives": []
             }
@@ -1592,76 +14351,6 @@
       "matched_program_slug": "welding"
     },
     {
-      "title": "Viticulture and Enology Diploma",
-      "credential": "diploma",
-      "program_code": "D15430",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1196",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Spring Semester",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "WBL",
-              "number": "111",
-              "title": "",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Air Conditioning, Heating, and Refrigeration Technology Certificate",
-      "credential": "certificate",
-      "program_code": "C35100",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1236",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Mechatronics Engineering Technology Diploma",
-      "credential": "diploma",
-      "program_code": "D40350",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1273",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "engineering"
-    },
-    {
-      "title": "Practical Nursing Diploma",
-      "credential": "diploma",
-      "program_code": "D45660",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1290",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "nursing"
-    },
-    {
-      "title": "Automotive Systems Technology Certificate",
-      "credential": "certificate",
-      "program_code": "C60160",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1241",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "automotive-technology"
-    },
-    {
       "title": "Computer-Integrated Machining Certificate",
       "credential": "certificate",
       "program_code": "C50210",
@@ -1669,29 +14358,36 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Cosmetology Certificate",
-      "credential": "certificate",
-      "program_code": "C55140",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1363",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Electrical Track Commercial Wiring Certificate",
-      "credential": "certificate",
-      "program_code": "C35130E",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1348",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "111",
+              "title": "Machining Technology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "112",
+              "title": "Machining Technology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "113",
+              "title": "Machining Technology III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -1702,7 +14398,97 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DME",
+              "number": "110",
+              "title": "Introduction to Digital Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "115",
+              "title": "Graphic Design Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "120",
+              "title": "Introduction to Multimedia",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "130",
+              "title": "Digital Animation I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Track Commercial Wiring Certificate",
+      "credential": "certificate",
+      "program_code": "C35130E",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1348",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "112",
+              "title": "DC/AC Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "114",
+              "title": "Commercial Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "118",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "126",
+              "title": "Electrical Computations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -1713,7 +14499,193 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "111",
+              "title": "Print Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "111",
+              "title": "Machining Technology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "121",
+              "title": "Introduction to CNC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "110",
+              "title": "Introduction to CAD/CAM",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "124",
+              "title": "CNC Milling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "122",
+              "title": "CNC Turning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology: Carpentry Certificate",
+      "credential": "certificate",
+      "program_code": "C35180",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1254",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "111",
+              "title": "Carpentry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "112",
+              "title": "Construction Materials &amp; Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "120",
+              "title": "Codes and Inspections",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cosmetology Certificate",
+      "credential": "certificate",
+      "program_code": "C55140",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1363",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "1st Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Cosmetology Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Salon I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "1st Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "Cosmetology Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Salon II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Cosmetology Concepts III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Salon III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "Cosmetology Concepts IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -1731,9 +14703,51 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "112",
+              "title": "DC/AC Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "115",
+              "title": "Industrial Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Courses in parenthesis are the WTCE (non-credit) course equivalent of the curriculum course. College Curriculum credit can be awarded for the following: ELC-3014N for ELC 115",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "3104N",
+              "title": "Electricity: Basic (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "118",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "126",
+              "title": "Electrical Computations",
               "credits": null,
               "or_alternatives": []
             }
@@ -1743,25 +14757,57 @@
       "matched_program_slug": null
     },
     {
-      "title": "Forensic Science Certificate",
+      "title": "Electrical Track Photovoltaic Systems Certificate",
       "credential": "certificate",
-      "program_code": "C5518C",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1308",
+      "program_code": "C35130D",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1349",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Construction Technology: Carpentry Certificate",
-      "credential": "certificate",
-      "program_code": "C35180",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1254",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "112",
+              "title": "DC/AC Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "118",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "220",
+              "title": "Photovoltaic System Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "221",
+              "title": "Adv PV Sys Designs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALT",
+              "number": "120",
+              "title": "Renewable Energy Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -1772,7 +14818,50 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "112",
+              "title": "DC/AC Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "113",
+              "title": "Residential Wiring I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "118",
+              "title": "National Electrical Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "126",
+              "title": "Electrical Computations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -1783,29 +14872,118 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "112",
+              "title": "DC/AC Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "125",
+              "title": "Diagrams and Schematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HYD",
+              "number": "110",
+              "title": "Hydraulics/Pneumatics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATR",
+              "number": "112",
+              "title": "Introduction to Automation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISC",
+              "number": "112",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "engineering"
     },
     {
-      "title": "Mechatronics Engineering Technology - Electronics Certificate",
+      "title": "Forensic Science Certificate",
       "credential": "certificate",
-      "program_code": "C40350B",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1368",
+      "program_code": "C5518C",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1308",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "engineering"
-    },
-    {
-      "title": "Electrical Track Photovoltaic Systems Certificate",
-      "credential": "certificate",
-      "program_code": "C35130D",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1349",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "115",
+              "title": "Crime Scene Photography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "146",
+              "title": "Trace Evidence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "245",
+              "title": "Friction Ridge Analysis",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "144",
+              "title": "Crime Scene Processing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "222",
+              "title": "Criminalistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "246",
+              "title": "Advanced Friction Ridge Analysis",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -1816,19 +14994,105 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NAS",
+              "number": "111",
+              "title": "Nurse Aide I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NAS",
+              "number": "112",
+              "title": "Nurse Aide II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": "nursing"
     },
     {
-      "title": "Viticulture and Enology Certificate - Viticulture (Grape Growing) Track",
+      "title": "Mechatronics Engineering Technology - Electronics Certificate",
       "credential": "certificate",
-      "program_code": "C15430A",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1191",
+      "program_code": "C40350B",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1368",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "112",
+              "title": "DC/AC Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "125",
+              "title": "Diagrams and Schematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATR",
+              "number": "112",
+              "title": "Introduction to Automation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "131",
+              "title": "Analog Electronics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISC",
+              "number": "112",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
     },
     {
       "title": "Viticulture and Enology Certificate - Enology (Winemaking) Track",
@@ -1838,7 +15102,364 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "1st Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "133",
+              "title": "Introduction to Winemaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "139",
+              "title": "Grape and Wine Science",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "285",
+              "title": "Winery Operations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "2nd Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "283",
+              "title": "Wine Production and Analysis",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology Certificate",
+      "credential": "certificate",
+      "program_code": "C50420",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1275",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "115",
+              "title": "SMAW (Stick) Plate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Symbols and Specifications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "GMAW (MIG) FCAW/Plate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "GTAW (TIG) Plate",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Viticulture and Enology Certificate - Marketing Track",
+      "credential": "certificate",
+      "program_code": "C15430C",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1194",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "132",
+              "title": "Wines of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "133",
+              "title": "Introduction to Winemaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "135",
+              "title": "Intro to Viticulture",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "284",
+              "title": "Wine Design and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "286",
+              "title": "Wine Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WBL",
+              "number": "121",
+              "title": "Work-Based Learning II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Viticulture and Enology Certificate - Viticulture (Grape Growing) Track",
+      "credential": "certificate",
+      "program_code": "C15430A",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1191",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "134",
+              "title": "Grape Harvest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "135",
+              "title": "Intro to Viticulture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "238",
+              "title": "Grape Pests, Diseases, and Disorders",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "138",
+              "title": "Vineyard Establishment and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "111",
+              "title": "Work-Based Learning I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "287",
+              "title": "Vineyard Operations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Viticulture and Enology Certificate - Tasting Room Operations",
+      "credential": "certificate",
+      "program_code": "C15430D",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1195",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "130",
+              "title": "Fundamentals of Viticulture and Enology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "131",
+              "title": "Wine Tasting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "132",
+              "title": "Wines of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "181",
+              "title": "Tasting Room Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "182",
+              "title": "Tasting Room Operations Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "131",
+              "title": "Work-Based Learning III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "188",
+              "title": "Wine Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "189",
+              "title": "Wine Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "286",
+              "title": "Wine Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -1849,93 +15470,65 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Viticulture and Enology Certificate - Marketing Track",
-      "credential": "certificate",
-      "program_code": "C15430C",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1194",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "business-administration"
-    },
-    {
-      "title": "Viticulture and Enology Certificate - Tasting Room Operations",
-      "credential": "certificate",
-      "program_code": "C15430D",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1195",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Welding Technology GMAW Certificate",
-      "credential": "certificate",
-      "program_code": "C50420A",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1276",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
       "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEN",
+              "number": "132",
+              "title": "Wines of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "134",
+              "title": "Grape Harvest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "135",
+              "title": "Intro to Viticulture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "238",
+              "title": "Grape Pests, Diseases, and Disorders",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
         {
           "name": "Spring Semester",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "WLD",
-              "number": "3106Z",
-              "title": "",
+              "prefix": "VEN",
+              "number": "138",
+              "title": "Vineyard Establishment and Development",
               "credits": null,
               "or_alternatives": []
             }
           ]
-        }
-      ],
-      "matched_program_slug": "welding"
-    },
-    {
-      "title": "Welding Technology Certificate",
-      "credential": "certificate",
-      "program_code": "C50420",
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1275",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": "welding"
-    },
-    {
-      "title": "Advanced Emergency Medical Technician Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1361",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
+        },
         {
-          "name": "Advanced Emergency Medical Technician Course",
+          "name": "Summer Semester",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Certification Testing: North Carolina Office of EMS, National Registry of EMTs Additional Testing Information: https://oems.nc.gov/ and https://www.nremt.org/",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Virginia residents pay the same rate as in-state students.",
+              "prefix": "VEN",
+              "number": "287",
+              "title": "Vineyard Operations",
               "credits": null,
               "or_alternatives": []
             }
@@ -1959,9 +15552,51 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "115",
+              "title": "SMAW (Stick) Plate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "*This course articulates to credit at Surry Community College.* WLD 3106Z1 for WLD 115",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Symbols and Specifications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "116",
+              "title": "SMAW (stick) Plate/Pipe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Welding Metallurgy",
               "credits": null,
               "or_alternatives": []
             }
@@ -1969,32 +15604,6 @@
         }
       ],
       "matched_program_slug": "welding"
-    },
-    {
-      "title": "Agriculture Workforce Courses",
-      "credential": "other",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1190",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Agriculture Workforce Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "VEN",
-              "number": "130",
-              "title": "",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
     },
     {
       "title": "Welding Technology Industrial Certificate",
@@ -2011,9 +15620,119 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "ISC",
+              "number": "112",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "115",
+              "title": "SMAW (Stick) Plate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "*This course articulates to credit at Surry Community College.* WLD 3106Z1 to WLD 115",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "GMAW (MIG) FCAW/Plate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Symbols and Specifications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology GMAW Certificate",
+      "credential": "certificate",
+      "program_code": "C50420A",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1276",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "GMAW (MIG) FCAW/Plate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Symbols and Specifications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "122",
+              "title": "GMAW (MIG) Plate/Pipe",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "3106Z",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Welding Metallurgy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "GTAW (TIG) Plate",
               "credits": null,
               "or_alternatives": []
             }
@@ -2049,6 +15768,46 @@
       "matched_program_slug": null
     },
     {
+      "title": "Advanced Emergency Medical Technician Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1361",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Advanced Emergency Medical Technician Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "4300",
+              "title": "Advanced Medical Technician (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certification Testing: North Carolina Office of EMS, National Registry of EMTs Additional Testing Information: https://oems.nc.gov/ and https://www.nremt.org/",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Virginia residents pay the same rate as in-state students.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Auto Dealer License Workforce Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -2075,6 +15834,172 @@
       "matched_program_slug": null
     },
     {
+      "title": "Agriculture Workforce Courses",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1190",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Agriculture Workforce Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "3001F",
+              "title": "Biological Pest Management (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "3001G",
+              "title": "Organic Crop Production (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "3001I",
+              "title": "Grape Pests, Diseases, and Disorders (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "4020A",
+              "title": "Wine Tasting (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOR",
+              "number": "3307F",
+              "title": "Farm Production Techniques (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOR",
+              "number": "3307G",
+              "title": "Fruit Tree Production (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOR",
+              "number": "3307H",
+              "title": "Fundamentals of Viticulture &amp; Enology (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOR",
+              "number": "3307I",
+              "title": "Wines of the World (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOR",
+              "number": "3307J",
+              "title": "Intro to Winemaking (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOR",
+              "number": "3307K",
+              "title": "Grape Harvest (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOR",
+              "number": "3307L",
+              "title": "Intro to Viticulture (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOR",
+              "number": "3307M",
+              "title": "Vineyard Operations (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOR",
+              "number": "3307N",
+              "title": "Vineyard Establishment and Development (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOR",
+              "number": "3307O",
+              "title": "Grape and Wine Science (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOS",
+              "number": "3070B",
+              "title": "Tasting Room Operations (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLS",
+              "number": "3810L",
+              "title": "Wine Finance (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLS",
+              "number": "3810M",
+              "title": "Wine Business (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLS",
+              "number": "3810N",
+              "title": "Wine Marketing (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLS",
+              "number": "3810O",
+              "title": "Winery Operations (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLS",
+              "number": "3810Q",
+              "title": "Wine Design and Management (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "130",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Autobody Technician Workforce Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -2089,6 +16014,41 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "AUT",
+              "number": "3109M",
+              "title": "Painting and Refinishing I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "3109N",
+              "title": "Non-Structural Damage I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "3109S",
+              "title": "Structural Damage I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "3109Q",
+              "title": "Plastics and Adhesives (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "3137N",
+              "title": "Intro to Transport Tech (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Virginia residents pay the same rate as in-state students.",
@@ -2099,32 +16059,6 @@
         }
       ],
       "matched_program_slug": null
-    },
-    {
-      "title": "Basic Law Enforcement Training (BLET) Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1303",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Basic Law Enforcement Training Workforce Certificate Course",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "College curriculum can be awarded for CJC 111, CJC 113, CJC 131, CJC 132, CJC 221, and CJC 231 for completion of this certificate and successfully passed the Commissions comprehensive certification examination.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "criminal-justice"
     },
     {
       "title": "Automotive Workforce Certificate",
@@ -2141,6 +16075,34 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "AUT",
+              "number": "3137N",
+              "title": "Intro to Transport Tech (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "3137V",
+              "title": "Intro to Sustainable Transport (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "3137O",
+              "title": "Basic Transportation Electricity (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "3137I",
+              "title": "Auto Braking Systems (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "TRN",
               "number": "110",
               "title": "",
@@ -2151,6 +16113,39 @@
         }
       ],
       "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Basic Law Enforcement Training (BLET) Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1303",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Basic Law Enforcement Training Workforce Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LET",
+              "number": "3110",
+              "title": "Basic Law Enforcement BLET (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "College curriculum can be awarded for CJC 111, CJC 113, CJC 131, CJC 132, CJC 221, and CJC 231 for completion of this certificate and successfully passed the Commissions comprehensive certification examination.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
     },
     {
       "title": "Central Sterile Processing Workforce Certificate",
@@ -2167,6 +16162,13 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "PHM",
+              "number": "3002",
+              "title": "Central Sterile Processing (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Certification Testing: International Association of Healthcare Central Service Material Management",
@@ -2177,39 +16179,6 @@
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Additional testing information: www.iahcsmm.org Virginia residents pay the same rate as in-state students.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Certified Production Technician - Industrial Manufacturing Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1269",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "CPT Industrial Manufacturing Workforce Certificate Course",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Certification Testing: MSSC - Certified Production Technician",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Additional testing information: https://www.msscusa.org/certification/production-certification-cpt/ Cost does not include books, tools, and supplies. Virginia residents pay the same rate as in-state students.",
               "credits": null,
               "or_alternatives": []
             }
@@ -2233,9 +16202,56 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "MED",
+              "number": "3300",
+              "title": "Medical Assisting (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Additional testing information: www.nhanow.com Virginia residents pay the same rate as in-state students.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Certified Production Technician - Industrial Manufacturing Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1269",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "CPT Industrial Manufacturing Workforce Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MFG",
+              "number": "3111C",
+              "title": "Certified Production Technician 4.0 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certification Testing: MSSC - Certified Production Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Additional testing information: https://www.msscusa.org/certification/production-certification-cpt/ Cost does not include books, tools, and supplies. Virginia residents pay the same rate as in-state students.",
               "credits": null,
               "or_alternatives": []
             }
@@ -2258,6 +16274,34 @@
           "credits_required": null,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "BPR",
+              "number": "3011A",
+              "title": "Print Reading-Construction (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "3112E",
+              "title": "Construction Materials and Methods (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "3124D",
+              "title": "Carpentry I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAR",
+              "number": "3112F",
+              "title": "Construction Codes and Inspection (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "BPR",
               "number": "130",
@@ -2299,6 +16343,34 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "CSC",
+              "number": "3110F",
+              "title": "Java Programming (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "3110B",
+              "title": "C++ Programming (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "3110J",
+              "title": "Python Programming (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "3110I",
+              "title": "Database Concepts (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Cost may not include associated textbooks and supplies. Virginia residents pay the same tuition rate as in-state students. *These courses meet the requirements for the “Continuing Education to Curriculum Credit” method of Credit for Prior Learning competencies and earn course credit. The content mastered is comparable to the student learning outcomes of a SCC curriculum course and may be used to fulfill degree, diploma, or certificate requirements. Contact the course instructor for complete details.",
@@ -2306,9 +16378,9 @@
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "**College Curriculum credit can be awarded for the following: CSC - 151 JAVA Programming for CSC - 3110F Java Programming (WTCE) , CSC - 134 C++ Programming for CSC - 3110B C++ Programming (WTCE) , DBA - 110 Database Concepts for CSC - 3110I Database Concepts (WTCE) CSC 121 Python Programming for CSC 3110J Python Programming",
+              "prefix": "CSC",
+              "number": "151",
+              "title": "JAVA Programming",
               "credits": null,
               "or_alternatives": []
             }
@@ -2332,61 +16404,65 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "*College Curriculum credit can be awarded for the following: COS - 111 Cosmetology Concepts I for COS - 3201A Cosmetology Theory I (WTCE) , COS - 112 Salon I for COS - 3201B Cosmetology Salon I (WTCE) , COS - 113 Cosmetology Concepts II for COS - 3201C Cosmetology Theory II (WTCE) , COS - 114 Salon II for COS - 3201D Cosmetology Salon II (WTCE) , COS - 115 Cosmetology Concepts III for COS - 3201E Cosmetology Theory III (WTCE) , COS - 116 Salon III for COS - 3201F Cosmetology Salon III (WTCE) , COS - 117 Cosmetology Concepts IV for COS - 3201G Cosmetology Theory IV (WTCE) , COS - 118 Salon IV for COS - 3201H Cosmetology Salon IV (WTCE) and successfully passed the certification examination.",
+              "prefix": "COS",
+              "number": "3201A",
+              "title": "Cosmetology Theory I (WTCE)",
               "credits": null,
               "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Digital Media Technology Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1358",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Digital Medical Technology Workforce Certificate Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
+            },
             {
-              "prefix": "DME",
-              "number": "110",
-              "title": "",
+              "prefix": "COS",
+              "number": "3201B",
+              "title": "Cosmetology Salon I (WTCE)",
               "credits": null,
               "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Electrical Systems - Commercial Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1353",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Electrical Systems - Commercial Workforce Certificate Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
+            },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "*College Curriculum credit can be awarded for the following: BPR - 130 Print Reading-Construction ELC - 112 DC/AC Electricity ELC - 114 Commercial Wiring ELC - 118 National Electrical Code ELC - 126 Electrical Computations Virginia residents pay the same rate as in-state students.",
+              "prefix": "COS",
+              "number": "3201C",
+              "title": "Cosmetology Theory II (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "3201D",
+              "title": "Cosmetology Salon II (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "3201E",
+              "title": "Cosmetology Theory III (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "3201F",
+              "title": "Cosmetology Salon III (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "3201G",
+              "title": "Cosmetology Theory IV (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "3201H",
+              "title": "Cosmetology Salon IV (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Cosmetology Concepts I",
               "credits": null,
               "or_alternatives": []
             }
@@ -2410,6 +16486,13 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "CJC",
+              "number": "3941",
+              "title": "Detention Officer Cert. (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Certification Testing: North Carolina Sheriff’s Training and Standards",
@@ -2429,23 +16512,112 @@
       "matched_program_slug": null
     },
     {
-      "title": "Electrical Systems - Residential Workforce Certificate",
+      "title": "Electrical Systems - Commercial Workforce Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1352",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1353",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [
         {
-          "name": "Electrical Systems - Residential Workforce Certificate Courses",
+          "name": "Electrical Systems - Commercial Workforce Certificate Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "*College Curriculum credit can be awarded for the following: BPR - 130 Print Reading-Construction ELC - 112 DC/AC Electricity ELC - 113 Residential Wiring I ELC - 118 National Electrical Code ELC - 126 Electrical Computations Cost does not include associated books, tools, and supplies. Virginia residents pay the same tuition rate as in-state students.",
+              "prefix": "BPR",
+              "number": "3011A",
+              "title": "Print Reading-Construction (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "3014G",
+              "title": "DC/AC Electricity (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "3119F",
+              "title": "Commercial Wiring (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "3100A",
+              "title": "National Electrical Code (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "3713A",
+              "title": "Electrical Computations (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Media Technology Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1358",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Digital Medical Technology Workforce Certificate Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SGR",
+              "number": "3100A",
+              "title": "Intro to Digital Media (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGR",
+              "number": "3100B",
+              "title": "Digital Media Tools (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGR",
+              "number": "3100C",
+              "title": "Intro to Multimedia (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGR",
+              "number": "3100D",
+              "title": "Digital Animation I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "110",
+              "title": "",
               "credits": null,
               "or_alternatives": []
             }
@@ -2469,9 +16641,16 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "*College Curriculum credit can be awarded for EMS - 110 EMT for completion of this certificate and successfully passing the certification examination. Certification Testing: North Carolina Office of EMS, National Registry of EMTs",
+              "prefix": "EMS",
+              "number": "4200",
+              "title": "Emergency Medical Technician Initial (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "110",
+              "title": "EMT",
               "credits": null,
               "or_alternatives": []
             },
@@ -2488,6 +16667,67 @@
       "matched_program_slug": null
     },
     {
+      "title": "Electrical Systems - Residential Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1352",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Electrical Systems - Residential Workforce Certificate Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "3011A",
+              "title": "Print Reading-Construction (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "3014G",
+              "title": "DC/AC Electricity (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "3119A",
+              "title": "Residential Wiring I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "3100A",
+              "title": "National Electrical Code (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "3713A",
+              "title": "Electrical Computations (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Esthetics Workforce Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -2495,7 +16735,29 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Esthetics Workforce Certifcate Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "3102A",
+              "title": "Esthetician I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "3102B",
+              "title": "Esthetician II (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -2513,6 +16775,13 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "FIP",
+              "number": "3600",
+              "title": "Emergency Vehicle Driver (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Certification Testing: North Carolina Office of EMS Additional testing information: https://www.ncems.org/",
@@ -2525,29 +16794,14 @@
       "matched_program_slug": null
     },
     {
-      "title": "Fire Apparatus Driver/Aerial Operator Workforce Certificate",
+      "title": "Fire Technical Rescuer Workforce Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1330",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1335",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [
-        {
-          "name": "Fire Apparatus Driver/Aerial Operator Workforce Certificate Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "OR",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
+      "requirement_groups": [],
       "matched_program_slug": null
     },
     {
@@ -2565,9 +16819,23 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "FIP",
+              "number": "3811",
+              "title": "Fire/Rescue Instructor I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Prerequisites: High School or equivalent required;",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3812",
+              "title": "Fire/Rescue Instructor Level 2 (WTCE)",
               "credits": null,
               "or_alternatives": []
             },
@@ -2605,6 +16873,27 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "FIP",
+              "number": "3718",
+              "title": "Fire Officer Level I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3719",
+              "title": "Fire Officer Level 2 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "6900",
+              "title": "Rescue Officer (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
@@ -2617,60 +16906,65 @@
       "matched_program_slug": null
     },
     {
-      "title": "Fire Technical Rescuer Workforce Certificate",
+      "title": "Fire Apparatus Driver/Aerial Operator Workforce Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1335",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Firefighter Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1331",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1330",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [
         {
-          "name": "Firefighter Workforce Certificate Courses",
+          "name": "Fire Apparatus Driver/Aerial Operator Workforce Certificate Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Virginia residents pay the same rate as in-state students.",
+              "prefix": "FIP",
+              "number": "3600",
+              "title": "Emergency Vehicle Driver (WTCE)",
               "credits": null,
               "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "General Maintenance Technician Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1360",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "General Maintenance Technician Workforce Certificate Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
-              "title": "*College Curriculum credit can be awarded for the following for completion of this certificate: AHR - 112 Heating Technology AHR 120 HVACR Maintenance BPR 130 Print Reading-Construction ELC 114 Commercial Wiring MNT 110 Introduction to Maintenance Procedures Virginia residents pay the same rate as in-state students.",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3623",
+              "title": "D/O Pumps Intro/Basic Ops (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3624",
+              "title": "D/O Pumps Hydr/Water Supply (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3625",
+              "title": "D/O Pumps Spr&amp;Sps/Maint&amp;Test (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3622",
+              "title": "D / O Pumps Apparatus Series (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3626",
+              "title": "D/O Aerial Apparatus Series (WTCE)",
               "credits": null,
               "or_alternatives": []
             }
@@ -2694,6 +16988,62 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "FRC",
+              "number": "1600",
+              "title": "Hazardous Materials Awareness Level (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1601",
+              "title": "Hazardous Materials Operations Level (HM Ops- Hazardous Materials Operations) (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1602",
+              "title": "HM Ops MSC (Chapter 6.2) -Hazardous Materials Personal Protective Equipment (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1603",
+              "title": "HM Ops MSC (Chapters 6.3/6.4) -Hazardous Materials Mass and Technical Decontamination (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1604",
+              "title": "HM Ops MSC (Chapter 6.7) -Hazardous Materials Detection, Monitoring and Sampling (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1605",
+              "title": "HM Ops MSC (Chapter 6.8) -Hazardous Materials Victim Rescue and Recovery (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1606",
+              "title": "HM Ops MSC (Chapters 6.5/6.9) -Hazardous Materials Evidence Preservation &amp; Illicit Laboratory Incidents (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1607",
+              "title": "HM Ops MSC (Chapter 6.6) -Hazardous Materials Product Control (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Certification Testing: Hazardous Materials Responder Certification Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
@@ -2706,23 +17056,114 @@
       "matched_program_slug": null
     },
     {
-      "title": "Human Resources Development Workforce Training Courses",
-      "credential": "other",
+      "title": "Firefighter Workforce Certificate",
+      "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1374",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1331",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [
         {
-          "name": "Human Resources Development (HRD) Training Courses",
+          "name": "Firefighter Workforce Certificate Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
+              "prefix": "FIP",
+              "number": "3040",
+              "title": "General and Communications (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3041",
+              "title": "Fireground Operations 1 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3042",
+              "title": "Fireground Operations 2 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3043",
+              "title": "Fireground Operations 3 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3044",
+              "title": "Fireground Operations 4 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3045",
+              "title": "Fireground Operations 5 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3046",
+              "title": "Fireground Operations 6 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3047",
+              "title": "Fireground Operations 7 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3048",
+              "title": "Fireground Operations 8 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3049",
+              "title": "Fireground Operations 9 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3050",
+              "title": "Rescue Operations 1 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "3051",
+              "title": "FLSE Initiatives (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "6413",
+              "title": "Mayday/Safety and Survival",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
-              "title": "Virginia residents pay the same tuition rate as in-state students. Per the NC General Statutes (G.S. 115D-5(b) (13)), individuals enrolling in courses offered through the Human Resources Development (HRD) Program may be granted a waiver of registration fees if they meet one of four criteria: Are unemployed;",
+              "title": "Virginia residents pay the same rate as in-state students.",
               "credits": null,
               "or_alternatives": []
             }
@@ -2746,9 +17187,44 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "**College Curriculum credit can be awarded for the following: AHR - 110 Introduction to Refrigeration for AHR - 3131C Intro to Refrigeration (WTCE) , ELC - 112 DC/AC Electricity for ELC - 3014G DC/AC Electricity (WTCE) , ELC - 125 Diagrams and Schematics for ELC - 3014H Diagrams and Schematics (WTCE) , AHR - 112 Heating Technology for AHR - 3131E Heating Technology (WTCE) , AHR - 160 Refrigerant Certification for AHR - 3128A Refrigerant Certification (WTCE) and successfully passed the certification examination. Certification Testing: EPA 608 Certification Additional testing information: http://www.refrigerationboard.org/ https://www.escogroup.org/ Virginia residents pay the same rate as in-state students.",
+              "prefix": "AHR",
+              "number": "3131C",
+              "title": "Intro to Refrigeration (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "3014G",
+              "title": "DC/AC Electricity (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "3014H",
+              "title": "Diagrams and Schematics (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "3131E",
+              "title": "Heating Technology (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "3128A",
+              "title": "Refrigerant Certification (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "110",
+              "title": "Introduction to Refrigeration",
               "credits": null,
               "or_alternatives": []
             }
@@ -2758,30 +17234,168 @@
       "matched_program_slug": null
     },
     {
-      "title": "Initial Fire and Life Safety Educator Workforce Certificate",
+      "title": "General Maintenance Technician Workforce Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1329",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1360",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [
         {
-          "name": "Initial Fire and Life Safety Educator Workforce Certification Courses",
+          "name": "General Maintenance Technician Workforce Certificate Courses",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Certification Testing: Fire and Life Safety Educator",
+              "prefix": "AHR",
+              "number": "3131E",
+              "title": "Heating Technology (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "3119F",
+              "title": "Commercial Wiring (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BPR",
+              "number": "3011A",
+              "title": "Print Reading-Construction (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MNT",
+              "number": "3065A",
+              "title": "Introduction to Maintenance Procedures (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "3131J",
+              "title": "HVACR Maintenance (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "112",
+              "title": "Heating Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Resources Development Workforce Training Courses",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1374",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Human Resources Development (HRD) Training Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRD",
+              "number": "3001",
+              "title": "Employability Skills (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRD",
+              "number": "3002",
+              "title": "Employability Lab (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRD",
+              "number": "3002F",
+              "title": "Workkeys Prep (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRD",
+              "number": "3003",
+              "title": "Career Planning and Assessment (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRD",
+              "number": "3004",
+              "title": "Career Readiness/Pathways (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRD",
+              "number": "3005Q",
+              "title": "Technology Awareness for Education Resources (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRD",
+              "number": "3005R",
+              "title": "Technology Awareness for PC (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRD",
+              "number": "3005S",
+              "title": "Technology Awareness for Online (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRD",
+              "number": "3005T",
+              "title": "Technology Awareness for Innovative Equipment (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRD",
+              "number": "3005V",
+              "title": "Technology Awareness Basics (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRD",
+              "number": "3006",
+              "title": "Employability Motivation &amp; Retention (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRD",
+              "number": "3008",
+              "title": "Financial Literacy (WTCE)",
               "credits": null,
               "or_alternatives": []
             },
             {
               "prefix": "ELEC",
               "number": "XXX",
-              "title": "Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
+              "title": "Virginia residents pay the same tuition rate as in-state students. Per the NC General Statutes (G.S. 115D-5(b) (13)), individuals enrolling in courses offered through the Human Resources Development (HRD) Program may be granted a waiver of registration fees if they meet one of four criteria: Are unemployed;",
               "credits": null,
               "or_alternatives": []
             }
@@ -2805,9 +17419,37 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "**College Curriculum credit can be awarded for the following: CTI - 110 IT Foundations for WEB - 3000D IT Foundations (WTCE) , CTI - 120 Network and Security Foundations for NET - 3100B Network and Security Foundations (WTCE) , CTS - 115 Information Systems Business Concepts for MLS - 3810H Info System Business Concepts (WTCE) , CIS 110 Introduction to Computers for CET - 3100A Tech Support Functions (WTCE) Virginia residents pay the same rate as in-state students.",
+              "prefix": "WEB",
+              "number": "3000D",
+              "title": "IT Foundations (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "3100B",
+              "title": "Network and Security Foundations (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLS",
+              "number": "3810H",
+              "title": "Info System Business Concepts (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "3100A",
+              "title": "Tech Support Functions (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTI",
+              "number": "110",
+              "title": "IT Foundations",
               "credits": null,
               "or_alternatives": []
             }
@@ -2828,32 +17470,6 @@
       "matched_program_slug": "engineering"
     },
     {
-      "title": "Medical Billing and Coding Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1227",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Medical Billing and Coding Workforce Certificate Course",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "*Students should contact Dr. Yvonne Johnson concerning details on articulation.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
       "title": "Medication Aide Certification Workforce Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -2868,6 +17484,13 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "PHM",
+              "number": "4100",
+              "title": "Medication Aide (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Certification Testing: North Carolina Board of Nursing",
@@ -2878,6 +17501,93 @@
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Additional testing information www.ncbon.org Virginia residents pay the same rate as in-state students.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Initial Fire and Life Safety Educator Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1329",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Initial Fire and Life Safety Educator Workforce Certification Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIP",
+              "number": "4630",
+              "title": "Fire and Life Safety Educator Level I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "4631",
+              "title": "Fire and Life Safety Educator Level 2 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "4632",
+              "title": "Fire and Life Safety Educator Level 3 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certification Testing: Fire and Life Safety Educator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Billing and Coding Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1227",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Medical Billing and Coding Workforce Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OST",
+              "number": "3150",
+              "title": "Medical Billing and Coding (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*Students should contact Dr. Yvonne Johnson concerning details on articulation.",
               "credits": null,
               "or_alternatives": []
             }
@@ -2901,31 +17611,12 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Students must purchase a materials kit through the SCC bookstore at an additional cost. Virginia residents pay the same rate as in-state students.",
+              "prefix": "COS",
+              "number": "3101A",
+              "title": "Manicurist/Nail Tech (WTCE)",
               "credits": null,
               "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Natural Hair Care Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1365",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Natural Hair Care Workforce Certificate Course",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -2953,6 +17644,48 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "SGR",
+              "number": "3100A",
+              "title": "Intro to Digital Media (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGR",
+              "number": "3100B",
+              "title": "Digital Media Tools (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGR",
+              "number": "3100E",
+              "title": "Intro to Audio Video Media (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGR",
+              "number": "3100C",
+              "title": "Intro to Multimedia (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGR",
+              "number": "3100D",
+              "title": "Digital Animation I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGR",
+              "number": "3100F",
+              "title": "Emerging Tech in Digital Media (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "*These courses meet the requirements for the “Continuing Education to Curriculum Credit” method of Credit for Prior Learning competencies and earn course credit. The content mastered is comparable to the student learning outcomes of a SCC curriculum course and may be used to fulfill degree, diploma, or certificate requirements. Contact the course instructor for complete details.",
@@ -2960,9 +17693,9 @@
               "or_alternatives": []
             },
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "**College Curriculum credit can be awarded for the following: DME - 110 Introduction to Digital Media for SGR - 3100A Intro to Digital Media (WTCE) , DME - 115 Graphic Design Tools for SGR - 3100B Digital Media Tools (WTCE) , DME - 140 Introduction to Audio/Video Media for SGR - 3100E Intro to Audio Video Media (WTCE) , DME - 120 Introduction to Multimedia for SGR - 3100C Intro to Multimedia (WTCE) , DME - 130 Digital Animation I for SGR - 3100D Digital Animation I (WTCE) , DME - 260 Emerging Technologies in Digital Media for SGR - 3100F Emerging Tech in Digital Media (WTCE)",
+              "prefix": "DME",
+              "number": "110",
+              "title": "Introduction to Digital Media",
               "credits": null,
               "or_alternatives": []
             }
@@ -2985,6 +17718,20 @@
           "credits_required": null,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "EPT",
+              "number": "4300",
+              "title": "NIMS Level 300 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPT",
+              "number": "4400",
+              "title": "NIMS Level 400 (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -3012,6 +17759,20 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "LEX",
+              "number": "3874",
+              "title": "Notary Public Education (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "3875",
+              "title": "eNotary Public (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "*Must be fully commissioned NC Notary Public to take e-Notary courses.",
@@ -3022,6 +17783,86 @@
         }
       ],
       "matched_program_slug": null
+    },
+    {
+      "title": "Natural Hair Care Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1365",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Natural Hair Care Workforce Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "3104",
+              "title": "Natural Hair Care Specialist (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Students must purchase a materials kit through the SCC bookstore at an additional cost. Virginia residents pay the same rate as in-state students.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nurse Aide I Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1297",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Nurse Aide I Workforce Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NAS",
+              "number": "3240",
+              "title": "Nurse Aide Level I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "College curriculum credit for Nurse Aide I can be awarded once the student completes the NAS 3240 course and after successfully passing the certification examination.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certification Testing: Credentia",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Additional testing information www.credentia.com Virginia residents pay the same rate as in-state students.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
     },
     {
       "title": "Paramedic Initial Workforce Certificate",
@@ -3037,6 +17878,13 @@
           "credits_required": null,
           "choose_n": null,
           "courses": [
+            {
+              "prefix": "EMS",
+              "number": "4400",
+              "title": "Paramedic Initial (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
@@ -3071,6 +17919,13 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "NAS",
+              "number": "3241",
+              "title": "Nurse Aide Level II (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Certification Testing: North Carolina Board of Nursing",
@@ -3081,79 +17936,6 @@
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Additional testing information www.ncbon.com Virginia residents pay the same rate as in-state students.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "nursing"
-    },
-    {
-      "title": "Pharmacy Technician Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1300",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Pharmacy Technician Workforce Certificate Course",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Certification Testing: Pharmacy Technician Certification Board",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Additional testing information www.ptcb.com Virginia residents pay the same rate as in-state students.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Nurse Aide I Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1297",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Nurse Aide I Workforce Certificate Course",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "College curriculum credit for Nurse Aide I can be awarded once the student completes the NAS 3240 course and after successfully passing the certification examination.",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Certification Testing: Credentia",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Additional testing information www.credentia.com Virginia residents pay the same rate as in-state students.",
               "credits": null,
               "or_alternatives": []
             }
@@ -3174,101 +17956,37 @@
       "matched_program_slug": null
     },
     {
-      "title": "Teacher Assistant Pathway Workforce Certificate",
+      "title": "Pharmacy Technician Workforce Certificate",
       "credential": "certificate",
       "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1366",
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1300",
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [
         {
-          "name": "Teacher Assistant Pathway Workforce Certificate Courses",
+          "name": "Pharmacy Technician Workforce Certificate Course",
           "credits_required": null,
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Virginia residents pay the same rate as in-state students.",
+              "prefix": "PHM",
+              "number": "3250",
+              "title": "Pharmacy Technician Training (WTCE)",
               "credits": null,
               "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Phlebotomy Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1301",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Phlebotomy Workforce Certificate Course",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
-              "title": "Virginia residents pay the same rate as in-state students.",
+              "title": "Certification Testing: Pharmacy Technician Certification Board",
               "credits": null,
               "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Technical Rescuer Machinery Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1339",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Technical Rescuer Machinery Certificate Course",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
+            },
             {
               "prefix": "ELEC",
               "number": "XXX",
-              "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Technical Rescuer Heavy Vehicle Rescue Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1372",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Technical Rescuer Heavy Vehicle Rescue Certificate Course",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
+              "title": "Additional testing information www.ptcb.com Virginia residents pay the same rate as in-state students.",
               "credits": null,
               "or_alternatives": []
             }
@@ -3292,9 +18010,230 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "FRC",
+              "number": "1206",
+              "title": "TR Confined Space Rescue Series (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1301",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Phlebotomy Workforce Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PBT",
+              "number": "3022C",
+              "title": "Phlebotomy Experience (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Virginia residents pay the same rate as in-state students.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Teacher Assistant Pathway Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1366",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Teacher Assistant Pathway Workforce Certificate Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "3010A",
+              "title": "Teacher Assistant (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRD",
+              "number": "3004C",
+              "title": "Human Resource Development (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Virginia residents pay the same rate as in-state students.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Rescuer Passenger Vehicle Rescue Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1371",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Technical Rescuer Passenger Vehicle Rescue Certificate Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FRC",
+              "number": "1200",
+              "title": "Technical Rescue Introduction Course (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1207",
+              "title": "Technical Rescue Passenger Vehicle Rescue Series (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1200",
+              "title": "Technical Rescue Introduction Course (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1208",
+              "title": "Technical Rescue Passenger Vehicle Rescue Awareness (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1209",
+              "title": "Technical Rescue Passenger Vehicle Rescue Operations (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1210",
+              "title": "Technical Rescue Passenger Vehicle Rescue Technician (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Rescuer Heavy Vehicle Rescue Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1372",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Technical Rescuer Heavy Vehicle Rescue Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FRC",
+              "number": "1211",
+              "title": "TR Heavy Vehicle Rescue Series (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Rescuer Machinery Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1339",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Technical Rescuer Machinery Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIP",
+              "number": "5720",
+              "title": "TR Machinery and Ag Rescue Block (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
               "credits": null,
               "or_alternatives": []
             }
@@ -3318,9 +18257,136 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "FRC",
+              "number": "1201",
+              "title": "Technical Rescue Rope Rescue Series (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1202",
+              "title": "Technical Rescue Rope Rescue Awareness (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1203",
+              "title": "Technical Rescue Rope Rescue Operations (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRC",
+              "number": "1204",
+              "title": "Technical Rescue Rope Rescue Technician (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Rescuer Structural Collapse Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1341",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Technical Rescuer Structural Collapse Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FRC",
+              "number": "1205",
+              "title": "TR Structural Collapse Series (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Rescuer Surface Water Rescue Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1337",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Technical Rescuer Surface Water Rescue Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FRC",
+              "number": "1215",
+              "title": "TR Surface Water Rescue Series (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Rescuer Wilderness Search Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1338",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Technical Rescuer Wilderness Search Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIP",
+              "number": "6300",
+              "title": "TR Wilderness Block (WTCE)",
               "credits": null,
               "or_alternatives": []
             },
@@ -3351,153 +18417,16 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Technical Rescuer Passenger Vehicle Rescue Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1371",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Technical Rescuer Passenger Vehicle Rescue Certificate Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "OR",
+              "prefix": "FRC",
+              "number": "1213",
+              "title": "Technical Rescue Trench Rescue Series (WTCE)",
               "credits": null,
               "or_alternatives": []
             },
             {
               "prefix": "ELEC",
               "number": "XXX",
-              "title": "FRC - 1200 Technical Rescue Introduction Course (WTCE)",
-              "credits": null,
-              "or_alternatives": []
-            },
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Technical Rescuer Surface Water Rescue Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1337",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Technical Rescuer Surface Water Rescue Certificate Course",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
               "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Technical Rescuer Structural Collapse Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1341",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Technical Rescuer Structural Collapse Certificate Course",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Technical Rescuer Wilderness Search Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1338",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Technical Rescuer Wilderness Search Certificate Course",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Certification Testing: Technical Rescuer Certification Additional testing may be required. Virginia residents pay the same rate as in-state students. Members of approved North Carolina fire departments and rescue squads may be eligible to receive tuition waivers for these classes.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Veterinary Assistant Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1357",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Veterinary Assistant Workforce Certificate",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Virginia residents pay the same rate as in-state students.",
               "credits": null,
               "or_alternatives": []
             }
@@ -3521,6 +18450,13 @@
           "choose_n": null,
           "courses": [
             {
+              "prefix": "TRA",
+              "number": "3607",
+              "title": "Truck Driver (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Certification Testing: NCDMV Commercial Driver License",
@@ -3531,6 +18467,93 @@
               "prefix": "ELEC",
               "number": "XXX",
               "title": "Additional testing information: https://www.ncdot.gov/dmv/license-id/driver-licenses/commercial/Pages/apply-for-cdl.aspx Virginia residents pay the same rate as in-state students.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Trucking Logistics Management Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1343",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Trucking Logistics Management Workforce Certificate Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLS",
+              "number": "3810C",
+              "title": "Operations of Trucking I (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLS",
+              "number": "3810D",
+              "title": "Operations of Trucking II (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOG",
+              "number": "3400B",
+              "title": "Transportation Logistics (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LOG",
+              "number": "3400C",
+              "title": "Fleet Management (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Virginia residents pay the same rate as in-state students.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Veterinary Assistant Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1357",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Veterinary Assistant Workforce Certificate",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VET",
+              "number": "3010",
+              "title": "Veterinary Assistant (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Virginia residents pay the same rate as in-state students.",
               "credits": null,
               "or_alternatives": []
             }
@@ -3551,43 +18574,6 @@
       "matched_program_slug": "welding"
     },
     {
-      "title": "Trucking Logistics Management Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1343",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [
-        {
-          "name": "Trucking Logistics Management Workforce Certificate Courses",
-          "credits_required": null,
-          "choose_n": null,
-          "courses": [
-            {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "Virginia residents pay the same rate as in-state students.",
-              "credits": null,
-              "or_alternatives": []
-            }
-          ]
-        }
-      ],
-      "matched_program_slug": "business-administration"
-    },
-    {
-      "title": "Construction Assistant Fast-Track Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1256",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
       "title": "Welding-Industrial Workforce Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -3602,9 +18588,44 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "College Curriculum credit can be awarded for the following: WLD - 110 Cutting Processes WLD - 115 SMAW (Stick) Plate WLD - 141 Symbols and Specifications WLD - 121 GMAW (MIG) FCAW/Plate ISC 112 Industrial Safety",
+              "prefix": "WLD",
+              "number": "3106O",
+              "title": "Cutting Processes (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "3106E",
+              "title": "Welding Stick (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "3106R",
+              "title": "Symbols and Specifications (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "3106L",
+              "title": "Welding: GMAW MIG Plate (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISC",
+              "number": "3036",
+              "title": "Industrial Safety (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
               "credits": null,
               "or_alternatives": []
             },
@@ -3621,6 +18642,32 @@
       "matched_program_slug": "welding"
     },
     {
+      "title": "Construction Assistant Fast-Track Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1256",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Construction Assistant Fast Track Workforce Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "3110C",
+              "title": "Construction Assistant (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
       "title": "Electrical Assistant Fast-Track Workforce Certificate",
       "credential": "certificate",
       "program_code": null,
@@ -3628,7 +18675,22 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Electrical Assistant Fast Track Workforce Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "3014M",
+              "title": "Electrical Assistant (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -3646,9 +18708,68 @@
           "choose_n": null,
           "courses": [
             {
-              "prefix": "ELEC",
-              "number": "XXX",
-              "title": "*College Curriculum credit can be awarded for ELC - 113 Residential Wiring I and ELC - 125 Diagrams and Schematics for completion of this certificate. Virginia residents pay the same rate as in-state students.",
+              "prefix": "ELC",
+              "number": "3014D",
+              "title": "Electrical Institute IV (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "113",
+              "title": "Residential Wiring I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC Technical Assistant Fast Track Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1239",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "HVAC Technician Assistant Fast Track Workforce Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHR",
+              "number": "3131H",
+              "title": "HVAC Technician Assistant (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Maintenance Technician Fast-Track Workforce Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1268",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Maintenance Technician Fast-Track Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MNT",
+              "number": "3065B",
+              "title": "Maintenance Technician (WTCE)",
               "credits": null,
               "or_alternatives": []
             }
@@ -3665,29 +18786,22 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "HVAC Technical Assistant Fast Track Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1239",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
-      "matched_program_slug": null
-    },
-    {
-      "title": "Maintenance Technician Fast-Track Workforce Certificate",
-      "credential": "certificate",
-      "program_code": null,
-      "catalog_url": "https://catalog.surry.edu/preview_program.php?catoid=7&poid=1268",
-      "total_credits": null,
-      "gpa_minimum": null,
-      "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Masonry Assistant Fast Track Workforce Certificate",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAS",
+              "number": "3002",
+              "title": "Masonry (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     },
     {
@@ -3698,7 +18812,22 @@
       "total_credits": null,
       "gpa_minimum": null,
       "description": null,
-      "requirement_groups": [],
+      "requirement_groups": [
+        {
+          "name": "Production Welder Fast-Track Workforce Certificate Course",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "3106X",
+              "title": "Production Welder (WTCE)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
       "matched_program_slug": null
     }
   ]

--- a/data/tx/DEFERRED-programs.md
+++ b/data/tx/DEFERRED-programs.md
@@ -19,7 +19,10 @@ houston(hccs) 97, vernon 59, weatherford 56.
   temple): their Acalog catalog dropdown doesn't expose a `selected` catoid in the
   standard `index.php` form, so catoid auto-discovery falls back to a wrong id with no
   programs. Needs per-college catoid pinning.
-- **blinn — 100 programs, 0 plannable**: links courses instead of inlining codes.
+- **blinn — 100 programs, 0 plannable**: NOT a code-format issue (the Acalog regex fix
+  that recovered surry/mott does not help here). Verified 2026-06-04: blinn's catalog
+  (catoid 22 and 24) now serves "Archived Content!" empty shells — no inline codes and no
+  preview_course links. Needs a separate source (newer catalog edition or PDF degree plans).
 - **Alamo Colleges District (san-antonio, northeast-lakeview, northwest-vista, palo-alto,
   st-philips, southwest-deaf) and Lone Star College System** publish ONE district-shared
   catalog, not per-college — needs a district splitter; only san-antonio (alamo.edu) was

--- a/scripts/lib/__tests__/scrape-acalog-programs.test.ts
+++ b/scripts/lib/__tests__/scrape-acalog-programs.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { parseCourseFromLabel } from "@/scripts/lib/scrape-acalog-programs";
+
+/**
+ * parseCourseFromLabel turns an Acalog course aria-label / link text into
+ * {prefix, number, title}. Catalogs vary in how they separate the prefix from
+ * the number; the regex must accept all known real formats while still
+ * rejecting free-text requirement-group headers ("Choose 3 credits…").
+ *
+ * The nbsp-hyphen (surry/NC) and hyphen-no-space (mott/MI) rows are the ones
+ * the 2026-06-04 fix added; the rest are regression guards for formats that
+ * already worked and must keep working.
+ */
+describe("parseCourseFromLabel — separator formats parse correctly", () => {
+  const cases: Array<{
+    name: string;
+    input: string;
+    expected: { prefix: string; number: string; title: string };
+  }> = [
+    {
+      name: "plain space (most common)",
+      input: "MAT 171 Precalculus Algebra",
+      expected: { prefix: "MAT", number: "171", title: "Precalculus Algebra" },
+    },
+    {
+      name: "dash between number and title (CT)",
+      input: "ENG 101 - English Composition",
+      expected: { prefix: "ENG", number: "101", title: "English Composition" },
+    },
+    {
+      name: "colon between number and title (Germanna)",
+      input: "ENG 111: College Composition I",
+      expected: { prefix: "ENG", number: "111", title: "College Composition I" },
+    },
+    {
+      name: "no space between prefix and number (FL Acalog)",
+      input: "ACG2021 Financial Accounting",
+      expected: { prefix: "ACG", number: "2021", title: "Financial Accounting" },
+    },
+    {
+      name: "no separator + trailing credit parenthetical (gaston)",
+      input: "ACA 122 Transfer & Career Success (1 Credit Hour)",
+      expected: { prefix: "ACA", number: "122", title: "Transfer & Career Success" },
+    },
+    {
+      name: "hyphen between prefix and number, spaces/nbsp (surry/NC) — FIX",
+      input: "WBL - 110 World of Work",
+      expected: { prefix: "WBL", number: "110", title: "World of Work" },
+    },
+    {
+      name: "hyphen with no space (mott/MI) — FIX",
+      input: "ACCT-101 Applied Accounting",
+      expected: { prefix: "ACCT", number: "101", title: "Applied Accounting" },
+    },
+    {
+      name: "number with trailing letter (lab section)",
+      input: "BIO 110L Lab",
+      expected: { prefix: "BIO", number: "110L", title: "Lab" },
+    },
+    {
+      name: "code only, no title",
+      input: "BIO 110",
+      expected: { prefix: "BIO", number: "110", title: "" },
+    },
+  ];
+
+  for (const { name, input, expected } of cases) {
+    it(`parses: ${name}`, () => {
+      expect(parseCourseFromLabel(input)).toEqual(expected);
+    });
+  }
+});
+
+describe("parseCourseFromLabel — free-text must stay null", () => {
+  const negatives = [
+    "Math / Natural Science Electives",
+    "Choose 3 credits from the following",
+    "Select one of the following",
+    "General Education Requirements",
+    "Restricted Elective",
+    "Choose one:",
+  ];
+
+  for (const input of negatives) {
+    it(`rejects: "${input}"`, () => {
+      expect(parseCourseFromLabel(input)).toBeNull();
+    });
+  }
+});

--- a/scripts/lib/scrape-acalog-programs.ts
+++ b/scripts/lib/scrape-acalog-programs.ts
@@ -238,14 +238,19 @@ function parseProgramCode(title: string): string | null {
  * The leading [A-Z]{2,5} anchor prevents matches against free-text electives
  * like "Math elective" or "Choose 3 credits from…" (lowercase / no code).
  */
-function parseCourseFromLabel(label: string): {
+// Exported for unit testing (see __tests__/scrape-acalog-programs.test.ts).
+export function parseCourseFromLabel(label: string): {
   prefix: string;
   number: string;
   title: string;
 } | null {
   const trimmed = label.trim();
+  // Prefix→number separator varies by catalog: plain space ("ENG 111"),
+  // none ("ACG2021"), hyphen-no-space ("ACCT-101", mott/MI), or
+  // nbsp-hyphen-nbsp ("WBL - 110", surry/NC). Allow an optional single
+  // hyphen flanked by optional whitespace. (\s already matches nbsp in JS.)
   const m = trimmed.match(
-    /^([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\b\s*(?:[-:]\s*)?(.*)$/,
+    /^([A-Z]{2,5})\s*-?\s*(\d{3,4}[A-Z]?)\b\s*(?:[-:]\s*)?(.*)$/,
   );
   if (!m) return null;
   // Strip trailing "(N Credit Hour(s))" / "(1-3 Credits)" parentheticals.


### PR DESCRIPTION
## What changes for someone using the site

The semester planner can now build degree plans for **Surry Community College (NC)** and **Mott Community College (MI)**. Their program pages previously showed empty requirements — you'd pick a degree and see no courses. Now:

- **Surry: 1 → 108** plannable programs (of 169)
- **Mott: 0 → 92** plannable programs (of 99)

That's ~199 degree programs across two colleges that go from unusable to fully plannable. No other college changes.

## What changed technically

One regex in the shared Acalog program parser (`scripts/lib/scrape-acalog-programs.ts`, `parseCourseFromLabel`). It only matched a **plain-space** separator between a course's prefix and number (`ENG 111`). Surry writes codes as `WBL - 110` (nbsp + hyphen) and Mott as `ACCT-101` (hyphen, no space), so every course in those programs parsed as nothing → 0 plannable. The fix allows an **optional hyphen** between prefix and number:

```diff
- /^([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\b\s*(?:[-:]\s*)?(.*)$/
+ /^([A-Z]{2,5})\s*-?\s*(\d{3,4}[A-Z]?)\b\s*(?:[-:]\s*)?(.*)$/
```

The codes were **inline all along** — the DEFERRED notes' "links courses / needs preview_course follow" diagnosis for mott/surry was wrong, and is corrected here. **blinn (TX)** was mis-blamed the same way; its catalog is actually archived/empty (corrected in the note, **not** fixed in this PR — it needs a different source).

## Files

- `scripts/lib/scrape-acalog-programs.ts` — regex fix + `export` for testability
- `scripts/lib/__tests__/scrape-acalog-programs.test.ts` — **new**, 15 cases: 8 real code formats (plain space, CT dash, Germanna colon, FL no-space, gaston no-separator, surry nbsp-hyphen, mott hyphen, lab-letter) + 6 free-text negatives that must stay `null`
- `data/nc/programs/surry.json`, `data/mi/programs/mott-community-college.json` — re-scraped single-college (no other college touched)
- `data/{nc,mi,tx}/DEFERRED-programs.md` — corrected diagnoses

## Verification

- **vitest 15/15** green on the new parser test.
- **`tsc --noEmit`** clean; **eslint** clean on changed files.
- **Real planner path:** `listPlannableProgramsForCollege("nc","surry")` → 108, `("mi","mott-community-college")` → 92 (this is the exact function the program-list page calls).
- Sampled recovered courses are real, clean codes — e.g. surry "Accounting and Finance Degree": `WBL 110, ACC 220, ACC 225, ECO 151, ENG 114, MAT 143`; mott "Associate in Fine Arts": `ENGL 101, ENGL 102, COMM 131, COMM 140, DESN 115`.

**Known gap (named):** I did not render the actual program page in a browser. The page's `buildMajorPlan` uses Next's `unstable_cache` (only runs inside the Next server), and the dev server was unstable on the shared disk this session. I verified the data + the planner's gate function in-process instead. **Post-merge check:** load `communitycollegepath.com/nc/college/surry/program/accounting-and-finance-degree-other` and confirm courses render.

## Scope note

Build-time scraper + data change only — no app-runtime code touched, so I ran typecheck + lint + vitest rather than a full `next build` (which also regenerates ~76 derived data snapshots we don't want in this diff). surry/mott Acalog scrapers are already cron-wired; no config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)