### PR TITLE
programs: CourseDog status-casing fallback → nwfsc (FL) plannable

### DIFF
--- a/data/fl/DEFERRED-programs.md
+++ b/data/fl/DEFERRED-programs.md
@@ -4,11 +4,12 @@ Programs rollout for Florida (FCS, 28 colleges). Catalog platform per college is
 fingerprinted by `scripts/fl/discover-catalogs.ts` → `data/fl/catalog-discovery.json`,
 then scraped by the matching platform wrapper (cloned from the NC tooling).
 
-## Shipped — 14 colleges scraped (~1,471 programs); **1,255 plannable across 14 colleges**
+## Shipped — 15 colleges scraped (~1,523 programs); **1,290 plannable across 15 colleges**
 
 Verified via `countRealCourses >= PLAN_MIN_COURSES` on local JSON, plannable per college:
 palmbeachstate 156, irsc 143, fscj 129, pensacolastate 112, daytonastate 108, **cf 85**,
-polk 80, **tcc-fl 77**, **phsc 70**, sjrstate 65, scf 63, fsw 60, southflorida 54, fgc 53.
+polk 80, **tcc-fl 77**, **phsc 70**, sjrstate 65, scf 63, fsw 60, southflorida 54, fgc 53,
+**nwfsc 35**.
 
 **Walker fix (2026-06-04):** phsc went 0 → 70 plannable. Its 17 category pages under
 `/academic-programs/` link to programs in a SIBLING URL tree (`/prog-desc/{level}/{slug}`)
@@ -45,9 +46,13 @@ stray "Acalog" footer mention can't re-trip this.
 - ~~cf, tcc-fl (Acalog) — 0 plannable~~ **RESOLVED 2026-06-04** (parser fix; see above).
 - **CourseLeaf (easternflorida, lssc, valencia) — 0.** Their program index doesn't
   match the common CourseLeaf path conventions; needs per-college index discovery.
-- **CourseDog (nwfsc) — 0.** `nwfsc_banner_sql` tenant variant returns 0 programs via
-  the shared Coursedog lib. (fscj, a standard `fscj_peoplesoft` Coursedog tenant, works
-  fine — the remaining gap is specifically the `*_banner_sql` variant.)
+- **CourseDog (nwfsc) — RESOLVED 2026-06-05 (0 → 35 plannable).** The `nwfsc_banner_sql`
+  tenant stores program status as lowercase `active`, so the shared lib's case-sensitive
+  `status is "Active"` filter returned 0. `listAllPrograms` in
+  `scripts/lib/scrape-coursedog-programs.ts` now falls back to an unfiltered fetch (keeping
+  only active programs via `isActiveProgramStatus`) when the filtered fetch is empty. 52
+  programs scraped, 35 plannable. The payload shape was standard all along — the prior
+  "payload differs" guess was wrong; it was purely the status-filter casing.
 - **9 colleges fingerprinted `unknown`** (gulfcoast, hccfl, mdc, nfc, seminolestate,
   sfcollege, spcollege, + the 2 above): catalog not found via probed patterns.
   Second-pass discovery (more subdomain patterns, PDF catalogs) is the next lever.

--- a/data/fl/programs/nwfsc.json
+++ b/data/fl/programs/nwfsc.json
@@ -1,0 +1,3838 @@
+{
+  "college_slug": "nwfsc",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.nwfsc.edu/programs",
+  "scraped_at": "2026-06-05T01:04:58.109Z",
+  "programs": [
+    {
+      "title": "AAS in Applied Management",
+      "credential": "AAS",
+      "program_code": "AAS-APMG",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AAS-APMG",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Elective Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2011",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "AS in Accounting Technology",
+      "credential": "other",
+      "program_code": "AS-ACCT",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-ACCT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2013",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2011",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Elective Courses",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "2023",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "AS in Professional Pilot Technology",
+      "credential": "other",
+      "program_code": "AS-AIRP",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-AIRP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "1320",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "1610C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "1870",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2210",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2473",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2550",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATF",
+              "number": "1100L",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATF",
+              "number": "2400L",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATF",
+              "number": "2500L",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "1100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "1120",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "1810",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Elective Courses",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATF",
+              "number": "2530L",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2560C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "AS in Business Administration",
+      "credential": "other",
+      "program_code": "AS-BADM",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-BADM",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2013",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Elective Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACG",
+              "number": "2011",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1250C",
+              "title": "Dining Room Management & Service",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "2284C",
+              "title": "Catering Banquet Event Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "AS in Computer Information Technology",
+      "credential": "other",
+      "program_code": "AS-CINF",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-CINF",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "2179C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2182C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1134",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1142",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1156C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "2104",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "2302C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "2390C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Elective Courses",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "1000C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2840",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "2145",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "1001",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "1020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2300",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2820",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "AS in Computer Programming & Analysis",
+      "credential": "other",
+      "program_code": "AS-CPRO",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-CPRO",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1411",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2030",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2220",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2224",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2360",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2700",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2800",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "1000",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Elective Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "2820",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "2541",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2840",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "1001",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "1020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2300",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2820",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "AS in Culinary Management",
+      "credential": "other",
+      "program_code": "AS-CUL",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-CUL",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGF",
+              "number": "1130",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FOS",
+              "number": "2201",
+              "title": "Food Service Sanitation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1202L",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1221C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1246C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "2284C",
+              "title": "Catering Banquet Event Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "2942",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1250C",
+              "title": "Dining Room Management & Service",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "AS in Cybersecurity",
+      "credential": "other",
+      "program_code": "AS-CYBE",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-CYBE",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "2880C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "2541",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "1531",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2352",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1700C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "2211C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1106",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1134",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "2314C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2179C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2222",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Elective Courses",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "2182C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2892C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "1001",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "1020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2300",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2820",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "2302C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "AS in Early Childhood Education",
+      "credential": "other",
+      "program_code": "AS-ECED",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-ECED",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGF",
+              "number": "1130",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEP",
+              "number": "2100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "AS in Emergency Medical Services",
+      "credential": "other",
+      "program_code": "AS-EMSR",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-EMSR",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGF",
+              "number": "1130",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "AS in Engineering Technology",
+      "credential": "other",
+      "program_code": "AS-ENGT",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-ENGT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electronics Specialization",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1180C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Maintenance Technician Specialization",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EET",
+              "number": "1180C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "AS in Hospitality and Tourism",
+      "credential": "other",
+      "program_code": "AS-HSTR",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-HSTR",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGF",
+              "number": "1130",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FOS",
+              "number": "2201",
+              "title": "Food Service Sanitation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1250C",
+              "title": "Dining Room Management & Service",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "2284C",
+              "title": "Catering Banquet Event Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "2942",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "AS in Health Services Management",
+      "credential": "other",
+      "program_code": "AS-HTMG",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-HTMG",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2013",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGF",
+              "number": "1130",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "AS in Medical Laboratory Technology",
+      "credential": "other",
+      "program_code": "AS-MLTP",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-MLTP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1010C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "1045C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1032C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "AS in Nursing",
+      "credential": "other",
+      "program_code": "AS-NURS",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-NURS",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEP",
+              "number": "2004",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "AS in Paralegal Studies",
+      "credential": "other",
+      "program_code": "AS-PARA",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-PARA",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGF",
+              "number": "1130",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUL",
+              "number": "2242",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Elective Courses",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLP",
+              "number": "1001",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "AS in Physical Therapist Assistant",
+      "credential": "other",
+      "program_code": "AS-PTAP",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-PTAP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGF",
+              "number": "1130",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEP",
+              "number": "2004",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "1800L",
+              "title": "Physical Therapy Clinical Practice I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "2704",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "2704L",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "AS in Radiography",
+      "credential": "other",
+      "program_code": "AS-RADT",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-RADT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "AS in Sports, Fitness & Recreation Management",
+      "credential": "other",
+      "program_code": "AS-SPFR",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-SPFR",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGF",
+              "number": "1130",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Elective Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLP",
+              "number": "1001",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEP",
+              "number": "2004",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "AS in Unmanned Vehicle Systems Operations",
+      "credential": "other",
+      "program_code": "AS-UVSO",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/AS-UVSO",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASC",
+              "number": "1320",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "1870",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2210",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2473",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2550",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2560C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2561C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2564C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2566C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "1100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Elective Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATT",
+              "number": "1810",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2220",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2224",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "BAS in Management and Supervision",
+      "credential": "other",
+      "program_code": "BAS-MGSU",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/BAS-MGSU",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Upper Division Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUL",
+              "number": "3320",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "4720",
+              "title": "Strategic Planning and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "3350",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "4940",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACG",
+              "number": "3083",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "BAS in Project Management",
+      "credential": "other",
+      "program_code": "BAS-PMGT",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/BAS-PMGT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Business Core Requirements in Bachelor of Applied Science in Project Management",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUL",
+              "number": "3320",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "4720",
+              "title": "Strategic Planning and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAN",
+              "number": "4931",
+              "title": "Capstone: Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "BS in Early Childhood Education",
+      "credential": "other",
+      "program_code": "BSE-BSEB",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/BSE-BSEB",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Course Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGF",
+              "number": "1130",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEP",
+              "number": "2100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EEC",
+              "number": "3511",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EEC",
+              "number": "4404",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EEX",
+              "number": "4201",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "BS in Elementary Education",
+      "credential": "other",
+      "program_code": "BSE-BSED",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/BSE-BSED",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Course Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGF",
+              "number": "1130",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Lower Division Coursework",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "1002",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Upper Division Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDE",
+              "number": "4226C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "BS in Nursing",
+      "credential": "other",
+      "program_code": "BSN-BSNG",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/BSN-BSNG",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Course Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENC",
+              "number": "1101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1085C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMH",
+              "number": "2020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "B.S.N. Common Prerequisite Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEP",
+              "number": "2004",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1045C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1032C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1046C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "2210C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "2211C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1005",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1005L",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Upper Division Courses",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "3080",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "CCC in Artificial Intelligence Awareness",
+      "credential": "other",
+      "program_code": "CC-AFIA",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-AFIA",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAI",
+              "number": "1001",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "1020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAI",
+              "number": "2100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2300",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2820",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCC in Commercial Pilot",
+      "credential": "other",
+      "program_code": "CC-AIRC",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-AIRC",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATT",
+              "number": "1100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "1120",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "2210",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATF",
+              "number": "2500L",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASC",
+              "number": "1870",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCC in Business Development and Entrepreneurship",
+      "credential": "other",
+      "program_code": "CC-BMDE",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-BMDE",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "2931",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "CCC in Business Management",
+      "credential": "other",
+      "program_code": "CC-BMGC",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-BMGC",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUL",
+              "number": "2241",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEB",
+              "number": "1011",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "CCC in Business Specialist",
+      "credential": "other",
+      "program_code": "CC-BMHR",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-BMHR",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OST",
+              "number": "2335",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "CCC in Building Construction Specialist",
+      "credential": "other",
+      "program_code": "CC-BUCO",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-BUCO",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCN",
+              "number": "1520C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCN",
+              "number": "1567C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCN",
+              "number": "2721",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "2770",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "2761C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCC in Child Care Center Management Specialization",
+      "credential": "other",
+      "program_code": "CC-CCCM",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-CCCM",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEP",
+              "number": "2100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "CCC in Preschool Specialization",
+      "credential": "other",
+      "program_code": "CC-CCPS",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-CCPS",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEP",
+              "number": "2100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCC in Early Childhood Development Specialization",
+      "credential": "other",
+      "program_code": "CC-CDEI",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-CDEI",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEP",
+              "number": "2100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "CCC in Computer Information Data Specialization",
+      "credential": "other",
+      "program_code": "CC-CIDS",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-CIDS",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "2179C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2182C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "2541",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCC in Infant/Toddler Specialization",
+      "credential": "other",
+      "program_code": "CC-CITS",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-CITS",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEP",
+              "number": "2100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCC in Computer Programmer",
+      "credential": "other",
+      "program_code": "CC-CMPG",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-CMPG",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "1000",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1411",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2010",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2030",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2220",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2224",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2360",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2700",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2800",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Elective Courses",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "2541",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2840",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "1001",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "1020",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2300",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAI",
+              "number": "2820",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCC in Computer Programming Specialist",
+      "credential": "other",
+      "program_code": "CC-CMPS",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-CMPS",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "1000",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2220",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2030",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2224",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "2800",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCC in Culinary Arts",
+      "credential": "other",
+      "program_code": "CC-CULA",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-CULA",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FOS",
+              "number": "2201",
+              "title": "Food Service Sanitation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1202L",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1221C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1246C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "2241C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "2942",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "2284C",
+              "title": "Catering Banquet Event Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCC in Culinary Arts Management Operations",
+      "credential": "other",
+      "program_code": "CC-CULM",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-CULM",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FOS",
+              "number": "2201",
+              "title": "Food Service Sanitation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1202L",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1221C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1246C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "CCC in Paramedic",
+      "credential": "other",
+      "program_code": "CC-EMPM",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-EMPM",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites for Admission",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSC",
+              "number": "1085C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSC",
+              "number": "1086C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCC in Event Planning Management",
+      "credential": "other",
+      "program_code": "CC-EPMG",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-EPMG",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FOS",
+              "number": "2201",
+              "title": "Food Service Sanitation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1250C",
+              "title": "Dining Room Management & Service",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "2284C",
+              "title": "Catering Banquet Event Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "CCC in Food & Beverage Management",
+      "credential": "other",
+      "program_code": "CC-FBMG",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-FBMG",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FOS",
+              "number": "2201",
+              "title": "Food Service Sanitation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1250C",
+              "title": "Dining Room Management & Service",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "2284C",
+              "title": "Catering Banquet Event Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "2942",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "CCC in Food & Beverage Operations",
+      "credential": "other",
+      "program_code": "CC-FBOP",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-FBOP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FOS",
+              "number": "2201",
+              "title": "Food Service Sanitation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "1250C",
+              "title": "Dining Room Management & Service",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "2284C",
+              "title": "Catering Banquet Event Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCC in Graphic Design Production",
+      "credential": "other",
+      "program_code": "CC-GRDP",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-GRDP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "2602C",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "CCC in Help Desk Support Technician",
+      "credential": "other",
+      "program_code": "CC-HDST",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-HDST",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "2182C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1106",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1134",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1156C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "2302C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2179C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCC in Information Technology Analysis",
+      "credential": "other",
+      "program_code": "CC-ITAS",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-ITAS",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "2179C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "2182C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "2541",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1134",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1142",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1156C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "2302C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "CCC in Information Technology Support Specialist",
+      "credential": "other",
+      "program_code": "CC-ITSS",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-ITSS",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CGS",
+              "number": "1100",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CGS",
+              "number": "2541",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COP",
+              "number": "1000",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1134",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "1156C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "1000C",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "CCC in Rooms Division Management",
+      "credential": "other",
+      "program_code": "CC-RMMG",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-RMMG",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FOS",
+              "number": "2201",
+              "title": "Food Service Sanitation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "2284C",
+              "title": "Catering Banquet Event Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "2942",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "CCC in Rooms Division Operations",
+      "credential": "other",
+      "program_code": "CC-RMOP",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/CC-RMOP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FOS",
+              "number": "2201",
+              "title": "Food Service Sanitation Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFT",
+              "number": "2942",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCP in Aviation Airframe Mechanics",
+      "credential": "other",
+      "program_code": "VC-AIRF",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/VC-AIRF",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "0701",
+              "title": "",
+              "credits": 3.67,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0702",
+              "title": "",
+              "credits": 3.67,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0703",
+              "title": "",
+              "credits": 3.67,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0704",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0712",
+              "title": "",
+              "credits": 7.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0713",
+              "title": "",
+              "credits": 7.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0714",
+              "title": "",
+              "credits": 7.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0717",
+              "title": "",
+              "credits": 7.5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCP in Aviation Powerplant Mechanics",
+      "credential": "other",
+      "program_code": "VC-POWR",
+      "catalog_url": "https://catalog.nwfsc.edu/programs/VC-POWR",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "0701",
+              "title": "",
+              "credits": 3.67,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0702",
+              "title": "",
+              "credits": 3.67,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0703",
+              "title": "",
+              "credits": 3.67,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0704",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0821C",
+              "title": "",
+              "credits": 7.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0822C",
+              "title": "",
+              "credits": 7.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0823C",
+              "title": "",
+              "credits": 7.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "0824C",
+              "title": "",
+              "credits": 7.5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/scripts/lib/__tests__/scrape-coursedog-programs.test.ts
+++ b/scripts/lib/__tests__/scrape-coursedog-programs.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { isActiveProgramStatus } from "@/scripts/lib/scrape-coursedog-programs";
+
+/**
+ * Coursedog tenants store program status with varying casing. The "Active"
+ * (capital A) filter sent to the search API returns 0 for tenants that store
+ * lowercase "active" (Banner-SQL / some Colleague syncs), so the scraper falls
+ * back to an unfiltered fetch and keeps only active programs via this helper.
+ * It must accept any casing of "active" (and a missing status) while dropping
+ * Inactive / Archived so the fallback never ships retired programs.
+ */
+describe("isActiveProgramStatus", () => {
+  it.each(["active", "Active", "ACTIVE", "  active  "])(
+    "keeps active (any casing/whitespace): %s",
+    (s) => {
+      expect(isActiveProgramStatus(s)).toBe(true);
+    },
+  );
+
+  it.each([undefined, ""])("keeps missing/blank status: %s", (s) => {
+    expect(isActiveProgramStatus(s)).toBe(true);
+  });
+
+  it.each(["Inactive", "inactive", "Archived", "archived", "Pending", "Draft"])(
+    "drops non-active status: %s",
+    (s) => {
+      expect(isActiveProgramStatus(s)).toBe(false);
+    },
+  );
+});

--- a/scripts/lib/scrape-coursedog-programs.ts
+++ b/scripts/lib/scrape-coursedog-programs.ts
@@ -241,6 +241,21 @@ const PROGRAMS_FILTER_BODY = {
   ],
 };
 
+// Empty filter — fetches ALL programs regardless of status. Fallback for
+// tenants that store status as lowercase "active" (Banner-SQL / some Colleague
+// syncs), which the case-sensitive "Active" filter above returns 0 for.
+const EMPTY_FILTER_BODY = { condition: "AND", filters: [] };
+
+/**
+ * Whether a Coursedog program status counts as "active" for scraping. Tenants
+ * vary in casing ("Active" vs "active"); a missing/blank status defaults to
+ * active. Inactive / Archived / etc. are dropped. Exported for unit testing.
+ */
+export function isActiveProgramStatus(status?: string): boolean {
+  const s = (status ?? "").trim().toLowerCase();
+  return s === "" || s === "active";
+}
+
 async function listAllPrograms(
   page: Page,
   tenantId: string,
@@ -256,8 +271,20 @@ async function listAllPrograms(
     url,
     PROGRAMS_FILTER_BODY,
   );
-  if (!resp) return [];
-  return resp.data ?? [];
+  let data = resp?.data ?? [];
+  // Casing fallback: when the "Active"-filtered search returns nothing, the
+  // tenant likely stores its status lowercase. Re-fetch unfiltered and keep
+  // only active/unspecified programs (drop Inactive/Archived) so the catalog
+  // isn't silently empty. Tenants that already return rows are untouched.
+  if (data.length === 0) {
+    const respAll = await apiPost<{ data: ProgramListItem[]; listLength: number }>(
+      page,
+      url,
+      EMPTY_FILTER_BODY,
+    );
+    data = (respAll?.data ?? []).filter((p) => isActiveProgramStatus(p.status));
+  }
+  return data;
 }
 
 async function getProgramDetail(


### PR DESCRIPTION
## What changes for someone using the site

The semester planner can now build degree plans for **Northwest Florida State College (nwfsc)** — 35 of its programs (e.g. *AS in Computer Information Technology*, 21 courses) went from invisible to plannable. Florida gains a 15th plannable-programs college.

## What changed technically

The shared CourseDog program scraper sends a **case-sensitive** `status is "Active"` filter to the CourseDog API. nwfsc's tenant (`nwfsc_banner_sql`) stores status as lowercase `active`, so the filter matched **nothing** and the college came back silently empty.

`listAllPrograms` in `scripts/lib/scrape-coursedog-programs.ts` now **falls back to an unfiltered fetch** when the filtered one returns 0, keeping only active programs via a new `isActiveProgramStatus` helper (drops Inactive/Archived). Tenants that already return rows are completely untouched — the fallback only fires on the 0-result case.

```diff
-  if (!resp) return [];
-  return resp.data ?? [];
+  let data = resp?.data ?? [];
+  if (data.length === 0) {
+    const respAll = await apiPost(page, url, EMPTY_FILTER_BODY);
+    data = (respAll?.data ?? []).filter((p) => isActiveProgramStatus(p.status));
+  }
+  return data;
```

## Honest scoping — this PR is narrower than first planned

I also tested the two other CourseDog colleges that scoping flagged, and **neither benefits** (verified live, not assumed):

- **isothermal (NC)** — now returns 153 programs, but **0 plannable**: the requirement *groups* parse, yet the course IDs inside them don't resolve to courses. That's a **separate, deeper CourseDog issue**, not the casing bug. Not committed here.
- **muskegon (MI)** — returns only 8 programs, 0 plannable. Genuinely thin. Not committed.

The earlier scoping estimate (isothermal ~179, muskegon ~84 plannable) was wrong — exactly the "verify the cheap label" trap. The freeform-HTML tenants (cape-fear/jackson/south-suburban) are a **different fix** for a later PR. There's also a known **200-program page cap** (`PROGRAMS_PAGE_SIZE`) that truncates very large CourseDog catalogs (central-carolina 654, del-mar 304) — out of scope here, noted for a follow-up.

## Files
- `scripts/lib/scrape-coursedog-programs.ts` — fetch fallback + `isActiveProgramStatus` (exported)
- `scripts/lib/__tests__/scrape-coursedog-programs.test.ts` — **new**, 12 cases (active any-casing/blank kept; Inactive/Archived/Pending/Draft dropped)
- `data/fl/programs/nwfsc.json` — **new** (52 programs, 35 plannable)
- `data/fl/DEFERRED-programs.md` — nwfsc marked resolved

## Verification
- **vitest 12/12** green; **tsc** clean; **eslint** 0 errors on changed files.
- **Real planner gate:** `listPlannableProgramsForCollege("fl","nwfsc")` → **35**, with real courses (ENC 1101, AMH 2010, ACG 2011…).
- Build-time scraper + data change only (no app-runtime code) → typecheck + lint + vitest, not a full `next build`.

**Post-merge check:** load `communitycollegepath.com/fl/college/nwfsc/programs` and confirm plannable programs list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)