### PR TITLE
ui(programs): skip 1-of-1 menu collapse + fix "1 credits" grammar

### DIFF
--- a/components/ProgramRequirements.tsx
+++ b/components/ProgramRequirements.tsx
@@ -211,11 +211,13 @@ function RequirementGroupBlock({
   // "Menu mode" = catalog defines a credit slot but lists more course-credits
   // than the slot needs. Heuristic: courses.length * 3 (assume avg ~3cr each)
   // materially exceeds the slot. Keeps short truly-required groups expanded
-  // (Eng Comp 6cr / 2 courses: 6 ≯ 4 → not menu).
+  // (Eng Comp 6cr / 2 courses: 6 ≯ 4 → not menu). The >= 2 floor blocks
+  // 1-of-1 groups (e.g. SDV 100, 1 cr) from rendering as a fake "choice".
   const menuMode =
     effectiveCredits != null &&
     effectiveCredits > 0 &&
     group.choose_n == null &&
+    group.courses.length >= 2 &&
     group.courses.length * 3 > effectiveCredits * 2;
   const sequenceMode = menuMode && SEQUENCE_RE.test(group.name);
   const collapsed = menuMode && !expanded;
@@ -226,7 +228,7 @@ function RequirementGroupBlock({
   const heading = sequenceMode
     ? `Full degree sequence — ${group.courses.length} courses, ${effectiveCredits} credits`
     : menuMode
-      ? `Choose ${effectiveCredits} credits from ${group.courses.length} approved courses`
+      ? `Choose ${effectiveCredits} credit${effectiveCredits === 1 ? "" : "s"} from ${group.courses.length} approved courses`
       : group.name;
 
   return (


### PR DESCRIPTION
## What changes for someone using the site

Open the [Engineering Degree, AS for Laurel Ridge](https://communitycollegepath.com/va/program/engineering) (expand the panel) and look at the first requirement group. Today it reads:

> **Choose 1 credits from 1 approved courses**
> SDV 100 — College Success Skills

Two things wrong: there's no actual *choice* (only one course meets the requirement, so it's literally required), and the grammar is broken ("1 credits"). After this PR, that same group renders the original wording — `Student Development (1 cr)` followed by `SDV 100` expanded — same as Written Communication and Natural Science already do for their small required groups.

The fix is data-shape-driven, so it also cleans up every other 1-of-1 group across the 25 states that have program data — none of which should ever have been collapsed.

And as a smaller defensive win: a hypothetical 1-credit slot with 2+ courses to pick from now reads `Choose 1 credit from N approved courses` instead of `Choose 1 credits from N`.

## How it works

One file, ~3 lines: `components/ProgramRequirements.tsx`.

1. Added `group.courses.length >= 2` to the `menuMode` condition. A "choice" needs at least two options; otherwise it's a single required course and should render normally.
2. Pluralized `credit` in the heading template (`credit${effectiveCredits === 1 ? "" : "s"}`). The course-count side stays hard-plural because the floor above guarantees M ≥ 2 whenever menu-mode fires.

## Verification

- ✅ `npm run lint` → 0 errors (warnings pre-existing)
- ✅ `npm run build` → complete
- ⚠️ Visual confirmation: same caveat as #1198 — no local browser-driven verification (disk pressure during this session prevented standing up a preview). Reviewer please spot-check the Laurel Ridge Engineering-AS panel — the SDV 100 row should no longer say "Choose 1 credits from 1 approved courses" and should look identical to how Written Communication (6 cr) renders today.

The previous PR's strings to look for elsewhere — `Choose 3 credits from 15 approved courses` (Arts & Humanities), `Show all 15 options`, etc. — should be completely unchanged on every group with 2+ courses. Only the 1-of-1 groups flip back to the unchanged render path.

## Test plan

- [ ] Visit `/va/program/engineering`, expand Laurel Ridge Engineering-AS
- [ ] Confirm Student Development group now reads "Student Development (1 cr)" with SDV 100 expanded — NOT "Choose 1 credits from 1 approved courses"
- [ ] Confirm the 3 menu-mode groups below it (Arts & Humanities, Literature, Social & Behavioral Sciences) are still collapsed exactly as in #1198

**DO NOT MERGE — stop for review.**