### PR TITLE
data(az): add degree-program requirements for 4 colleges (planner unlock)

### DIFF
--- a/data/az/programs/coconino-community-college.json
+++ b/data/az/programs/coconino-community-college.json
@@ -1,0 +1,6983 @@
+{
+  "college_slug": "coconino-community-college",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.coconino.edu",
+  "scraped_at": "2026-06-05T01:37:08.352Z",
+  "programs": [
+    {
+      "title": "Visual Arts",
+      "credential": "other",
+      "program_code": "AFA",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=870",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 32 credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "higher-level quantitative reasoning course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 21 credits",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Drawing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "160",
+              "title": "Color and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "165",
+              "title": "Three-dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "201",
+              "title": "Art History: Prehistoric to 1400",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "201",
+              "title": "may fulfill an AGEC requirement in the Arts and Humanities category",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "202",
+              "title": "Art History: 1400 - 2000",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "202",
+              "title": "may fulfill an AGEC requirement in the Arts and Humanities category",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "210",
+              "title": "Life Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "120",
+              "title": "Ceramics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Ceramics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "136",
+              "title": "Digital Photography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "190",
+              "title": "Oil/Acrylic Painting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "191",
+              "title": "Oil/Acrylic Painting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "236",
+              "title": "Digital Photography II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "General Education List of Approved Courses at CCC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=847",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Written and Oral Communication: Composition (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102H",
+              "title": "College Composition II Honors",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written and Oral Communication: Communication and Languages (0-4) (WOCC)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "201",
+              "title": "American Sign Language III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "202",
+              "title": "American Sign Language IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "105",
+              "title": "Introduction to Journalism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "270",
+              "title": "Creative Writing: Fiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272",
+              "title": "Creative Writing: Non-Fiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "101",
+              "title": "Beginning French I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "102",
+              "title": "Beginning French II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "101",
+              "title": "Beginning Japanese I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "102",
+              "title": "Beginning Japanese II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAV",
+              "number": "101",
+              "title": "Beginning Navajo I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAV",
+              "number": "102",
+              "title": "Beginning Navajo II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAV",
+              "number": "201",
+              "title": "Intermediate Navajo I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAV",
+              "number": "202",
+              "title": "Intermediate Navajo II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Beginning Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "102",
+              "title": "Beginning Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "201",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "202",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPC",
+              "number": "100",
+              "title": "Fundamentals of Speech Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "232",
+              "title": "Business Statistics and Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "230",
+              "title": "Calculus and Analytic Geometry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "241",
+              "title": "Calculus and Analytic Geometry III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "261",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "187",
+              "title": "Pre-Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "187H",
+              "title": "Pre-Calculus Honors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "211",
+              "title": "Business Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus and Analytic Geometry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "140",
+              "title": "College Math with Algebra Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Introduction to Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Introduction to Statistics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Arts and Humanities (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIS",
+              "number": "201",
+              "title": "Indigenous North American Expression",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "102",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "201",
+              "title": "Art History: Prehistoric to 1400",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "202",
+              "title": "Art History: 1400 - 2000",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Art Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPS",
+              "number": "100",
+              "title": "Overview of the Colorado Plateau",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "237",
+              "title": "Women in Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Dystopian Literature: Dark Imagination or Prophecy?",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "139",
+              "title": "Introduction to Creative Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "200",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "205",
+              "title": "Technology and Human Values",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "235",
+              "title": "American Arts and Ideas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "241",
+              "title": "Humanities I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "241H",
+              "title": "Humanities I Honors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "242",
+              "title": "Humanities II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "242H",
+              "title": "Humanities II Honors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "145",
+              "title": "Jazz History and Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "159",
+              "title": "Music Appreciation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "207",
+              "title": "American Popular Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "235",
+              "title": "Country Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "240",
+              "title": "Music of World Cultures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "245",
+              "title": "Rock and Pop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101H",
+              "title": "Introduction to Philosophy-Honors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "103",
+              "title": "Introduction to Logic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "201",
+              "title": "Comparative Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "241",
+              "title": "Asian Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "101",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social and Behavioral Sciences (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIS",
+              "number": "101",
+              "title": "Introduction to Applied Indigenous Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "101",
+              "title": "Introduction to Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "230",
+              "title": "Deviant Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "280",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "102",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "103",
+              "title": "Culture and Language",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "110",
+              "title": "Exploring Archeology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "230",
+              "title": "Peoples of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "241",
+              "title": "Magic, Witchcraft and Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "250",
+              "title": "Peoples of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "214",
+              "title": "Legal, Ethical, and Regulatory Issues in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "101",
+              "title": "Communication Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPS",
+              "number": "100",
+              "title": "Overview of the Colorado Plateau",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "204",
+              "title": "Macroeconomic Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "205",
+              "title": "Microeconomic Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "102",
+              "title": "Human Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "133",
+              "title": "World/Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "U.S. History to 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "U.S. History from 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "Western Civilizations to 1660",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Western Civilizations from 1660",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "211",
+              "title": "World History to 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "212",
+              "title": "World History from 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "101",
+              "title": "Introduction to Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "110",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "Introduction to World Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "220",
+              "title": "Arizona and National Constitution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "233",
+              "title": "Global Environmental Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "227",
+              "title": "Personality Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "236",
+              "title": "Psychology of Women",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "250",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Sociology of Gender",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "215",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences (4)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANT",
+              "number": "101",
+              "title": "Introduction to Physical Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Biology Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "105",
+              "title": "Environmental Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "Unity of Life I: Life of the Cell",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "182",
+              "title": "Unity of Life II: Multicellular Organisms",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "130",
+              "title": "Fundamental Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "171",
+              "title": "Fundamentals of Environmental Science: Humans and the Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNR",
+              "number": "215",
+              "title": "Communication in Conservation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "131",
+              "title": "Introduction to Physical Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "102",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "105",
+              "title": "Introduction to Planetary Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "110",
+              "title": "Natural Disasters",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "232",
+              "title": "Geology of the Colorado Plateau",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "111",
+              "title": "College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "112",
+              "title": "College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "180",
+              "title": "Introduction to Astronomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "262",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Institutions in the Americas (3)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIS",
+              "number": "101",
+              "title": "Introduction to Applied Indigenous Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "201",
+              "title": "Indigenous North American Expression",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "202",
+              "title": "Roots of U.S Federal American Indian Policy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "232",
+              "title": "Museums and Indigenous Peoples: Reclaiming Culture and Identity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "290",
+              "title": "Foundations of Indigenous Environmental Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "230",
+              "title": "Peoples of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "200",
+              "title": "Introduction to the Deaf Community",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPS",
+              "number": "100",
+              "title": "Overview of the Colorado Plateau",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "133",
+              "title": "World/Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "U.S. History to 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "U.S. History from 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "Western Civilizations to 1660",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Western Civilizations from 1660",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "211",
+              "title": "World History to 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "212",
+              "title": "World History from 1500",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "235",
+              "title": "American Arts and Ideas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "241",
+              "title": "Humanities I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "241H",
+              "title": "Humanities I Honors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "242",
+              "title": "Humanities II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "242H",
+              "title": "Humanities II Honors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "145",
+              "title": "Jazz History and Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "207",
+              "title": "American Popular Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "240",
+              "title": "Music of World Cultures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "245",
+              "title": "Rock and Pop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "101",
+              "title": "Introduction to Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "110",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "Introduction to World Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "220",
+              "title": "Arizona and National Constitution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "233",
+              "title": "Global Environmental Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "American Sign Language and Interpreting Studies",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=848",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 32 credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "higher-level quantitative reasoning course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 28 credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "may fulfill an AGEC requirement in the AdditionalRequired General Education Credits - Communication andLanguages category.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "200",
+              "title": "Introduction to the Deaf Community",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "200",
+              "title": "may fulfill an AGEC requirement in the Institutions in the Americas category",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "201",
+              "title": "American Sign Language III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "202",
+              "title": "American Sign Language IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "203",
+              "title": "Comparative Analysis of American Sign Language to English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "215",
+              "title": "American Sign Language Literature: Narratives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "201",
+              "title": "Ethics and Social Justice of Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "211",
+              "title": "Fundamentals of Interpreting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "212",
+              "title": "Fundamentals of Interpreting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any additional coursework as needed to complete 60 total credit hours.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=852",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 32 credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "higher-level quantitative reasoning course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 28 credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "**Degree Template",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=909",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 32 credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Science",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=871",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 32 credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Higher-level quantitative reasoning course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 28 credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus and Analytic Geometry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This course can also be used to fulfill the General Education Quantitative Reasoning requirement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Select one science course sequence from the following options:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "Unity of Life I: Life of the Cell",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "182",
+              "title": "Unity of Life II: Multicellular Organisms",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "161",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "262",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "102",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "These science courses can also be used to fulfill the general education science requirement and/or the additional required general education credits.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Additional courses numbered 100 or above which transfer to Arizona state universities as equivalent, departmental elective credit, or general elective credit to total 60 credits for the degree.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "University majors require certain lower-division courses; these are the courses that should be taken as the degree core. To select the most appropriate courses for your program of study, it is strongly advised that students meet with an academic advisor to discuss degree requirements at their intended university and consult the CCC Pathways for guidance.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Business",
+      "credential": "AA",
+      "program_code": "ABUS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=869",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 32 credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "higher-level quantitative reasoning course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 28 credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "211",
+              "title": "Business Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "20-25 credits of courses numbered 100 or above which transfer to Arizona state universities as equivalent,departmental elective credit, or general elective credit tototal 60 credits for the degree. At least 12 of these credits must be taken in the ACC,BUS, or ECN prefixes. University majors require certain lower-division courses; these are the courses that should be taken as the degree core. To select the most appropriate courses for your program of study, create an educational plan with an advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "**Certificate Template",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=908",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=910",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "131",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Collision Repair Technician",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=912",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ABO",
+              "number": "103",
+              "title": "Introduction to Auto Body Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABO",
+              "number": "104",
+              "title": "Introduction to Automotive Refinishing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABO",
+              "number": "203",
+              "title": "Advanced Automotive Body Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ABO",
+              "number": "204",
+              "title": "Advanced Refinishing Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "102",
+              "title": "Basic Welding Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Arizona General Education Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=969",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 32 credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "140",
+              "title": "College Math with Algebra Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "higher-level quantitative reasoning course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administration of Justice",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=844",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 29 credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6-8)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 33 credits",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "101",
+              "title": "Introduction to Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "105",
+              "title": "Juvenile Detention Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "110",
+              "title": "The Correction Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "120",
+              "title": "Substantive Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "150",
+              "title": "Rules of Criminal Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "160",
+              "title": "Justice Systems Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "200",
+              "title": "Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "220",
+              "title": "Rules of Evidence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "230",
+              "title": "Deviant Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "240",
+              "title": "Juvenile Justice Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "280",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "American Sign Language and Interpreting Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=872",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "200",
+              "title": "Introduction to the Deaf Community",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "201",
+              "title": "American Sign Language III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "202",
+              "title": "American Sign Language IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "203",
+              "title": "Comparative Analysis of American Sign Language to English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "215",
+              "title": "American Sign Language Literature: Narratives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "201",
+              "title": "Ethics and Social Justice of Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "211",
+              "title": "Fundamentals of Interpreting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "212",
+              "title": "Fundamentals of Interpreting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=842",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "105",
+              "title": "Individual Income Tax Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "108",
+              "title": "Practical Accounting Procedures 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Practical Accounting Procedures 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "204",
+              "title": "National Payroll Certification Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "206",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Principles of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "142",
+                  "title": "College Mathematics"
+                }
+              ]
+            },
+            {
+              "prefix": "MAT",
+              "number": "140",
+              "title": "College Math with Algebra Review",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Computer Technology",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=846",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 19-24 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "higher-level quantitative reasoning course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 32 credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "130",
+              "title": "IT Support Fundamentals and A+ Prep",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "161",
+              "title": "Linux Administration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "171",
+              "title": "Linux Administration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "215",
+              "title": "Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "228",
+              "title": "Networking Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "236",
+              "title": "Enterprise database and SQL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "237",
+              "title": "Introduction to Computer Security",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Elective Requirements: 12-16 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "220",
+              "title": "Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "240",
+              "title": "Administering Windows Server Hybrid Core Infrastructure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "242",
+              "title": "Introduction to Cloud Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "243",
+              "title": "AWS Cloud Architecting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "244",
+              "title": "AWS Cloud Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "AWS Cloud Developing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "Artificial Intelligence Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "261",
+              "title": "Cybersecurity Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "262",
+              "title": "Ethical Hacking for Cybersecurity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "289",
+              "title": "Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "298",
+              "title": "Special Topics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heating, Ventilation, Air Conditioning, Refrigeration (HVACr) Level 1 Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=895",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTM",
+              "number": "111",
+              "title": "Plumbing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "122",
+              "title": "Construction Material and Equipment Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "123",
+              "title": "Building Construction Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "130",
+              "title": "Blueprint Reading and Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "150",
+              "title": "Basic Electrical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "151",
+              "title": "House Wiring I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "152",
+              "title": "House Wiring II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "211",
+              "title": "International Residential Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "238",
+              "title": "Heating Ventilation, Air Conditioning and Refrigeration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "239",
+              "title": "Heating Ventilation, Air-Conditioning and Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=856",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 25 credits",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6-8)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "140",
+              "title": "College Math with Algebra Review",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social and Behavioral Sciences (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "214",
+              "title": "Legal, Ethical, and Regulatory Issues in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "205",
+              "title": "Microeconomic Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 36 credits",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "105",
+              "title": "Individual Income Tax Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "108",
+              "title": "Practical Accounting Procedures 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Practical Accounting Procedures 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "204",
+              "title": "National Payroll Certification Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "206",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Principles of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "256",
+              "title": "Principles of Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Mathematics of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "204",
+              "title": "Macroeconomic Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Business",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=857",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 25 credits",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6-8)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "140",
+              "title": "College Math with Algebra Review",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 30 credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "108",
+              "title": "Practical Accounting Procedures 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Principles of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "256",
+              "title": "Principles of Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Mathematics of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "214",
+              "title": "Legal, Ethical, and Regulatory Issues in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "204",
+              "title": "Macroeconomic Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "205",
+              "title": "Microeconomic Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Electives: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ACC or BUS - Any ACC or BUS course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "213",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "289",
+              "title": "Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "201",
+              "title": "Leadership Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hospitality Management, Restaurant Emphasis",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=863",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 25 credits",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6-8)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Mathematics of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "140",
+              "title": "College Math with Algebra Review",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Requirements: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "214",
+              "title": "Legal, Ethical, and Regulatory Issues in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "100",
+              "title": "Introduction to Hospitality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "201",
+              "title": "Leadership Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPC",
+              "number": "100",
+              "title": "Fundamentals of Speech Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Restaurant Emphasis: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "140",
+              "title": "Food Production Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "240",
+              "title": "Commercial Food Production",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Principles of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "256",
+              "title": "Principles of Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "211",
+              "title": "Human Resources/Personnel Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "204",
+              "title": "Macroeconomic Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "205",
+              "title": "Microeconomic Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hotel and Restaurant Services Introduction Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=887",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "100",
+              "title": "Introduction to Hospitality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "210",
+              "title": "Guest Service Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "220",
+              "title": "Property Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hotel and Restaurant Services Intermediate Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=888",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Completion of the Introduction Certificate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "108",
+              "title": "Practical Accounting Procedures 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Principles of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Technology: Alternative Energy Technician",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=861",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 22 credits",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-4)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences (4)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "171",
+              "title": "Fundamentals of Environmental Science: Humans and the Environment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirments: 48 credits",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "111",
+              "title": "Plumbing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "115",
+              "title": "Introduction to Wood Working",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "120",
+              "title": "Building the Human Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "122",
+              "title": "Construction Material and Equipment Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "123",
+              "title": "Building Construction Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "124",
+              "title": "Building Construction Methods II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "130",
+              "title": "Blueprint Reading and Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "132",
+              "title": "Solar Water Heating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "138",
+              "title": "Introduction to Solar Design Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "150",
+              "title": "Basic Electrical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "151",
+              "title": "House Wiring I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "211",
+              "title": "International Residential Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "235",
+              "title": "Solar Home Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "236",
+              "title": "Photovoltaics and Wind Power",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "237",
+              "title": "Battery-Based Photovoltaic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "289",
+              "title": "Internship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality Management, Lodging and Guest Experience Management",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=892",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 25 Credits",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Mathematics of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "140",
+              "title": "College Math with Algebra Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "214",
+              "title": "Legal, Ethical, and Regulatory Issues in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "100",
+              "title": "Introduction to Hospitality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "201",
+              "title": "Leadership Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPC",
+              "number": "100",
+              "title": "Fundamentals of Speech Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lodging and Guest Experience Emphasis: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "210",
+              "title": "Guest Service Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "220",
+              "title": "Property Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "255",
+              "title": "Principles of Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "256",
+              "title": "Principles of Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "211",
+              "title": "Human Resources/Personnel Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "204",
+              "title": "Macroeconomic Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "205",
+              "title": "Microeconomic Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Environmental Technology: Alternative Energy Intermediate Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=881",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTM",
+              "number": "111",
+              "title": "Plumbing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "115",
+              "title": "Introduction to Wood Working",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "122",
+              "title": "Construction Material and Equipment Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "123",
+              "title": "Building Construction Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "124",
+              "title": "Building Construction Methods II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "130",
+              "title": "Blueprint Reading and Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "138",
+              "title": "Introduction to Solar Design Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "150",
+              "title": "Basic Electrical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "097",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or higher (3)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Google IT Support Professional Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=896",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "132",
+              "title": "Google IT Support Professional I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "134",
+              "title": "Google IT Support Professional II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "136",
+              "title": "Google IT Support Professional III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Technology: Alternative Energy Advanced Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=882",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Completion of the Intermediate Certificate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "120",
+              "title": "Building the Human Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "132",
+              "title": "Solar Water Heating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "133",
+              "title": "Solar Greenhouse Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "151",
+              "title": "House Wiring I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "235",
+              "title": "Solar Home Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "236",
+              "title": "Photovoltaics and Wind Power",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "250",
+              "title": "Innovative and Alternative Building Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "289",
+              "title": "Internship I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "142",
+                  "title": "College Mathematics"
+                },
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=898",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Automotive Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "200",
+              "title": "General Maintenance and Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "106",
+              "title": "Engines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "107",
+              "title": "Engine Service and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Electrical and Electronic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "120",
+              "title": "Brake Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "133",
+              "title": "Automatic Drive Trains",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "136",
+              "title": "Manual Drive Trains",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "139",
+              "title": "Suspension and Steering Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Automotive HVAC",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Construction Technology",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=860",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 25 credits",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6-8)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "140",
+              "title": "College Math with Algebra Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR higher level course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 36 credits",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "108",
+              "title": "Practical Accounting Procedures 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "111",
+              "title": "Plumbing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "122",
+              "title": "Construction Material and Equipment Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "123",
+              "title": "Building Construction Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "124",
+              "title": "Building Construction Methods II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "130",
+              "title": "Blueprint Reading and Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "150",
+              "title": "Basic Electrical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "211",
+              "title": "International Residential Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "224",
+              "title": "Concrete and Masonry Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "288",
+              "title": "Construction Supervision and Scheduling",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Elective Requirements: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTM",
+              "number": "115",
+              "title": "Introduction to Wood Working",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "120",
+              "title": "Building the Human Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "151",
+              "title": "House Wiring I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "102",
+              "title": "Basic Welding Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=879",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTM",
+              "number": "111",
+              "title": "Plumbing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "115",
+              "title": "Introduction to Wood Working",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "122",
+              "title": "Construction Material and Equipment Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "123",
+              "title": "Building Construction Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "124",
+              "title": "Building Construction Methods II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "130",
+              "title": "Blueprint Reading and Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "150",
+              "title": "Basic Electrical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "151",
+              "title": "House Wiring I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "211",
+              "title": "International Residential Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "238",
+              "title": "Heating Ventilation, Air Conditioning and Refrigeration I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=880",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "100",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "110",
+              "title": "Early Childhood Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "120",
+              "title": "Health, Safety, and Nutrition for the Young Child",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "220",
+              "title": "Language Arts for the Young Child",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "234",
+              "title": "Child Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "240",
+              "title": "School, Family, and Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "250",
+              "title": "Children with Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Sustainable Green Building",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=868",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 22 credits",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6-8)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences (4)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "171",
+              "title": "Fundamentals of Environmental Science: Humans and the Environment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 39 credits",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTM",
+              "number": "120",
+              "title": "Building the Human Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "122",
+              "title": "Construction Material and Equipment Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "123",
+              "title": "Building Construction Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "124",
+              "title": "Building Construction Methods II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "130",
+              "title": "Blueprint Reading and Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "131",
+              "title": "Green Building Introduction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "132",
+              "title": "Solar Water Heating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "133",
+              "title": "Solar Greenhouse Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "134",
+              "title": "Rain Water Harvest Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "138",
+              "title": "Introduction to Solar Design Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "150",
+              "title": "Basic Electrical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "235",
+              "title": "Solar Home Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "236",
+              "title": "Photovoltaics and Wind Power",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "250",
+              "title": "Innovative and Alternative Building Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "260",
+              "title": "Green Building I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "289",
+              "title": "Internship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction and Industry Trades",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=894",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences (4)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "171",
+              "title": "Fundamentals of Environmental Science: Humans and the Environment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 44 credits",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "211",
+              "title": "International Residential Code",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "288",
+              "title": "Construction Supervision and Scheduling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "102",
+              "title": "Basic Welding Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Apprenticeship Practicum (6000 hours)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office Management",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=864",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6-8)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "140",
+              "title": "College Math with Algebra Review",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 44 credits",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "108",
+              "title": "Practical Accounting Procedures 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "110",
+              "title": "Health Care Ethics and Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "145",
+              "title": "Medical Assistant Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "146",
+              "title": "Medical Assistant A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "147",
+              "title": "Medical Assistant A Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "148",
+              "title": "Medical Assistant B",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "149",
+              "title": "Medical Assistant B Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "290",
+              "title": "Medical Assisting Externship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Medical Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=889",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "145",
+              "title": "Medical Assistant Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "146",
+              "title": "Medical Assistant A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "147",
+              "title": "Medical Assistant A Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "148",
+              "title": "Medical Assistant B",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "149",
+              "title": "Medical Assistant B Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "290",
+              "title": "Medical Assisting Externship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=903",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements: 25 credits",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6-8)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 35 credits",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "100",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "110",
+              "title": "Early Childhood Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "120",
+              "title": "Health, Safety, and Nutrition for the Young Child",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "200",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "220",
+              "title": "Language Arts for the Young Child",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "234",
+              "title": "Child Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "240",
+              "title": "School, Family, and Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "250",
+              "title": "Children with Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "265",
+              "title": "Observation and Assessment Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "270",
+              "title": "Early Childhood Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "210",
+              "title": "Creative Arts for the Young Child",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "230",
+              "title": "Exploration and Discovery for the Young Child",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Assisted Living Facility Caregiver Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=897",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Caregiving I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Other requirements: Food handlers’ card (embedded in the program with an additional fee)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=890",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "131",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "110",
+              "title": "Nursing Assistant I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "111",
+              "title": "Nursing Assistant Clinical",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Basic Detention Academy Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=876",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "216",
+              "title": "Basic Detention Academy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=865",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Courses not applicable to the degree:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "Unity of Life I: Life of the Cell",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Courses applicable to degree:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "130",
+              "title": "Fundamental Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Other requirements: AZ CNA or LNA License",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements: 35 credits",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6-8)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Social and Behavioral Sciences (3)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences (4)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "218",
+              "title": "Human Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "130",
+              "title": "Fundamental Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 42 credits",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NTR",
+              "number": "135",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "114",
+              "title": "Introduction to Nursing Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "116",
+              "title": "Nursing Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "124",
+              "title": "Nursing Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "215",
+              "title": "Nursing Concepts III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "220",
+              "title": "Nursing Concepts IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "222",
+              "title": "Management and Leadership in Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Pre-Health Careers Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=891",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "Unity of Life I: Life of the Cell",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "130",
+              "title": "Fundamental Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NTR",
+              "number": "135",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Health Careers",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=867",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements: 25 credits",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6-8)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Social and Behavioral Sciences (6)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences (4)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "Unity of Life I: Life of the Cell",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 26 credits",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "131",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "218",
+              "title": "Human Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "130",
+              "title": "Fundamental Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NTR",
+              "number": "135",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "110",
+              "title": "Health Care Ethics and Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "145",
+              "title": "Medical Assistant Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "148",
+              "title": "Medical Assistant B",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "149",
+              "title": "Medical Assistant B Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "131",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "110",
+              "title": "Nursing Assistant I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "111",
+              "title": "Nursing Assistant Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Introduction to Statistics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=862",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6-8)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Degree Core requirements: 42 credits",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "131",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "104",
+              "title": "Principles of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "110",
+              "title": "Fire Behavior and Combustion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "135",
+              "title": "Fire Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "138",
+              "title": "Hazardous Materials First Responder",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "145",
+              "title": "Principles of Fire and Emergency Services Safety &amp;  Survival",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "180",
+              "title": "Firefighter I and II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "233",
+              "title": "Introduction to Wildland Fire Behavior/Fire Fighter and Human Factors in the Wildland",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "235",
+              "title": "Fire Protection Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "241",
+              "title": "Building Construction for Fire Protection",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Intermediate Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=884",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "131",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "138",
+              "title": "Hazardous Materials First Responder",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "180",
+              "title": "Firefighter I and II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "233",
+              "title": "Introduction to Wildland Fire Behavior/Fire Fighter and Human Factors in the Wildland",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Wildfire Suppression Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=883",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "131",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "233",
+              "title": "Introduction to Wildland Fire Behavior/Fire Fighter and Human Factors in the Wildland",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "243",
+              "title": "Wildland Fire Chain Saws",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "253",
+              "title": "Wildland Fire Observation and Origin Scene Protection, Portable Pumps and Water Use, Basic Air Operations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Advanced Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=885",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Completion of the Intermediate Certificate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "104",
+              "title": "Principles of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "110",
+              "title": "Fire Behavior and Combustion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "135",
+              "title": "Fire Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "145",
+              "title": "Principles of Fire and Emergency Services Safety &amp;  Survival",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "235",
+              "title": "Fire Protection Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "241",
+              "title": "Building Construction for Fire Protection",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Company Officer Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=902",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "238",
+              "title": "Strategy and Tactics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "239",
+              "title": "Principles of Fire and Emergency Service Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "240",
+              "title": "Legal Aspects of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Engineer Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=901",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "136",
+              "title": "Fire Protection Hydraulics and Water Supply",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "139",
+              "title": "Fire Apparatus Driver Operator",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic Studies",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=866",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Written and Oral Communication: Composition (6-8)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101A",
+              "title": "College Composition I with Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning (3-5)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MAT",
+                  "number": "140",
+                  "title": "College Math with Algebra Review"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Degree Core Requirements: 53 credits",
+          "credits_required": 53,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "262A",
+              "title": "Paramedic A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "262B",
+              "title": "Paramedic B",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "262C",
+              "title": "Paramedic C",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "131",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "131A",
+              "title": "Emergency Medical Technician A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "AND",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "131B",
+              "title": "Emergency Medical Technician B",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Law Enforcement Training Academy",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=905",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LET",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "109",
+              "title": "Substantive Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "113",
+              "title": "Criminal Justice Crime Control Policies and Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "151",
+              "title": "Firearms I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "153",
+              "title": "Firearms II/Handguns",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "154",
+              "title": "Firearms III/Long Weapons",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "162",
+              "title": "Domestic Violence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "201",
+              "title": "Rules of Evidence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "205",
+              "title": "Effective Communication and Report Writing in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "210",
+              "title": "Constitutional Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "215",
+              "title": "Criminalistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "230",
+              "title": "The Police Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "260",
+              "title": "Procedural Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "270",
+              "title": "Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "275",
+              "title": "Criminal Investigation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LET",
+              "number": "290",
+              "title": "Courtroom Testimony Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Paramedicine Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=904",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "262A",
+              "title": "Paramedic A",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "262B",
+              "title": "Paramedic B",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "262C",
+              "title": "Paramedic C",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automated Industrial Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=906",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIT",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "105",
+              "title": "Maintenance Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "110",
+              "title": "Mechanical Power Transmission Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "115",
+              "title": "Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "120",
+              "title": "Pneumatic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "125",
+              "title": "Electrical Systems I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=907",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTM",
+              "number": "122",
+              "title": "Construction Material and Equipment Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "123",
+              "title": "Building Construction Methods I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "124",
+              "title": "Building Construction Methods II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "130",
+              "title": "Blueprint Reading and Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "150",
+              "title": "Basic Electrical Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "151",
+              "title": "House Wiring I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "152",
+              "title": "House Wiring II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "155",
+              "title": "Commercial Wiring I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTM",
+              "number": "211",
+              "title": "International Residential Code",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automated Industrial Technology Certificate Level II",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.coconino.edu/preview_program.php?catoid=14&poid=911",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIT",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "105",
+              "title": "Maintenance Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "110",
+              "title": "Mechanical Power Transmission Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "115",
+              "title": "Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "120",
+              "title": "Pneumatic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "125",
+              "title": "Electrical Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "205",
+              "title": "Programable Electronics and Variable Frequency Drives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "210",
+              "title": "Programmable Logic Controller Programming And Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "215",
+              "title": "Process Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "225",
+              "title": "Industrial Motors and Motor Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "260",
+              "title": "Manufacturing Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "270",
+              "title": "Robotics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/az/programs/mohave-community-college.json
+++ b/data/az/programs/mohave-community-college.json
@@ -1,0 +1,14629 @@
+{
+  "college_slug": "mohave-community-college",
+  "catalog_year": "2026-2027",
+  "catalog_url": "https://catalog.mohave.edu",
+  "scraped_at": "2026-06-05T01:36:49.800Z",
+  "programs": [
+    {
+      "title": "Advanced Automotive Technology Certificate (ATA.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9631",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "105",
+              "title": "Introduction to the Automotive Service Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "125",
+              "title": "Automotive Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "165",
+              "title": "Automotive Braking Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "175",
+              "title": "Automotive Suspension Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Register early for required trade courses and labs to stay on schedule.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "145",
+              "title": "Automotive Engine Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "155",
+              "title": "Automotive Steering Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "210",
+              "title": "Automotive Engine Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "215",
+              "title": "Automotive HVAC Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Enroll in the next sequence of required courses as registration opens.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "230",
+              "title": "Automotive Business Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "245",
+              "title": "Automotive Powertrain Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "275",
+              "title": "Introduction to Hybrid/Alternative Fuel Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Complete the remaining coursework and required program requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "AAS General Education Core Requirements",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9539",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Communications: 6",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "105",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "151",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "136",
+              "title": "Technical/Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Critical Thinking and Reasoning: 3-5",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any 100-level or above math, technical math, integrated or vocational math Credits: (3-4)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any 100-level or above laboratory science course Credits: (4-5)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "151",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Or any vocational ethics course from the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "175",
+              "title": "Business Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "100",
+              "title": "Medical Law and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Global Awareness: 3-4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANT",
+              "number": "102",
+              "title": "Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "World Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "230",
+              "title": "World Art History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "207",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "137",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "233",
+              "title": "English Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "234",
+              "title": "English Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "235",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "236",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GHY",
+              "number": "240",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "History of the United States I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "History of the United States II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "135",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "136",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "150",
+              "title": "Humanities I - Gods, Myths, and Empires",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "151",
+              "title": "Humanities II - Reason, Conquest, and Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "250",
+              "title": "Introduction to Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Appreciation and Literature of Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "205",
+              "title": "Comparative World Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "135",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Food Management Certificate (FM.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9649",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "105",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "136",
+              "title": "Microsoft Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "101",
+              "title": "Introduction  to Business and Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "234",
+              "title": "History of the Indigenous Americas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Culinary Business Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "248",
+              "title": "Culinary Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Accounting, AAS (ACC.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9540",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Using QuickBooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "105",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "110",
+              "title": "Business Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "131",
+              "title": "Microsoft Office",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "135",
+              "title": "Accounting Systems and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "139",
+              "title": "Income Tax Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "101",
+              "title": "Introduction  to Business and Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "136",
+              "title": "Microsoft Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "143",
+              "title": "Payroll Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "225",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "250",
+              "title": "Non-Profit and Governmental Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "221",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "155",
+              "title": "Cost Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "230",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "130",
+              "title": "Financial Management for Entrepreneurs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "202",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "222",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Administration of Justice, AA (AJS.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9541",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "101",
+              "title": "Introduction to Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "109",
+              "title": "Substantive Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "212",
+              "title": "Juvenile Justice Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "230",
+              "title": "The Police Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Natural Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "240",
+              "title": "The Correction Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "260",
+              "title": "Procedural Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "151",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "151",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "225",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "245",
+              "title": "Ethics in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "270",
+              "title": "Community Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "275",
+              "title": "Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "234",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "270",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Social and Behavioral Sciences category of the AGEC Suggested additional Social and Behavioral Sciences AGEC courses: PSY 234 SOC 132 SOC 133 SOC 136 SOC 140 Course substitutions allowed for General Education in the AGEC as long as it is relevant to the program in place of a COM course: SPA 101 and/ or SPA 102 ENG 136 ENG 138 in place of PHI 101/ PHI 151 ASL 101 and/ or ASL 102",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Alternative Elementary Teaching Pathway (AETP.ND)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9662",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pathway Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "205",
+              "title": "Introduction to Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "214",
+              "title": "Cultural Diversity in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "222",
+              "title": "The Exceptional Student",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "270",
+              "title": "Classroom Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "303",
+              "title": "Child and Adolescent Learning and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "312",
+              "title": "Creative Foundations: Methods for Teaching Fine Arts in the K-8 Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "315",
+              "title": "Brain Based Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "340",
+              "title": "Structured English Immersion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "435",
+              "title": "Literacy in Elementary I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "438",
+              "title": "Literacy in Elementary II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "483",
+              "title": "Elementary Science Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "485",
+              "title": "Elementary Math Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "487",
+              "title": "Elementary Social Studies Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "495",
+              "title": "Alternative Pathway Student Teaching and Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "100",
+              "title": "Arizona Constitution and Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "227",
+              "title": "United States Constitution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*POS 100 and POS 227 can be waived with passing APEA/NES test score for AZ and US constitution.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Alternative Secondary Teaching Pathway (ASTP.ND)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9663",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pathway Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "205",
+              "title": "Introduction to Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "214",
+              "title": "Cultural Diversity in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "222",
+              "title": "The Exceptional Student",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "242",
+              "title": "Secondary Reading and Decoding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "270",
+              "title": "Classroom Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "315",
+              "title": "Brain Based Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "340",
+              "title": "Structured English Immersion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "495",
+              "title": "Alternative Pathway Student Teaching and Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "100",
+              "title": "Arizona Constitution and Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "227",
+              "title": "United States Constitution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*POS 100 and POS 227 can be waived with passing APEA/NES test score for AZ and US constitution.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Complete one course from the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "271",
+              "title": "Secondary Language Arts Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "273",
+              "title": "Secondary Science Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "275",
+              "title": "Secondary Math Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "277",
+              "title": "Secondary Social Studies Methods",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Art, AA (ART.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9545",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "World Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "101",
+              "title": ", AST 101 , BIO 160 or any course within the Natural Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "221",
+              "title": "Drawing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "230",
+              "title": "World Art History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Written and Oral Communication category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "102",
+              "title": "Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Social & Behavioral Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective: Any transferable course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "125",
+              "title": "Painting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "151",
+              "title": "Photo I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "171",
+              "title": "Ceramics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "175",
+              "title": "Sculpture I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "234",
+              "title": "History of the Indigenous Americas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Institutions of the Americas category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective: Any transferable course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Social & Behavioral Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "289",
+              "title": "Portfolio and Presentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Arizona General Education Curriculum (AGEC.CC)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9676",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Written and Oral Communication Courses: 6-10 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "100",
+              "title": "Introduction to Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "151",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "136",
+              "title": "Technical/Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "102",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Arts & Humanities: 6-9 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "The Science of Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "125",
+              "title": "Painting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "126",
+              "title": "Painting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "World Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "133",
+              "title": "History of Visual Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "148",
+              "title": "Introduction to Visual Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "151",
+              "title": "Photo I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "171",
+              "title": "Ceramics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "172",
+              "title": "Ceramics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "175",
+              "title": "Sculpture I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "176",
+              "title": "Sculpture II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "221",
+              "title": "Drawing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "223",
+              "title": "Figure Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "230",
+              "title": "World Art History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "243",
+              "title": "Figure Drawing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "245",
+              "title": "Digital Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "256",
+              "title": "Photo II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "214",
+              "title": "Cultural Diversity in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "137",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "138",
+              "title": "Creative Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "233",
+              "title": "English Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "234",
+              "title": "English Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "235",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "236",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "238",
+              "title": "Writing Fiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "239",
+              "title": "Poetry Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "150",
+              "title": "Humanities I - Gods, Myths, and Empires",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "151",
+              "title": "Humanities II - Reason, Conquest, and Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "250",
+              "title": "Introduction to Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Appreciation and Literature of Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102",
+              "title": "Fundamentals of Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "151",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "205",
+              "title": "Comparative World Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "102",
+              "title": "Elementary Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning: 3-4 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "250",
+              "title": "Non-Profit and Governmental Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "208",
+              "title": "Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "221",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "222",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "181",
+              "title": "Plane Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Finite Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "211",
+              "title": "Introductory Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "212",
+              "title": "Brief Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "221",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "231",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "241",
+              "title": "Calculus Analytic and Geometry III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "260",
+              "title": "Introduction to Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "235",
+              "title": "Statistics for Behavioral Sciences",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences: 4-8 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Introduction to Astronomy with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Biology Concepts with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "General Biology I (Majors) with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "182",
+              "title": "General Biology II (Majors) with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "Microbiology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "290",
+              "title": "Field Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "130",
+              "title": "Fundamental Chemistry with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "235",
+              "title": "General Organic Chemistry I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "236",
+              "title": "General Organic Chemistry II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "102",
+              "title": "Introduction to Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "210",
+              "title": "Engineering Mechanics I: Statics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "212",
+              "title": "Engineering Mechanics II: Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "101",
+              "title": "Environmental Science with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "101",
+              "title": "Physical Geology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "102",
+              "title": "Historical Geology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "110",
+              "title": "Environmental Geology and Natural Disasters with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "140",
+              "title": "Introduction to Oceanography with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUT",
+              "number": "203",
+              "title": "Human Nutrition in Health and Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "111",
+              "title": "General Physics I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "112",
+              "title": "General Physics II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "University Physics I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "116",
+              "title": "University Physics II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences: 6-9 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANT",
+              "number": "102",
+              "title": "Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "207",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "History of the United States I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "History of the United States II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "135",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "136",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "137",
+              "title": "Twentieth Century World History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "234",
+              "title": "History of the Indigenous Americas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "281",
+              "title": "Latin American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "135",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "245",
+              "title": "Lifespan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Introduction to Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "270",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "290",
+              "title": "Research Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "132",
+              "title": "Social Problems in Modern Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "133",
+              "title": "Sociology of Deviant Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "136",
+              "title": "Marriage and Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WST",
+              "number": "101",
+              "title": "Introduction to Women&#039;s and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Institutions of the Americas: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "History of the United States I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "History of the United States II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "234",
+              "title": "History of the Indigenous Americas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "281",
+              "title": "Latin American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "100",
+              "title": "Arizona Constitution and Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "227",
+              "title": "United States Constitution",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Bodywork Certificate (ABW.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9644",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "108",
+              "title": "Introduction to Bodywork and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "118",
+              "title": "Auto Plastic Repair/Adhesives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "128",
+              "title": "Fiberglass Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "208",
+              "title": "Advanced Body Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "218",
+              "title": "Automotive Welding and Cutting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "228",
+              "title": "Fixed Panel Replacement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "248",
+              "title": "Unibody/Frame Straightening",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Art, Visual Communications, AA (ARTV.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9620",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "World Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "148",
+              "title": "Introduction to Visual Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "100",
+              "title": "Introduction to Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or COM 121 or COM 151",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "136",
+              "title": "Technical/Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "230",
+              "title": "World Art History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "245",
+              "title": "Digital Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "133",
+              "title": "History of Visual Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "151",
+              "title": "Photo I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "102",
+              "title": "Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "234",
+              "title": "History of the Indigenous Americas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Institutions of the Americas category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "289",
+              "title": "Portfolio and Presentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Social & Behavioral Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "221",
+              "title": "Drawing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Natural Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "256",
+              "title": "Photo II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Associate of General Studies, AGS (GS.AGS)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9622",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Natural Science category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYE",
+              "number": "100",
+              "title": "Career Pathways and Case Studies in the Arts and Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Quantitative Reasoning category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "136",
+              "title": "Technical/Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fourth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Automotive Estimating Certificate (AES.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9646",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "108",
+              "title": "Introduction to Bodywork and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "109",
+              "title": "Introduction to Refinishing and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "125",
+              "title": "Auto Body Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "248",
+              "title": "Unibody/Frame Straightening",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "250",
+              "title": "Automotive Collision Estimating",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Basic Automotive Technology Certificate (ATB.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9630",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "105",
+              "title": "Introduction to the Automotive Service Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "125",
+              "title": "Automotive Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "145",
+              "title": "Automotive Engine Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASE",
+              "number": "155",
+              "title": "Automotive Steering Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "165",
+              "title": "Automotive Braking Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASE",
+              "number": "175",
+              "title": "Automotive Suspension Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Refinishing Certificate (ARF.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9645",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACT",
+              "number": "109",
+              "title": "Introduction to Refinishing and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "119",
+              "title": "Panel Preparation and Masking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "129",
+              "title": "Stationary/Structural Auto Glass",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "230",
+              "title": "Final Detail/Vehicle Delivery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "239",
+              "title": "Advanced Refinishing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACT",
+              "number": "249",
+              "title": "Custom Paint and Airbrushing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Behavioral Health Aide (BHA.CT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=10354",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HPS",
+              "number": "100",
+              "title": "Career Exploration in Healthcare, Public Service, and Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "100",
+              "title": "Introduction to Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "215",
+              "title": "Resilience and Stress Management for the Human Service Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "230",
+              "title": "Case Management and Documentation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHA",
+              "number": "145",
+              "title": "Legal, Ethical, and Professional Issues in Behavioral Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Behavioral Health and Social Work Certificate (BHSW.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9667",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "Introduction to Behavioral Health and Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "133",
+              "title": "Sociology of Deviant Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Register early for required trade courses and labs to stay on schedule.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "270",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "289",
+              "title": "Contemporary Social Problems and Relationships - Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Complete the remaining coursework and required program requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biology, BS (BIO.BS)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9960",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "General Biology I (Majors) with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Build an academic plan and become familiar with degree requirements in the catalog.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "182",
+              "title": "General Biology II (Majors) with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "181",
+              "title": "Plane Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review course progress and general education completion.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "211",
+              "title": "Introductory Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "235",
+              "title": "General Organic Chemistry I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "200",
+              "title": "Biological Inquiry: Research Methods and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Social and Behavioral Science category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Social and Behavioral Science category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Check degree progress and adjust the academic plan if needed.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "236",
+              "title": "General Organic Chemistry II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "150",
+              "title": "Humanities I - Gods, Myths, and Empires",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "History of the United States I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any course(s) totaling 3 credits within the Institutions of the Americas category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Confirm lower-division coursework is on track for completion.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "221",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "Microbiology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "301",
+              "title": "Ecological Field Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "307",
+              "title": "Genetics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Seek leadership, research, or applied learning opportunities in the field of study.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "111",
+              "title": "General Physics I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "University Physics I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "308",
+              "title": "Cell Biology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "309",
+              "title": "Ecology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "310",
+              "title": "Evolution Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: IF taking PHY 111 and PHY 112, will need to take an additional AGEC course to meet the program total of 120 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Seventh Semester: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "112",
+              "title": "General Physics II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "116",
+              "title": "University Physics II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "302",
+              "title": "Marine Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "305",
+              "title": "Botany",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "306",
+              "title": "Zoology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: IF taking PHY 111 and PHY 112, will need to take an additional AGEC course to meet the program total of 120 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Eighth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "400",
+              "title": "Molecular Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "401",
+              "title": "Advanced Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "402",
+              "title": "Immunology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "415",
+              "title": "Biological Sciences Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit the graduation application and verify completion requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Business - Bookkeeping Certificate (BKP.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9548",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Using QuickBooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "110",
+              "title": "Business Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "136",
+              "title": "Microsoft Excel",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "135",
+              "title": "Accounting Systems and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "139",
+              "title": "Income Tax Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "143",
+              "title": "Payroll Procedures",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business - Entrepreneurship and e-Marketing Certificate (BUE.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9551",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisites: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "105",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "101",
+              "title": "Introduction  to Business and Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "165",
+              "title": "Social Media Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "161",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "130",
+              "title": "Financial Management for Entrepreneurs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "250",
+              "title": "Business Plan for Entrepreneurs",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business - Organizational Management Certificate (ORGM.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9652",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "105",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "101",
+              "title": "Introduction  to Business and Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "102",
+              "title": "Human Relations in the Workplace",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "120",
+              "title": "Managing and Supervising Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "161",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "162",
+              "title": "Retailing and Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration, ABus (BUS.ABUS)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9549",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Natural Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Social & Behavioral Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "136",
+              "title": "Technical/Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "202",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Finite Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "245",
+              "title": "Digital Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "208",
+              "title": "Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "221",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "212",
+              "title": "Brief Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "207",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "222",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "151",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business - Retail Management Certificate (RTM.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9626",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "102",
+              "title": "Human Relations in the Workplace",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "105",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "120",
+              "title": "Managing and Supervising Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "131",
+              "title": "Microsoft Office",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "161",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "162",
+              "title": "Retailing and Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "247",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business and Entrepreneurship, AAS (BUE.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9552",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "101",
+              "title": "Introduction  to Business and Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "105",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "110",
+              "title": "Business Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "131",
+              "title": "Microsoft Office",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "143",
+              "title": "Payroll Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "102",
+              "title": "Human Relations in the Workplace",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "120",
+              "title": "Managing and Supervising Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "175",
+              "title": "Business Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "136",
+              "title": "Microsoft Excel",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "130",
+              "title": "Financial Management for Entrepreneurs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "260",
+              "title": "Global Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "161",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "162",
+              "title": "Retailing and Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "165",
+              "title": "Social Media Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "250",
+              "title": "Business Plan for Entrepreneurs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "202",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "207",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "247",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Chemistry, AS (CHM.AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9553",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Institutions of the Americas category of the AGEC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "181",
+              "title": "Plane Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Social & Behavioral Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "235",
+              "title": "General Organic Chemistry I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "221",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Social & Behavioral Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.) Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "236",
+              "title": "General Organic Chemistry II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "231",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "University Physics I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "116",
+              "title": "University Physics II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Arts & Humanities category of the AGEC",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Child Development Associate® Credential™ (CD.ND)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9563",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Credential Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "111",
+              "title": "Safety, Health, and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "112",
+              "title": "Learning Environment in Early Childhood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "113",
+              "title": "Principles of Child Development and Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "114",
+              "title": "Physical Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "115",
+              "title": "Intellectual Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "116",
+              "title": "Social, Emotional, and Self-Concept Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "117",
+              "title": "Observation, Behavior, and Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "118",
+              "title": "Understanding Families and Communities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "119",
+              "title": "Program Operation and Professionalism",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Computer Graphics and Web Design Certificate (WEB.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9554",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Exploring Information and Technology Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "142",
+              "title": "Digital Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "143",
+              "title": "Web Page Design I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "206",
+              "title": "Web Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "243",
+              "title": "Web Page Design II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Commercial/Industrial Electricity (ELCI.CT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9567",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "210",
+              "title": "Commercial Electricity I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "211",
+              "title": "Commercial Electricity II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "221",
+              "title": "Low Voltage Control Systems II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "230",
+              "title": "Industrial Electricity I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "231",
+              "title": "Industrial Electricity II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "240",
+              "title": "Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Aided Design Certificate (CADE.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9674",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "100",
+              "title": "CAD Fundamentals and Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "102",
+              "title": "Advanced CAD",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "104",
+              "title": "CAD for Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "110",
+              "title": "CAD Capstone Project",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Confirm program requirements and course expectations with an academic advisor or success coach early in the term.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Graphics and Web Design, AAS (CGWD.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9555",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "105",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "142",
+              "title": "Digital Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "World Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "101",
+              "title": "Introduction  to Business and Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "230",
+              "title": "World Art History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "110",
+              "title": "Business Math",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "125",
+              "title": "Basic Game Design and Creation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "143",
+              "title": "Web Page Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "206",
+              "title": "Web Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "175",
+              "title": "Business Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "131",
+              "title": "Microsoft Office",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Student may choose another Global Awareness Course from AAS General Education Checklist in place of SOC 131.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "165",
+              "title": "Social Media Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "210",
+              "title": "Database Management and SQL Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "243",
+              "title": "Web Page Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "270",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "CIS Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems Administration, AAS (CISA.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9556",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "115",
+              "title": "A+ Computer Technology Hardware",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "143",
+              "title": "Web Page Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "153",
+              "title": "Network Fundamentals and Infrastructure",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Biology Concepts with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "116",
+              "title": "A+ Computer Technology Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "204",
+              "title": "Programming and Game Development  in C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Introduction to Astronomy with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "250",
+              "title": "Introduction to Cinema",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "208",
+              "title": "Programming in C#",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "210",
+              "title": "Database Management and SQL Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "253",
+              "title": "Cybersecurity Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "270",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "207",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "230",
+              "title": "World Art History II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems, ABus (CISB.ABUS)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9557",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Special Requirements for the AGEC - B:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "207",
+              "title": "Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Methods Requirement: 3-4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Finite Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "231",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements: 25",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "202",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "208",
+              "title": "Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "221",
+              "title": "Financial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "222",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "208",
+              "title": "Programming in C#",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "270",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Technician Certification (CTC.CT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9965",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Exploring Information and Technology Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "115",
+              "title": "A+ Computer Technology Hardware",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "116",
+              "title": "A+ Computer Technology Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "270",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "215",
+              "title": "Linux (Unix) OS Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science, AS (CS.AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9616",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisites: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "181",
+              "title": "Plane Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "221",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course from the Arts and Humanities category in the AGEC",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "208",
+              "title": "Programming in C#",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "University Physics I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "231",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Computer Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "204",
+              "title": "Programming and Game Development  in C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "116",
+              "title": "University Physics II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course from the Institutions of the Americas category in the AGEC",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "210",
+              "title": "Computer Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course in the Arts and Humantities category of the AGEC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "210",
+              "title": "Database Management and SQL Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course from the Social and Behaviorial Sciences category in the AGEC ​",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "206",
+              "title": "Web Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "CTE Entrepreneurship, AAS (ENTR.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9653",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "105",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or COM 151 or BUS 204",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "175",
+              "title": "Business Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "131",
+              "title": "Microsoft Office",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "101",
+              "title": "Introduction  to Business and Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "130",
+              "title": "Financial Management for Entrepreneurs",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "165",
+              "title": "Social Media Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "250",
+              "title": "Business Plan for Entrepreneurs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "161",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cosmetology (COS.CT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9959",
+      "total_credits": 40,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "141",
+              "title": "Cosmetology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "142",
+              "title": "Cosmetology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "143",
+              "title": "Cosmetology III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "144",
+              "title": "Cosmetology IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "145",
+              "title": "Cosmetology V",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CTE Organizational Management, AAS (ORGM.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9654",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "105",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or COM 151 or BUS 204",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "175",
+              "title": "Business Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "131",
+              "title": "Microsoft Office",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "101",
+              "title": "Introduction  to Business and Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "102",
+              "title": "Human Relations in the Workplace",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUE",
+              "number": "120",
+              "title": "Managing and Supervising Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "161",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "162",
+              "title": "Retailing and Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Cybersecurity and Network Support, AAS (CSNS.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9589",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "105",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Exploring Information and Technology Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "115",
+              "title": "A+ Computer Technology Hardware",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "116",
+              "title": "A+ Computer Technology Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "110",
+              "title": "Business Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "153",
+              "title": "Network Fundamentals and Infrastructure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "154",
+              "title": "Network Services and Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "209",
+              "title": "Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and update your academic plan if needed.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "210",
+              "title": "Database Management and SQL Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Global Awareness category of the AAS General Education Checklist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "215",
+              "title": "Linux (Unix) OS Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "156",
+              "title": "Cybersecurity Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "253",
+              "title": "Cybersecurity Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "270",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "275",
+              "title": "Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "280",
+              "title": "CIS Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Culinary Arts Management, AAS (CHSM.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9560",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements: 16",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "105",
+              "title": "Business English",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "234",
+              "title": "History of the Indigenous Americas",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements: 45-47",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "111",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "121",
+              "title": "Fundamentals of the Pantry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "131",
+              "title": "Fundamentals of Sauce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "141",
+              "title": "Fundamentals of Butchery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "220",
+              "title": "Culinary Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Preservation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Culinary Business Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "161",
+              "title": "Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "248",
+              "title": "Culinary Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUE",
+              "number": "250",
+              "title": "Business Plan for Entrepreneurs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Indigenous Fusion I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "251",
+              "title": "Indigenous Fusion II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "255",
+              "title": "Modern Gastronomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Culinary Externship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Culinary Arts Certificate (CHSM.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9559",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "111",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "121",
+              "title": "Fundamentals of the Pantry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "131",
+              "title": "Fundamentals of Sauce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "220",
+              "title": "Culinary Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "141",
+              "title": "Fundamentals of Butchery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Preservation Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "234",
+              "title": "History of the Indigenous Americas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Culinary Business Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "250",
+              "title": "Indigenous Fusion I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "251",
+              "title": "Indigenous Fusion II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "255",
+              "title": "Modern Gastronomy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting Certificate (DAE.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9561",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAE",
+              "number": "100",
+              "title": "Clinical Dental Assisting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "101",
+              "title": "Biomedical Dental Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "105",
+              "title": "Dental Infection Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "111",
+              "title": "Dental Radiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "112",
+              "title": "Dental Radiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "114",
+              "title": "Clinical Dental Assisting Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "128",
+              "title": "Dental Specialties and Materials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Security Certification (CyS.CT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9675",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Exploring Information and Technology Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "115",
+              "title": "A+ Computer Technology Hardware",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "116",
+              "title": "A+ Computer Technology Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "153",
+              "title": "Network Fundamentals and Infrastructure",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "253",
+              "title": "Cybersecurity Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "156",
+              "title": "Cybersecurity Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene, AAS (DAE.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9562",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisites: 21 credits",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "Microbiology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "130",
+              "title": "Fundamental Chemistry with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAE",
+              "number": "111",
+              "title": "Dental Radiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "112",
+              "title": "Dental Radiology Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "101",
+              "title": "Pre-Clinical Dental Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "121",
+              "title": "Dental Anatomy, Histology &amp; Embryology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "122",
+              "title": "Head and Neck Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAE",
+              "number": "118",
+              "title": "Dental Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "104",
+              "title": "Dental Hygiene Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "112",
+              "title": "Periodontology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "114",
+              "title": "Dental Hygiene Clinic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "118",
+              "title": "Anesthesiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 5 credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEH",
+              "number": "117",
+              "title": "Applied Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "214",
+              "title": "Dental Hygiene Clinic II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEH",
+              "number": "212",
+              "title": "Periodontology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "223",
+              "title": "General and Oral Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "224",
+              "title": "Dental Hygiene Theory III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "234",
+              "title": "Dental Hygiene Clinic III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEH",
+              "number": "236",
+              "title": "Nutrition in Dental Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "243",
+              "title": "Community Dental Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "244",
+              "title": "Dental Hygiene Theory IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEH",
+              "number": "254",
+              "title": "Dental Hygiene Clinic IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography Cardiac Pathway, AAS (DMSCP.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=10222",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisites: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Mathematical Literacy for College Students",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "107",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "110",
+              "title": "Introduction to Sonography and Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "112",
+              "title": "Introduction to Adult Echocardiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "121",
+              "title": "Sonographic Physics &amp; Instrumentation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "122",
+              "title": "Cardiac Clinical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "132",
+              "title": "Adult Echocardiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "142",
+              "title": "Cardiac Clinical II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "152",
+              "title": "Advanced Adult Echocardiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "221",
+              "title": "Sonographic Physics &amp; Instrumentation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 5 credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "162",
+              "title": "Cardiac Clinical III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "231",
+              "title": "Cardiac Clinical IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "248",
+              "title": "Echocariography as a Profession",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "150",
+              "title": "Vascular Sonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "210",
+              "title": "Advanced Vascular and Special Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education, AA (EDU.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9634",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "World Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Biology Concepts with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 4 credit course within the Natural Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "205",
+              "title": "Introduction to Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "101",
+              "title": "Physical Geology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 4 credit course within the Natural Sciences category of AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "214",
+              "title": "Cultural Diversity in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260",
+              "title": "Building Reading Literacy through Word Study, Comprehension Strategies, and Phonics Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Math for Elementary Teachers I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "151",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Math for Elementary Teachers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "245",
+              "title": "Lifespan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "222",
+              "title": "The Exceptional Student",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "270",
+              "title": "Classroom Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "138",
+              "title": "Creative Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "100",
+              "title": "Arizona Constitution and Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education, AA (EDEC.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9565",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Biology Concepts with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 4 credit course within the Natural Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "World Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "205",
+              "title": "Introduction to Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "101",
+              "title": "Physical Geology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 4 credit course within the Natural Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "214",
+              "title": "Cultural Diversity in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "245",
+              "title": "Lifespan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Social & Behavioral Science category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Math for Elementary Teachers I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "160",
+              "title": "Early Childhood Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "162",
+              "title": "Curriculum and Experiences in Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Math for Elementary Teachers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260",
+              "title": "Building Reading Literacy through Word Study, Comprehension Strategies, and Phonics Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "270",
+              "title": "Classroom Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "100",
+              "title": "Arizona Constitution and Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "161",
+              "title": "Health, Safety, and Nutrition for the Young Child",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "151",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Elementary Education, BA (ELED.BA)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9961",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "World Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Biology Concepts with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 4 credit course within the Natural Science category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Build an academic plan and become familiar with degree requirements in the catalog.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "205",
+              "title": "Introduction to Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "101",
+              "title": "Physical Geology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 4 credit course within the Natural Science category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review course progress and general education completion.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "214",
+              "title": "Cultural Diversity in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260",
+              "title": "Building Reading Literacy through Word Study, Comprehension Strategies, and Phonics Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Math for Elementary Teachers I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "151",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Check degree progress and confirm you meet program requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "161",
+              "title": "Math for Elementary Teachers II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "245",
+              "title": "Lifespan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "222",
+              "title": "The Exceptional Student",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "270",
+              "title": "Classroom Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "100",
+              "title": "Arizona Constitution and Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "138",
+              "title": "Creative Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Confirm lower-division coursework is on track for completion.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "303",
+              "title": "Child and Adolescent Learning and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "306",
+              "title": "Supervised Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "315",
+              "title": "Brain Based Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "483",
+              "title": "Elementary Science Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "485",
+              "title": "Elementary Math Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Seek leadership, research, or applied learning opportunities in the field of study.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "307",
+              "title": "Supervised Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "345",
+              "title": "Empowering Diverse Learners Through Differentiation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "435",
+              "title": "Literacy in Elementary I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "438",
+              "title": "Literacy in Elementary II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "487",
+              "title": "Elementary Social Studies Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Refine application materials such as resumes, personal statements, or portfolios.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Seventh Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "340",
+              "title": "Structured English Immersion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "380",
+              "title": "The Psychology of Learning: Insights for Teaching and Instruction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review degree progress to ensure all requirements are scheduled.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Eighth Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "308",
+              "title": "Supervised Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "310",
+              "title": "Engaging Learners Through Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "312",
+              "title": "Creative Foundations: Methods for Teaching Fine Arts in the K-8 Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "320",
+              "title": "Integrating Technology in Education: Tools, Strategies, and Best Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "360",
+              "title": "Assessment Strategies for K-8 Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Complete a final degree progress review with your advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Ninth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "496",
+              "title": "Student Teaching and Seminar I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "497",
+              "title": "Student Teaching and Seminar II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit the graduation application and verify completion requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography, AAS (DMS.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9669",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisites: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Mathematical Literacy for College Students",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "107",
+              "title": "Conceptual Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "110",
+              "title": "Introduction to Sonography and Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "121",
+              "title": "Sonographic Physics &amp; Instrumentation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "130",
+              "title": "Abdominal Sonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review your academic plan and confirm your course sequence with your advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "135",
+              "title": "Small Parts and Superficial Structures in Diagnostic Sonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "150",
+              "title": "Vascular Sonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "221",
+              "title": "Sonographic Physics &amp; Instrumentation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Research career interests or transfer options related to your program of study.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 5 credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "140",
+              "title": "Obstetrical and Gynecological Sonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "180",
+              "title": "General Sonography Clinical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Meet with your advisor to confirm continued progress through program requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "210",
+              "title": "Advanced Vascular and Special Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "230",
+              "title": "General Sonography Clinical II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "250",
+              "title": "Sonography as a Profession I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and update your academic plan if needed.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "240",
+              "title": "General Sonography Clinical III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "270",
+              "title": "Sonography as a Profession II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Prepare career readiness items such as resumes, personal statements, or employment documents.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "260",
+              "title": "General Sonography Clinical IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit your graduation application and verify completion of eligibility requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Fighter Certificate (FF.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9574",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "105",
+              "title": "Principles of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "220",
+              "title": "Occupational Safety and Health for the Fire Service",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "150",
+              "title": "Fire Fighter II Academy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering, AS (ENGR.AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9571",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisites: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "181",
+              "title": "Plane Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "221",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "102",
+              "title": "Introduction to Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Computer Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "231",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "University Physics I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "250",
+              "title": "Introduction to Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "241",
+              "title": "Calculus Analytic and Geometry III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "116",
+              "title": "University Physics II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "260",
+              "title": "Introduction to Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "202",
+              "title": "Engineering Circuit Analysis with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "English, AA (ENG.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9572",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "138",
+              "title": "Creative Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "150",
+              "title": "Humanities I - Gods, Myths, and Empires",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Elementary Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 or 4 credit course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "136",
+              "title": "Technical/Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "137",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "151",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or COM 100 or COM 121",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "233",
+              "title": "English Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "235",
+              "title": "American Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "238",
+              "title": "Writing Fiction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Natural Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Institutions of the Americas category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Social & Behavioral Science category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "234",
+              "title": "English Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "236",
+              "title": "American Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "239",
+              "title": "Poetry Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "english"
+    },
+    {
+      "title": "Fire Officer Certificate (FOC.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9575",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "120",
+              "title": "Fire Behavior and Combustion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "222",
+              "title": "Fire Protection Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "133",
+              "title": "Fundamentals of Fire Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "233",
+              "title": "Building Construction for Fire Protection",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "221",
+              "title": "Fire Administration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "235",
+              "title": "Fire Strategy and Tactics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "242",
+              "title": "Fire Investigation I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Food Preparation Certificate (FP.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9650",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "111",
+              "title": "Fundamentals of Culinary Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "121",
+              "title": "Fundamentals of the Pantry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "131",
+              "title": "Fundamentals of Sauce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "220",
+              "title": "Culinary Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science, AAS (FSC.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9576",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "105",
+              "title": "Principles of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "220",
+              "title": "Occupational Safety and Health for the Fire Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "150",
+              "title": "Fire Fighter II Academy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Mathematical Literacy for College Students",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "120",
+              "title": "Fire Behavior and Combustion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "133",
+              "title": "Fundamentals of Fire Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "135",
+              "title": "Fire Apparatus/Hydraulics/Driver Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "233",
+              "title": "Building Construction for Fire Protection",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "136",
+              "title": "Technical/Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "221",
+              "title": "Fire Administration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "222",
+              "title": "Fire Protection Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "235",
+              "title": "Fire Strategy and Tactics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services, BA (HUS.BA)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9962",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HPS",
+              "number": "100",
+              "title": "Career Exploration in Healthcare, Public Service, and Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPS",
+              "number": "101",
+              "title": "The Successful Healthcare Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any AGEC course or MAT 101 or MAT 121 pre-requisite if needed.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "100",
+              "title": "Introduction to Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "Introduction to Behavioral Health and Social Work",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAC",
+              "number": "101",
+              "title": "Models of Treatment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Institutions of the Americas category within the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAC",
+              "number": "111",
+              "title": "Psychopharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or COM 100 or COM 151",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "151",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "210",
+              "title": "Community Health and Wellness I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUT",
+              "number": "203",
+              "title": "Human Nutrition in Health and Disease",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "245",
+              "title": "Lifespan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "230",
+              "title": "Case Management and Documentation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Biology Concepts with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 4 credit course within the Natural Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "205",
+              "title": "Comparative World Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "215",
+              "title": "Resilience and Stress Management for the Human Service Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "231",
+              "title": "Family Systems and Interventions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Seventh Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "300",
+              "title": "Co-Occurring Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "301",
+              "title": "Ethics in Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "310",
+              "title": "Introduction to Public Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "312",
+              "title": "Assessment and Treatment of Addictive Disorders",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Eighth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "330",
+              "title": "Research Methods in Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "331",
+              "title": "Child Welfare and Family Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "345",
+              "title": "Diversity and Cultural Competence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "350",
+              "title": "Victimology and Advocacy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Ninth Semester- 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "332",
+              "title": "Crisis Intervention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "351",
+              "title": "The Helping Relationship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Tenth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "402",
+              "title": "Program Planning and Evaluation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "410",
+              "title": "Community Health and Wellness II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "430",
+              "title": "Case Management and Documentation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "450",
+              "title": "Counseling Theories and Techniques",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Eleventh Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "411",
+              "title": "Health Policy and Advocacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "431",
+              "title": "Trauma-Informed Care for Children and Families",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "451",
+              "title": "Group Counseling and Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "460",
+              "title": "Human Services Externship and Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC Refrigeration Technician Certificate (HVTR.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9665",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HVA",
+              "number": "100",
+              "title": "Safety and Workforce Readiness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "108",
+              "title": "HVAC Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "116",
+              "title": "Freezer/Refrigerator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "216",
+              "title": "Ice Machines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "250",
+              "title": "Boiler, Chiller, Cooling Tower Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "History, AA (HIS.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9578",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "102",
+              "title": "Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any course within the Social & Behavioral Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "150",
+              "title": "Humanities I - Gods, Myths, and Empires",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "History of the United States I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "102",
+              "title": "Historical Geology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Introduction to Astronomy with Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any course within the Social & Behavioral Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "History of the United States II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "281",
+              "title": "Latin American History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "151",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any course within the Written and Oral Communication category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any transferable course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "135",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "234",
+              "title": "History of the Indigenous Americas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "151",
+              "title": "Humanities II - Reason, Conquest, and Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "136",
+              "title": "Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "137",
+              "title": "Twentieth Century World History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any transferable course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "history"
+    },
+    {
+      "title": "HVAC Installer Certificate (HVIN.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9642",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HVA",
+              "number": "100",
+              "title": "Safety and Workforce Readiness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "106",
+              "title": "Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "107",
+              "title": "Heating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "108",
+              "title": "HVAC Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "228",
+              "title": "Air Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC Technician Certificate (HVTN.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9581",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HVA",
+              "number": "100",
+              "title": "Safety and Workforce Readiness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "106",
+              "title": "Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "107",
+              "title": "Heating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "108",
+              "title": "HVAC Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "207",
+              "title": "Heat Pumps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC/R Technician Certificate (HVT.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9666",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HVA",
+              "number": "100",
+              "title": "Safety and Workforce Readiness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "106",
+              "title": "Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "107",
+              "title": "Heating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "108",
+              "title": "HVAC Electrical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "207",
+              "title": "Heat Pumps",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HVA",
+              "number": "116",
+              "title": "Freezer/Refrigerator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "216",
+              "title": "Ice Machines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "228",
+              "title": "Air Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "250",
+              "title": "Boiler, Chiller, Cooling Tower Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance and Mechatronics (INMM.CT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=10353",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MFG",
+              "number": "202",
+              "title": "Industrial Maintenance Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "205",
+              "title": "Troubleshooting Industrial Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "210",
+              "title": "Troubleshooting Industrial Fluid Power Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "216",
+              "title": "PLC Programming and Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "250",
+              "title": "Manufacturing Assembly Line Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Introduction to Welding Certificate (WIN.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9670",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "103",
+              "title": "Welding Safety and Industry Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "104",
+              "title": "Introduction to Thermal and Mechanical Cutting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "107",
+              "title": "Introduction to Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "108",
+              "title": "Introduction to Welding Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Requirements: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Structural Steel 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Structural Steel 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Basic Pipe Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Intermediate Pipe Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Production 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Geology, AS (GLG.AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9577",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GLG",
+              "number": "101",
+              "title": "Physical Geology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Institutions of Americas category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "181",
+              "title": "Plane Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "102",
+              "title": "Historical Geology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Social & Behavioral Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "221",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "110",
+              "title": "Environmental Geology and Natural Disasters with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.) Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "115",
+              "title": "University Physics I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "231",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLG",
+              "number": "140",
+              "title": "Introduction to Oceanography with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Social & Behavorial Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "116",
+              "title": "University Physics II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Law Enforcement Academy Preparation Certificate (AJS.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9647",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements: 15",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "101",
+              "title": "Introduction to Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "109",
+              "title": "Substantive Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "230",
+              "title": "The Police Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "270",
+              "title": "Community Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "275",
+              "title": "Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Liberal Arts, AA (LBA.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9582",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Biology Concepts with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 4 credit course within the Natural Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or PHI 151 or PHI 205",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYE",
+              "number": "100",
+              "title": "Career Pathways and Case Studies in the Arts and Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "100",
+              "title": "Introduction to Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or COM 121 or COM 151",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "151",
+              "title": "Humanities II - Reason, Conquest, and Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "132",
+              "title": "Social Problems in Modern Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "World Art History I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "230",
+              "title": "World Art History II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "135",
+              "title": "Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Institutions of Americas category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any transferable elective course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NOTES: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Fifth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Manufacturing Processes and Systems (MFPS.CT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=10352",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MFG",
+              "number": "100",
+              "title": "Manufacturing Safety and Workforce Readiness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "105",
+              "title": "Applied Electricity and Electronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "110",
+              "title": "Fluid Power System Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "111",
+              "title": "Mechanical System Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MFG",
+              "number": "116",
+              "title": "Automation and Motor Control Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Life Science, AS (LS.AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9583",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "General Biology I (Majors) with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Institutions of Americas category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "182",
+              "title": "General Biology II (Majors) with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "181",
+              "title": "Plane Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Written and Oral Communications category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "221",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Arts & Humanities cateogry of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "235",
+              "title": "General Organic Chemistry I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Social & Behavioral Sciences cateogry of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course with a BIO prefix within the Natural Science category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "236",
+              "title": "General Organic Chemistry II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Written and Oral Communication category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant Certificate (MDA.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9643",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisites: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HES",
+              "number": "113",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HES",
+              "number": "129",
+              "title": "Anatomy and Physiology for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEA",
+              "number": "100",
+              "title": "Medical Law and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "110",
+              "title": "Administrative Medical Assisting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "205",
+              "title": "Pathophysiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "256",
+              "title": "Medical Assisting Clinical Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HES",
+              "number": "128",
+              "title": "Pharmacology for Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "116",
+              "title": "Electronic Medical Records",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "249",
+              "title": "Medical Assisting Lab Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "257",
+              "title": "Medical Assistant Clinical Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEA",
+              "number": "258",
+              "title": "Medical Assistant Externship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "260",
+              "title": "Medical Assisting Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mathematics, AA (MATH.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9584",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Written and Oral Communications category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Institutions of Americas category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any transferrable elective within the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "181",
+              "title": "Plane Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Social & Behavioral Science category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Use available academic success resources to strengthen study strategies and time management.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Written and Oral Communication category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "221",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any transferrable elective course within the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "231",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any transferable elective course within the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "241",
+              "title": "Calculus Analytic and Geometry III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any transferable elective course within the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "260",
+              "title": "Introduction to Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any transferable elective course within the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "Medical Billing and Coding Certificate (INS.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9586",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisites: 6-7 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HES",
+              "number": "113",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HES",
+              "number": "129",
+              "title": "Anatomy and Physiology for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEA",
+              "number": "100",
+              "title": "Medical Law and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "120",
+              "title": "Introduction to Medical Insurance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "130",
+              "title": "Medical Coding I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEA",
+              "number": "116",
+              "title": "Electronic Medical Records",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "131",
+              "title": "Medical Coding II-CPT/HCPCS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "141",
+              "title": "Medical Billing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Assistant (MLA.CT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=10351",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HES",
+              "number": "113",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HES",
+              "number": "129",
+              "title": "Anatomy and Physiology for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "100",
+              "title": "Medical Law and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHB",
+              "number": "101",
+              "title": "Basic Phlebotomy Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHB",
+              "number": "102",
+              "title": "Phlebotomy Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHB",
+              "number": "201",
+              "title": "Medical Laboratory Assisting Principles and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHB",
+              "number": "202",
+              "title": "Medical Laboratory Assistant Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Support Certificate (NS.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9966",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Exploring Information and Technology Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "115",
+              "title": "A+ Computer Technology Hardware",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "116",
+              "title": "A+ Computer Technology Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "153",
+              "title": "Network Fundamentals and Infrastructure",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "154",
+              "title": "Network Services and Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "215",
+              "title": "Linux (Unix) OS Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "New Program Template",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9963",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing Assistant Program (NA.ND)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9594",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Nursing Assistant Program Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Completed Nursing Assistant Program application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAP",
+              "number": "115",
+              "title": "Nursing Assistant",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Paralegal Certificate (PLG.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9595",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "101",
+              "title": "Legal Research and Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "103",
+              "title": "Legal Ethics for Paralegals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "104",
+              "title": "Civil Law and Litigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "108",
+              "title": "Property Law and Real Estate Transactions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PAR",
+              "number": "105",
+              "title": "Contract Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "106",
+              "title": "Criminal Law and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "107",
+              "title": "Tort Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "201",
+              "title": "Legal Research and Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "206",
+              "title": "Paralegal Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing, AAS (ADN.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9593",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisites: 25 credits",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "General Biology I (Majors) with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "Microbiology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "130",
+              "title": "Fundamental Chemistry with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any 100-level Math course * or higher",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "245",
+              "title": "Lifespan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Active and unencumbered Nursing Assistant Licensure (CNA/LNA)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HPS",
+              "number": "100",
+              "title": "Career Exploration in Healthcare, Public Service, and Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPS",
+              "number": "101",
+              "title": "The Successful Healthcare Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPS",
+              "number": "102",
+              "title": "Essential Skills in Healthcare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "103",
+              "title": "Foundations of Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "126",
+              "title": "Mental Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "111",
+              "title": "Medical Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "124",
+              "title": "Pediatrics in Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "125",
+              "title": "Obstetrics in Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "212",
+              "title": "Medical Surgical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "213",
+              "title": "Medical Surgical Nursing III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "250",
+              "title": "Nursing Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Paramedic, AAS (EMS.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9598",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HES",
+              "number": "129",
+              "title": "Anatomy and Physiology for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HES",
+              "number": "113",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "100",
+              "title": "Medical Law and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Paramedic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HES",
+              "number": "128",
+              "title": "Pharmacology for Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "243",
+              "title": "Paramedic IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUT",
+              "number": "203",
+              "title": "Human Nutrition in Health and Disease",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "136",
+              "title": "Technical/Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pathway to Diagnostic Medical Sonography, AA (PDMS.AGS)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9677",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pathway to Dental Hygiene (PDAE.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9655",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements: 39 credits",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Elective Options: 21 credits",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic Certificate (EMS.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9597",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Paramedic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "242",
+              "title": "Paramedic III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "243",
+              "title": "Paramedic IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "244",
+              "title": "Paramedic V",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pathway to Nursing (PADN.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9656",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Pathway to Paramedic (PEMS.AGS)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9657",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pathway to Physical Therapist Assistant (PPTA.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9658",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pathway to Radiologic Technology (PRADT.AGS)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9659",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal, AAS (PLG.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9596",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PAR",
+              "number": "101",
+              "title": "Legal Research and Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "103",
+              "title": "Legal Ethics for Paralegals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "104",
+              "title": "Civil Law and Litigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Intermediate Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PAR",
+              "number": "105",
+              "title": "Contract Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "107",
+              "title": "Tort Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "201",
+              "title": "Legal Research and Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "136",
+              "title": "Technical/Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "138",
+              "title": "Microsoft Word",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PAR",
+              "number": "106",
+              "title": "Criminal Law and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "108",
+              "title": "Property Law and Real Estate Transactions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "202",
+              "title": "Wills, Trusts and Estates",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "131",
+              "title": "Microsoft Office",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PAR",
+              "number": "203",
+              "title": "Family Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "204",
+              "title": "Corporation Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "205",
+              "title": "Bankruptcy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAR",
+              "number": "206",
+              "title": "Paralegal Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "125",
+              "title": "Introduction to Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pathway to Substance Abuse Counseling (PSAC.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9660",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pathway to Respiratory Care Practitioner (PRCP.AGS)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9678",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pathway to Surgical Technology (PSGT.AGS)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9661",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy Certificate (MAPH.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9587",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HES",
+              "number": "129",
+              "title": "Anatomy and Physiology for Allied Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HES",
+              "number": "113",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "100",
+              "title": "Medical Law and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHB",
+              "number": "101",
+              "title": "Basic Phlebotomy Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHB",
+              "number": "102",
+              "title": "Phlebotomy Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Patisserie and Baking Certificate (CULPB.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9547",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "114",
+              "title": "Introduction to Baking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "215",
+              "title": "Art of Bread",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "216",
+              "title": "Art of Pastry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "217",
+              "title": "Art of Confections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "248",
+              "title": "Culinary Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant, AAS (PTA.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9599",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisites: 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Students may need to meet with an advisor for the multiple measure assessment to determine college-level proficiency with reading, writing and math.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "General Biology I (Majors) with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "**Notes: Students selected for the PTA program in the spring must complete BIO 181 prior to the start of the fall semester. Applicants must have an appropriate score on the placement examination or successfully completed ABE 021, TRE 089, and TRM 091 or MAT 101, and have a minimum of 2.7 cumulative GPA.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "101",
+              "title": "Survey of Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "103",
+              "title": "Kinesiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "200",
+              "title": "Patient Mobility Techniques",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "202",
+              "title": "Physical Therapy Modalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "203",
+              "title": "Clinical Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "214",
+              "title": "Electromodalities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "215",
+              "title": "Wound Care",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "206",
+              "title": "Clinical Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "217",
+              "title": "Clinical Neurology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "208",
+              "title": "Rehabilitation of Special Populations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "210",
+              "title": "Orthopedic Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "230",
+              "title": "Physical Therapy Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "280",
+              "title": "Clinical Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "290",
+              "title": "Clinical Practicum III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pipe Welding and Fabrication Certificate (WPF.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9671",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "103",
+              "title": "Welding Safety and Industry Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "104",
+              "title": "Introduction to Thermal and Mechanical Cutting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Basic Pipe Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Intermediate Pipe Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "223",
+              "title": "Advanced Pipe Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "233",
+              "title": "Pipe Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "243",
+              "title": "Pipe Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Production Welding Certificate (WPR.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9672",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "103",
+              "title": "Welding Safety and Industry Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "104",
+              "title": "Introduction to Thermal and Mechanical Cutting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "170",
+              "title": "Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "171",
+              "title": "Production 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "270",
+              "title": "Production 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "271",
+              "title": "Introduction to Aluminum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "272",
+              "title": "Production Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Practical Nursing - LPN Step-out Certificate (PNSO.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9600",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements: 32 credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "General Biology I (Majors) with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "Microbiology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "130",
+              "title": "Fundamental Chemistry with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPS",
+              "number": "100",
+              "title": "Career Exploration in Healthcare, Public Service, and Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPS",
+              "number": "101",
+              "title": "The Successful Healthcare Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPS",
+              "number": "102",
+              "title": "Essential Skills in Healthcare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any 100-level Math course * or higher",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "245",
+              "title": "Lifespan Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "103",
+              "title": "Foundations of Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "126",
+              "title": "Mental Health Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "111",
+              "title": "Medical Surgical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "124",
+              "title": "Pediatrics in Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "125",
+              "title": "Obstetrics in Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Professional Applications Certificate (CISP.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9602",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "135",
+              "title": "Microsoft Access",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "136",
+              "title": "Microsoft Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "138",
+              "title": "Microsoft Word",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "141",
+              "title": "Microsoft PowerPoint",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "142",
+              "title": "Digital Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "143",
+              "title": "Web Page Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "243",
+              "title": "Web Page Design II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Requirements: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology, AAS (RADT.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9604",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisites: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Mathematical Literacy for College Students",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "General Biology I (Majors) with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "105",
+              "title": "Fundamentals of Radiologic Technology and Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "110",
+              "title": "Radiographic Positioning I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "115",
+              "title": "Radiographic Physics and Digital Imaging I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "140",
+              "title": "Radiographic Positioning II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "165",
+              "title": "Radiographic Physics and Digital Imaging II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "169",
+              "title": "Radiography Clinical Education I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "189",
+              "title": "Radiography Clinical Education II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HES",
+              "number": "113",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "209",
+              "title": "Radiography Clinical Education III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "260",
+              "title": "Radiographic Advanced Imaging Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "215",
+              "title": "Radiation Biology and Protection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "249",
+              "title": "Radiography Clinical Education IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester: 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "275",
+              "title": "RAD Registry Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "289",
+              "title": "Radiography Clinical Education V",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Rehabilitation Technician (RT.CT)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9664",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "100",
+              "title": "Rehabilitation Aide",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "102",
+              "title": "Anatomy of the Neuromuscular and Skeletal Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "104",
+              "title": "Therapeutic Exercise",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "106",
+              "title": "Advanced Patient Care for Rehabilitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "108",
+              "title": "Rehabilitation Management Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Programming and Game Development Certificate (PGD.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9603",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose four courses from the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "125",
+              "title": "Basic Game Design and Creation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "200",
+              "title": "Programming and Game Development with Python",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "204",
+              "title": "Programming and Game Development  in C++",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "206",
+              "title": "Web Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "208",
+              "title": "Programming in C#",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Computer Science I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Residential Construction, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9964",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTR",
+              "number": "100",
+              "title": "Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTR",
+              "number": "101",
+              "title": "Safety and Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTR",
+              "number": "120",
+              "title": "Basic Residential Concrete",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTR",
+              "number": "130",
+              "title": "Basic Residential Framing 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTR",
+              "number": "131",
+              "title": "Basic Residential Framing 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTR",
+              "number": "132",
+              "title": "Residential Interior Finish",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTR",
+              "number": "140",
+              "title": "Residential Electrical Preparations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTR",
+              "number": "150",
+              "title": "Plumbing Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Confirm program requirements and course expectations with an academic advisor or success coach early in the term.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Care Practitioner, AAS (RCP.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9668",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisites: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Mathematical Literacy for College Students",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HES",
+              "number": "113",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "Microbiology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RES",
+              "number": "101",
+              "title": "Intro to Respiratory Care and Human Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "102",
+              "title": "RCP Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "103",
+              "title": "RCP Therapeutics and Equipment with Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RES",
+              "number": "104",
+              "title": "RCP Principal Applications of Mechanical Ventilation and Life Support with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "105",
+              "title": "RCP Clinical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "202",
+              "title": "RCP Perinatal / Neonatal / Pediatric",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RES",
+              "number": "201",
+              "title": "RCP Clinical II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RES",
+              "number": "203",
+              "title": "RCP Clinical III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "204",
+              "title": "RCP Transition to Professional Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RES",
+              "number": "205",
+              "title": "RCP Advanced Diagnostics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Residential Wiring Certificate (RESW.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9568",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "110",
+              "title": "Residential Wiring I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "111",
+              "title": "Residential Wiring II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "112",
+              "title": "Electrical Problem-Solving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "115",
+              "title": "AC/DC Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "121",
+              "title": "Low Voltage Control Systems I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social and Behavioral Science, AA (SOC.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9606",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "205",
+              "title": "Comparative World Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "History of the United States I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or POS 120 or any 3 credit course within the Institutions of the Americas category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "135",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "132",
+              "title": "Social Problems in Modern Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Biology Concepts with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 4 credit course within the Natural Science category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "234",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "235",
+              "title": "Statistics for Behavioral Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "270",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Race and Ethnic Relations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "245",
+              "title": "Lifespan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Introduction to Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "290",
+              "title": "Research Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any 3 credit course within the Arts and Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Options: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "100",
+              "title": "Introduction to Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "151",
+              "title": "Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "133",
+              "title": "Sociology of Deviant Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "136",
+              "title": "Marriage and Family",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WST",
+              "number": "101",
+              "title": "Introduction to Women&#039;s and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Structural Steel Welding and Fabrication Certificate (WSSF.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9673",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "103",
+              "title": "Welding Safety and Industry Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "104",
+              "title": "Introduction to Thermal and Mechanical Cutting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "123",
+              "title": "Structural Steel 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "133",
+              "title": "Structural Steel 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "210",
+              "title": "Structural Steel 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "211",
+              "title": "Structural Steel Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "212",
+              "title": "Structural Steel Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Substance Abuse Counseling Post-Degree Certificate (SACP.CT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9648",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAC",
+              "number": "101",
+              "title": "Models of Treatment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "111",
+              "title": "Psychopharmacology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAC",
+              "number": "221",
+              "title": "Cultural Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "241",
+              "title": "Disorders Co-Occurring with Substance Abuse",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAC",
+              "number": "122",
+              "title": "Ethics in Substance Abuse Treatment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "252",
+              "title": "Counseling Groups and Individuals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAC",
+              "number": "262",
+              "title": "Clinical Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "272",
+              "title": "Service Coordination",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Substance Abuse Counseling, AA (SAC.AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9629",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "131",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Biology Concepts with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "101",
+              "title": "Models of Treatment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "111",
+              "title": "Psychopharmacology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "221",
+              "title": "Cultural Diversity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "241",
+              "title": "Disorders Co-Occurring with Substance Abuse",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "120",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "122",
+              "title": "Ethics in Substance Abuse Treatment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "252",
+              "title": "Counseling Groups and Individuals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHI",
+              "number": "151",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUT",
+              "number": "203",
+              "title": "Human Nutrition in Health and Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "135",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "245",
+              "title": "Lifespan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "262",
+              "title": "Clinical Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "272",
+              "title": "Service Coordination",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology, AAS (SGT.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9608",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Prerequisite: 11",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "101",
+              "title": "Mathematical Literacy for College Students",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Anatomy and Physiology of Human Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HES",
+              "number": "113",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SGT",
+              "number": "121",
+              "title": "Orientation and  Introduction to Surgery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "122",
+              "title": "Surgical Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "Microbiology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SGT",
+              "number": "210",
+              "title": "Surgical Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "212",
+              "title": "Surgical Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "220",
+              "title": "Pharmacology for Surgical Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "221",
+              "title": "Surgical Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "231",
+              "title": "Surgical Technology Clinic I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SGT",
+              "number": "232",
+              "title": "Surgical Technology Clinic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "235",
+              "title": "Surgical Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science, AS (SC.AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9605",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "College Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "101",
+              "title": "Environmental Science with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Introduction to Astronomy with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Institutions of Americas category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review your academic plan and confirm your course sequence with advisor.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "181",
+              "title": "General Biology I (Majors) with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Begin exploring career interests or transfer options related to your program of study. (If interested in transferring to another college or organization, start reviewing requirements and opportunities.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "182",
+              "title": "General Biology II (Majors) with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "111",
+              "title": "General Physics I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Social & Behavioral Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Review progress toward graduation and confirm remaining requirements.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Written and Oral Communications category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "112",
+              "title": "General Physics II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Arts & Humanities category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course within the Social & Behavioral Sciences category of the AGEC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "211",
+              "title": "Introductory Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Notes: Submit your graduation application and verify completion of eligibility.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology, CST Pathway to AAS (SGTP.AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mohave.edu/preview_program.php?catoid=71&poid=9621",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "100",
+              "title": "Biology Concepts with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "121",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HES",
+              "number": "113",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I with Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "Microbiology with Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester: 4 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II with Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/az/programs/pima-community-college.json
+++ b/data/az/programs/pima-community-college.json
@@ -1,0 +1,13678 @@
+{
+  "college_slug": "pima-community-college",
+  "catalog_year": "2026-2027",
+  "catalog_url": "https://catalog.pima.edu",
+  "scraped_at": "2026-06-05T01:36:24.194Z",
+  "programs": [
+    {
+      "title": "Accounting, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3686",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "105",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "110",
+              "title": "Spreadsheets: Microsoft Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "200",
+              "title": "Computerized Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "204",
+              "title": "Individual Tax Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Financial Accounting [SUN# ACC 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "281",
+              "title": "QuickBooks Computer Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "205",
+              "title": "Corporate and Partnership Tax Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Managerial Accounting [SUN# ACC 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "120",
+              "title": "Business and Professional Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Tax Pathway",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "290",
+              "title": "Internship in Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "292",
+              "title": "Volunteer Income Tax Preparation Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Bookkeeping Pathway",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "273",
+              "title": "Governmental and Nonprofit Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "290",
+              "title": "Internship in Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "292",
+              "title": "Volunteer Income Tax Preparation Field Experience",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "233",
+              "title": "Cost Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Bookkeeping Pathway",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "250",
+              "title": "Certified Bookkeeper",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Select one course below:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "270",
+              "title": "Current Topics in Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "290",
+              "title": "Internship in Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Tax Pathway",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "206",
+              "title": "Topics in Tax Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "207",
+              "title": "IRS Enrolled Agent Exam",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 61 Credits",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Aircraft General Mechanics Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3693",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "103",
+              "title": "Applied Technical Mathematics for Aviation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "110",
+              "title": "Aircraft Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "114",
+              "title": "Regulatory Requirements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "202",
+              "title": "Aviation Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "205",
+              "title": "Motion Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "206",
+              "title": "Materials and Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "207",
+              "title": "Weight and Balance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "208",
+              "title": "Basic Electricity",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Support Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 21 Credits",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aircraft Structural Repair Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3696",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STR",
+              "number": "106",
+              "title": "Advanced Aircraft Sheet Metal Repair I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STR",
+              "number": "260",
+              "title": "Advanced Aircraft Composite Repair I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STR",
+              "number": "150",
+              "title": "Advanced Aircraft Sheet Metal Repair II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STR",
+              "number": "262",
+              "title": "Advanced Aircraft Composite Repair II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "STR",
+              "number": "151",
+              "title": "Advanced Aircraft Sheet Metal Repair III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STR",
+              "number": "264",
+              "title": "Advanced Aircraft Composite Repair III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aircraft Airframe and Powerplant Mechanics Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3695",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "202",
+              "title": "Aviation Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "205",
+              "title": "Motion Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "103",
+              "title": "Applied Technical Mathematics for Aviation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "114",
+              "title": "Regulatory Requirements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "206",
+              "title": "Materials and Processes",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "110",
+              "title": "Aircraft Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "207",
+              "title": "Weight and Balance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "208",
+              "title": "Basic Electricity",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "105",
+              "title": "Aircraft Sheet Metal Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "219",
+              "title": "Airframe Inspections",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "224",
+              "title": "Atmospheric Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "209",
+              "title": "Intermediate Electricity",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "130",
+              "title": "Aircraft Composite Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "225",
+              "title": "Fire, Ice, Rain, and Fuel Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "211",
+              "title": "Alternate Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "218",
+              "title": "Airframe Rigging and Landing Gear Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "226",
+              "title": "Engine Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "234",
+              "title": "Engine Fuel Metering and Operation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "228",
+              "title": "Aircraft Propellers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "232",
+              "title": "Reciprocating Engine Overhaul",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "229",
+              "title": "Engine Support Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "233",
+              "title": "Turbine Engines",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 58 Credits",
+          "credits_required": 58,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting, Bookkeeping Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3685",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "105",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "110",
+              "title": "Spreadsheets: Microsoft Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "200",
+              "title": "Computerized Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "204",
+              "title": "Individual Tax Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Financial Accounting [SUN# ACC 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "281",
+              "title": "QuickBooks Computer Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 31 Credits",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Arizona General Education Curriculum",
+      "credential": "other",
+      "program_code": "AGEC",
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3789",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Written and Oral Communication: 6-10 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WRT",
+              "number": "101",
+              "title": "English Composition I [SUN# ENG 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WRT",
+              "number": "101S",
+              "title": "English Composition I / Integrated Studio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WRT",
+              "number": "102",
+              "title": "English Composition II [SUN# ENG 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARB",
+              "number": "101",
+              "title": "Elementary Modern Standard Arabic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARB",
+              "number": "102",
+              "title": "Elementary Modern Standard Arabic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "201",
+              "title": "American Sign Language III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "202",
+              "title": "American Sign Language IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHI",
+              "number": "101",
+              "title": "Elementary Chinese (Mandarin) I [SUN# CHI 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHI",
+              "number": "102",
+              "title": "Elementary Chinese (Mandarin) II [SUN# CHI 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "102",
+              "title": "Introduction to Communication [SUN# COM 1100]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "110",
+              "title": "Public Speaking and Presentations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "120",
+              "title": "Business and Professional Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "130",
+              "title": "Teamwork and Leadership in Small Groups [SUN# COM 2271]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "140",
+              "title": "Interpersonal Communication [SUN# COM 1110]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "200",
+              "title": "Intercultural Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "101",
+              "title": "Elementary French I [SUN# FRE 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "102",
+              "title": "Elementary French II [SUN# FRE 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "201",
+              "title": "Intermediate French I [SUN# FRE 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "202",
+              "title": "Intermediate French II [SUN# FRE 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "101",
+              "title": "Elementary German I [SUN# GER 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "102",
+              "title": "Elementary German II [SUN# GER 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "201",
+              "title": "Intermediate German I [SUN# GER 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "202",
+              "title": "Intermediate German II [SUN# GER 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "101",
+              "title": "Elementary Japanese I [SUN# JPN 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "102",
+              "title": "Elementary Japanese II [SUN# JPN 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "201",
+              "title": "Intermediate Japanese I [SUN# JPN 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "202",
+              "title": "Intermediate Japanese II [SUN# JPN 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KOR",
+              "number": "101",
+              "title": "Elementary Korean I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KOR",
+              "number": "102",
+              "title": "Elementary Korean II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Elementary Spanish I [SUN# SPA 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "102",
+              "title": "Elementary Spanish II [SUN# SPA 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "103",
+              "title": "Beginning Spanish for Heritage and Bilingual Learners",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "201",
+              "title": "Intermediate Spanish I [SUN# SPA 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "202",
+              "title": "Intermediate Spanish II [SUN# SPA 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "203",
+              "title": "Writing &amp; Oral Skills for Heritage &amp; Bilingual Learners",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "253",
+              "title": "Intermediate Spanish for Heritage and Bilingual Learners",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "YAQ",
+              "number": "101",
+              "title": "Elementary Yaqui I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "YAQ",
+              "number": "102",
+              "title": "Elementary Yaqui II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Arts and Humanities: 6-9 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "112",
+              "title": "Exploring Non-Western Cultures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "202",
+              "title": "Sexuality, Gender and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Basic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "Exploring Art and Visual Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Survey of Painting Materials and Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I [SUN# ART 1111]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Color and Composition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "120",
+              "title": "3D Design [SUN# ART 1115]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "Art and Culture: Prehistoric through Gothic [SUN# ART 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Art and Culture: Late Gothic through Modern Periods [SUN# ART 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Biomedical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "250",
+              "title": "Computer 2D Animation: Adobe After Effects",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "251",
+              "title": "Computer 3D Animation: Maya",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "252",
+              "title": "Interactive Design I: UX/UI Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "108",
+              "title": "Literature/Social Studies for Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FDC",
+              "number": "132",
+              "title": "Global Fashion and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FDC",
+              "number": "141",
+              "title": "Introduction to Fashion Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "202",
+              "title": "Sexuality, Gender and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Introduction to Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Introduction to Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "103",
+              "title": "World History Before 1500 [SUN# HIS 1100]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "World History After 1500 [SUN# HIS 1111]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "113",
+              "title": "Chinese Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "114",
+              "title": "Japanese Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "141",
+              "title": "History of the United States I [SUN# HIS 1131]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "142",
+              "title": "History of the United States II [SUN# HIS 1132]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "147",
+              "title": "History of Arizona",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "160",
+              "title": "Latin America Before Independence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "161",
+              "title": "Modern Latin America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "274",
+              "title": "The Holocaust",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "251",
+              "title": "Western Humanities I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "253",
+              "title": "Western Humanities III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "260",
+              "title": "Intercultural Perspectives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "224",
+              "title": "Southwestern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "225",
+              "title": "Science Fiction Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "227",
+              "title": "Literature and the Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "231",
+              "title": "Introduction to Shakespeare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "261",
+              "title": "Modern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "265",
+              "title": "Major American Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "280",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "165",
+              "title": "Mexican American Culture, Community and Identity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "219",
+              "title": "Mexican American Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102",
+              "title": "Music Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "109",
+              "title": "Pima Jazz Band II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "111",
+              "title": "Exploring Music through Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "125",
+              "title": "Structure of Music I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "127",
+              "title": "Aural Perception I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "Exploring Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "160",
+              "title": "Popular Music in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "201",
+              "title": "History and Literature of Music I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "202",
+              "title": "History and Literature of Music II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy [SUN# PHI 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "122",
+              "title": "God, Mind, and Matter",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "130",
+              "title": "Introductory Studies in Ethics and Social Philosophy [SUN# PHI 1105]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "140",
+              "title": "Philosophy of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "151",
+              "title": "Wisdom of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "246",
+              "title": "Existential Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "130",
+              "title": "Asian Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "140",
+              "title": "Philosophy of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "200",
+              "title": "Religion in Popular Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "220",
+              "title": "Old Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "221",
+              "title": "New Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "184",
+              "title": "Introductory Ethics: A Social Services Perspective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "105",
+              "title": "Theater Appreciation [SUN# THE 1100]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WRT",
+              "number": "205",
+              "title": "Introduction to Poetry Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WRT",
+              "number": "206",
+              "title": "Short Story Writing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative Reasoning: 3-4 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Statistical Methods in Economics and Business [SUN# BUS 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "Topics in College Mathematics [SUN# MAT 1142]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "College Algebra [SUN# MAT 1151]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "167",
+              "title": "Introductory Statistics [SUN# MAT 1160]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Finite Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "187",
+              "title": "Precalculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "189",
+              "title": "Trigonometry [SUN# MAT 1187]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "212",
+              "title": "Topics in Calculus [SUN# MAT 2212]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus I [SUN# MAT 2220]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "227",
+              "title": "Discrete Mathematics in Computer Science [SUN# MAT 2227]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "231",
+              "title": "Calculus II [SUN# MAT 2230]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "241",
+              "title": "Calculus III [SUN# MAT 2241]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "252",
+              "title": "Introduction to Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "262",
+              "title": "Differential Equations [SUN# MAT 2262]",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences: 4-8 Credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSN",
+              "number": "154",
+              "title": "Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences: 6-9 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AFA",
+              "number": "120",
+              "title": "The African American Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "101",
+              "title": "Introduction to American Indian Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "101",
+              "title": "Human Origins and Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "102",
+              "title": "Introduction to Cultural Anthropology and Linguistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "110",
+              "title": "Buried Cities and Lost Tribes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "112",
+              "title": "Exploring Non-Western Cultures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "202",
+              "title": "Sexuality, Gender and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "210",
+              "title": "Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "101",
+              "title": "Human Origins and Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "110",
+              "title": "Buried Cities and Lost Tribes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "107",
+              "title": "Human Development and Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "117",
+              "title": "Child Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "150",
+              "title": "An Economic Perspective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "201",
+              "title": "Microeconomic Principles [SUN# ECN 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "202",
+              "title": "Macroeconomic Principles [SUN# ECN 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Diversity in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "103",
+              "title": "Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "104",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "105",
+              "title": "Climate Change",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLS",
+              "number": "110",
+              "title": "Introduction to Cities and Global Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "100",
+              "title": "Introduction to Feminist Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "201",
+              "title": "La Chicana",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "202",
+              "title": "Sexuality, Gender and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Introduction to Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Introduction to Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "103",
+              "title": "World History Before 1500 [SUN# HIS 1100]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "World History After 1500 [SUN# HIS 1111]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "113",
+              "title": "Chinese Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "114",
+              "title": "Japanese Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "141",
+              "title": "History of the United States I [SUN# HIS 1131]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "142",
+              "title": "History of the United States II [SUN# HIS 1132]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "147",
+              "title": "History of Arizona",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "160",
+              "title": "Latin America Before Independence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "161",
+              "title": "Modern Latin America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "254",
+              "title": "History of Women in the United States: The 20th Century",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "274",
+              "title": "The Holocaust",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "260",
+              "title": "Intercultural Perspectives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JRN",
+              "number": "102",
+              "title": "Survey of Media Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIS",
+              "number": "150",
+              "title": "Social Media and Ourselves",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIS",
+              "number": "210",
+              "title": "Hacking and Open Source Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIS",
+              "number": "260",
+              "title": "Learning in the Information Age",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "165",
+              "title": "Mexican American Culture, Community and Identity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "201",
+              "title": "La Chicana",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "219",
+              "title": "Mexican American Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "151",
+              "title": "Wisdom of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "100",
+              "title": "Introduction to Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "201",
+              "title": "American National Government and Politics [SUN# POS 1110]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "202",
+              "title": "Introduction to International Relations [SUN# POS 1120]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "203",
+              "title": "Introduction to Political Ideas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "204",
+              "title": "Introduction to Comparative Politics [SUN# POS 2204]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "210",
+              "title": "National and State Constitutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "240",
+              "title": "Understanding Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology [SUN# PSY 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "132",
+              "title": "Psychology and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "216",
+              "title": "Psychology of Gender",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "218",
+              "title": "Health Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "200",
+              "title": "Religion in Popular Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "220",
+              "title": "Old Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "221",
+              "title": "New Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology [SUN# SOC 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "110",
+              "title": "Introduction to Cities and Global Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "120",
+              "title": "Current Social Problems [SUN# SOC 2250]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "127",
+              "title": "Relationships, Families and Marriage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Race, Ethnicity, Minority Groups and Social Justice [SUN# SOC 2215]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "204",
+              "title": "Gender Identities, Interactions and Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "215",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "110",
+              "title": "Introduction to Social Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "182",
+              "title": "A Social Services Perspective of Government",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Institutions in the Americas: 3 Credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AFA",
+              "number": "120",
+              "title": "The African American Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFA",
+              "number": "130",
+              "title": "The African Diaspora",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "101",
+              "title": "Introduction to American Indian Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "148",
+              "title": "Ethics in the Workplace",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAS",
+              "number": "110",
+              "title": "Food, People and the Planet",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "105",
+              "title": "Climate Change",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "100",
+              "title": "Introduction to Feminist Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "201",
+              "title": "La Chicana",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "141",
+              "title": "History of the United States I [SUN# HIS 1131]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "142",
+              "title": "History of the United States II [SUN# HIS 1132]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "147",
+              "title": "History of Arizona",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "160",
+              "title": "Latin America Before Independence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "161",
+              "title": "Modern Latin America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "254",
+              "title": "History of Women in the United States: The 20th Century",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "224",
+              "title": "Southwestern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "227",
+              "title": "Literature and the Environment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "265",
+              "title": "Major American Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "165",
+              "title": "Mexican American Culture, Community and Identity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "201",
+              "title": "La Chicana",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "219",
+              "title": "Mexican American Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "100",
+              "title": "Introduction to Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "201",
+              "title": "American National Government and Politics [SUN# POS 1110]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "202",
+              "title": "Introduction to International Relations [SUN# POS 1120]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "203",
+              "title": "Introduction to Political Ideas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "204",
+              "title": "Introduction to Comparative Politics [SUN# POS 2204]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "210",
+              "title": "National and State Constitutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology [SUN# SOC 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "120",
+              "title": "Current Social Problems [SUN# SOC 2250]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "127",
+              "title": "Relationships, Families and Marriage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Race, Ethnicity, Minority Groups and Social Justice [SUN# SOC 2215]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "204",
+              "title": "Gender Identities, Interactions and Relations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AGEC Total: 32-35 Credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aircraft Avionics Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3697",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATT",
+              "number": "110",
+              "title": "Introduction to Avionics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "111",
+              "title": "Avionics Installer",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATT",
+              "number": "112",
+              "title": "Airframe and Instrument Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "113",
+              "title": "Communications Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Five Weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATT",
+              "number": "210",
+              "title": "Dependent Navigation Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATT",
+              "number": "214",
+              "title": "Application of Avionics System Knowledge",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 28 Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automated Industrial Technology Level I Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3689",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIT",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "105",
+              "title": "Modern Maintenance Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "110",
+              "title": "Mechanical Power Transmission Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "115",
+              "title": "Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "120",
+              "title": "Pneumatic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "125",
+              "title": "DC and AC Components",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automated Industrial Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3688",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIT",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "105",
+              "title": "Modern Maintenance Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "110",
+              "title": "Mechanical Power Transmission Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "115",
+              "title": "Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "120",
+              "title": "Pneumatic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "125",
+              "title": "DC and AC Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIT",
+              "number": "205",
+              "title": "Power Electronics and Variable Frequency Drives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "210",
+              "title": "Programmable Logic Controller Programming and Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "215",
+              "title": "Process Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "225",
+              "title": "Industrial Motors and Motor Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "270",
+              "title": "Robotics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 60 Credits",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automated Industrial Technology Level II Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3690",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIT",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "105",
+              "title": "Modern Maintenance Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "110",
+              "title": "Mechanical Power Transmission Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "115",
+              "title": "Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "120",
+              "title": "Pneumatic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "125",
+              "title": "DC and AC Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIT",
+              "number": "205",
+              "title": "Power Electronics and Variable Frequency Drives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "210",
+              "title": "Programmable Logic Controller Programming and Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "215",
+              "title": "Process Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "225",
+              "title": "Industrial Motors and Motor Controls",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "270",
+              "title": "Robotics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 32 Credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Mechanics Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3691",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Small Engine Troubleshoot and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "101",
+              "title": "Automotive Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "105",
+              "title": "Light Line Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "128",
+              "title": "Automotive Electrical Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "120",
+              "title": "Engine Diagnosis and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "139",
+              "title": "Automotive Steering and Suspension Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Automotive Brakes Diagnosis and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Automotive Heating, Ventilation, and Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 25 Credits",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Trades I",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3806",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Small Engine Troubleshoot and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "120",
+              "title": "Engine Diagnosis and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GTC",
+              "number": "145",
+              "title": "Introduction to Automotive Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 7.5 Credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3692",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Small Engine Troubleshoot and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "101",
+              "title": "Automotive Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "105",
+              "title": "Light Line Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "120",
+              "title": "Engine Diagnosis and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "128",
+              "title": "Automotive Electrical Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "139",
+              "title": "Automotive Steering and Suspension Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "140",
+              "title": "Automotive Brakes Diagnosis and Repair",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "122",
+              "title": "Engine Remove and Install",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "124",
+              "title": "Diesel, Hybrid, and Electric Vehicles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "129",
+              "title": "Automotive Electrical Accessories",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "126",
+              "title": "Engine Performance and Driveability Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "132",
+              "title": "Automotive Drivetrain Removal and Replacement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "133",
+              "title": "Automatic Transmission/Transaxle Service and Rebuilding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "136",
+              "title": "Automotive Manual Transmission and Driveline Service",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Automotive Heating, Ventilation, and Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 61 Credits",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive, Ford ASSET, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3814",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AFM",
+              "number": "101",
+              "title": "Noise, Vibration and Harshness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFM",
+              "number": "161",
+              "title": "Automotive Electrical Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFM",
+              "number": "191",
+              "title": "Dealership Work Experience I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AFM",
+              "number": "141",
+              "title": "Steering &amp; Suspension Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFM",
+              "number": "151",
+              "title": "Automotive Braking and Vehicle Dynamic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFM",
+              "number": "162",
+              "title": "Electronic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFM",
+              "number": "192",
+              "title": "Dealership Work Experience II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AFM",
+              "number": "111",
+              "title": "Internal Combustion Engines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFM",
+              "number": "171",
+              "title": "Climate Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AFM",
+              "number": "281",
+              "title": "Gasoline Engine Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFM",
+              "number": "291",
+              "title": "Dealership Work Experience III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AFM",
+              "number": "221",
+              "title": "Automatic Transmissions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFM",
+              "number": "231",
+              "title": "Manual Transmission and Drivelines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFM",
+              "number": "292",
+              "title": "Dealership Work Experience IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 72 Credits",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Autonomous Vehicle Driver & Operations Specialist Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3777",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIT",
+              "number": "100",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "125",
+              "title": "DC and AC Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUV",
+              "number": "101",
+              "title": "Introduction to Autonomous Vehicles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "136",
+              "title": "Computer Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGM",
+              "number": "106",
+              "title": "Transportation and Traffic Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Trades III",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3808",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Small Engine Troubleshoot and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "120",
+              "title": "Engine Diagnosis and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "128",
+              "title": "Automotive Electrical Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GTC",
+              "number": "143",
+              "title": "Suspension, Steering, and Brakes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GTC",
+              "number": "144",
+              "title": "Vehicle HVAC Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GTC",
+              "number": "145",
+              "title": "Introduction to Automotive Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GTC",
+              "number": "240",
+              "title": "Engine Repairs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GTC",
+              "number": "241",
+              "title": "Advanced Driveability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GTC",
+              "number": "244",
+              "title": "Electrical Accessories",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 28.5 Credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Trades II",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3807",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Small Engine Troubleshoot and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "120",
+              "title": "Engine Diagnosis and Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "128",
+              "title": "Automotive Electrical Fundamentals and Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GTC",
+              "number": "143",
+              "title": "Suspension, Steering, and Brakes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GTC",
+              "number": "144",
+              "title": "Vehicle HVAC Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GTC",
+              "number": "145",
+              "title": "Introduction to Automotive Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 16.5 Credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3816",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "114",
+              "title": "Regulatory Requirements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "202",
+              "title": "Aviation Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "205",
+              "title": "Motion Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "206",
+              "title": "Materials and Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "207",
+              "title": "Weight and Balance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "110",
+              "title": "Aircraft Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "208",
+              "title": "Basic Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "209",
+              "title": "Intermediate Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "211",
+              "title": "Alternate Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "218",
+              "title": "Airframe Rigging and Landing Gear Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "224",
+              "title": "Atmospheric Controls",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "105",
+              "title": "Aircraft Sheet Metal Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "130",
+              "title": "Aircraft Composite Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "219",
+              "title": "Airframe Inspections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "225",
+              "title": "Fire, Ice, Rain, and Fuel Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVM",
+              "number": "226",
+              "title": "Engine Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "228",
+              "title": "Aircraft Propellers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "229",
+              "title": "Engine Support Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "232",
+              "title": "Reciprocating Engine Overhaul",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "233",
+              "title": "Turbine Engines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "234",
+              "title": "Engine Fuel Metering and Operation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total Program Credits: 70 Credits",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Business Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3704",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "104",
+              "title": "Computer Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "110",
+              "title": "Human Relations in Business and Industry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Financial Accounting [SUN# ACC 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "148",
+              "title": "Ethics in the Workplace",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "200",
+              "title": "Small Business Management/Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "111",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Building Trades II - Construction",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3798",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "145",
+              "title": "Carpentry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "172",
+              "title": "Electrical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "181",
+              "title": "Residential and Industrial Plumbing I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 21-22 Credits",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building and Construction Technologies, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3698",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "265",
+              "title": "Sustainability for Building Trades",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "286",
+              "title": "International Residential Code (IRC) I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "151",
+              "title": "Computer-Aided Drafting for Construction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "287",
+              "title": "International Residential Code (IRC) II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "166",
+              "title": "Introduction to Revit",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "290",
+              "title": "Building and Construction Technologies Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "184",
+              "title": "National Electrical Code I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "271",
+              "title": "Electrical IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "272",
+              "title": "Electrical V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "273",
+              "title": "Electrical VI",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "284",
+              "title": "National Electrical Code II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "290",
+              "title": "Building and Construction Technologies Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "231",
+              "title": "Residential and Industrial HVAC IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "232",
+              "title": "Residential and Industrial HVAC V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "265",
+              "title": "Sustainability for Building Trades",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "233",
+              "title": "Residential and Industrial HVAC VI",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "234",
+              "title": "Residential and Industrial HVAC VII",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "290",
+              "title": "Building and Construction Technologies Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "236",
+              "title": "Residential and Industrial Plumbing IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "237",
+              "title": "Residential and Industrial Plumbing V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "265",
+              "title": "Sustainability for Building Trades",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "238",
+              "title": "Residential and Industrial Plumbing VI",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "239",
+              "title": "Residential and Industrial Plumbing VII",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "290",
+              "title": "Building and Construction Technologies Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "105",
+              "title": "Survey of Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "110",
+              "title": "Human Relations in Business and Industry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "202",
+              "title": "Construction Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "265",
+              "title": "Sustainability for Building Trades",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "290",
+              "title": "Building and Construction Technologies Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 61-65 Credits",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Trades II - Electrical",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3800",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "172",
+              "title": "Electrical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "173",
+              "title": "Electrical II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 20-22 Credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Trades I",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3797",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 9-10 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Trades II - HVAC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3802",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "132",
+              "title": "Residential and Industrial HVAC I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "133",
+              "title": "Residential and Industrial HVAC II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "134",
+              "title": "Residential and Industrial HVAC III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 21-22 Credits",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Trades II - Plumbing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3804",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "106",
+              "title": "Soldering and Brazing for BCT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "181",
+              "title": "Residential and Industrial Plumbing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "182",
+              "title": "Residential and Industrial Plumbing II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 21-22 Credits",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Trades III - Construction",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3799",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "145",
+              "title": "Carpentry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "172",
+              "title": "Electrical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "181",
+              "title": "Residential and Industrial Plumbing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "202",
+              "title": "Construction Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "BCT Elective** - 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 27-28 Credits",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Trades III - Plumbing",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3805",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "106",
+              "title": "Soldering and Brazing for BCT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "181",
+              "title": "Residential and Industrial Plumbing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "182",
+              "title": "Residential and Industrial Plumbing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "202",
+              "title": "Construction Business Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 27-28 Credits",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Trades III - HVAC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3803",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "106",
+              "title": "Soldering and Brazing for BCT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "132",
+              "title": "Residential and Industrial HVAC I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "133",
+              "title": "Residential and Industrial HVAC II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "134",
+              "title": "Residential and Industrial HVAC III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "231",
+              "title": "Residential and Industrial HVAC IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 29 Credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Trades III - Electrical",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3801",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "135",
+              "title": "National Electrical Code Residential Wiring Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "172",
+              "title": "Electrical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "173",
+              "title": "Electrical II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "202",
+              "title": "Construction Business Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 27-28 Credits",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration, ABUS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3706",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Total: 60-64 Credits",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3705",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "104",
+              "title": "Computer Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "110",
+              "title": "Human Relations in Business and Industry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Financial Accounting [SUN# ACC 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "148",
+              "title": "Ethics in the Workplace",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "200",
+              "title": "Small Business Management/Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "111",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Managerial Accounting [SUN# ACC 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "eCommerce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "220",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "200",
+              "title": "Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGT",
+              "number": "270",
+              "title": "Computer Applications for Managers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "276",
+              "title": "Human Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "280",
+              "title": "Business Organization and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Complete one of the following electives (3 credits)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "290",
+              "title": "Internship in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "202",
+              "title": "Macroeconomic Principles [SUN# ECN 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "230",
+              "title": "Dynamics of Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "200",
+              "title": "Advertising",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 60 Credits",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Basics II",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3809",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "110",
+              "title": "Human Relations in Business and Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "200",
+              "title": "Small Business Management/Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Carpenter Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3700",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "120",
+              "title": "Blueprint Reading for Construction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "123",
+              "title": "Concrete/Masonry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "145",
+              "title": "Carpentry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "100",
+              "title": "Computer Literacy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "146",
+              "title": "Woodworking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "147",
+              "title": "Woodworking II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 32-33 Credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cabinetmaker Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3699",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "120",
+              "title": "Blueprint Reading for Construction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "146",
+              "title": "Woodworking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "147",
+              "title": "Woodworking II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "151",
+              "title": "Computer-Aided Drafting for Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "100",
+              "title": "Computer Literacy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "148",
+              "title": "Cabinetmaking I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "149",
+              "title": "Cabinetmaking II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 32-33 Credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Class A Vehicle Driver Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3761",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TDT",
+              "number": "118",
+              "title": "Basic Vehicle Operations and Commercial Driver&#039;s License Req",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDT",
+              "number": "119",
+              "title": "Basic Driving Maneuvers-Class A CDL",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 8.5 Credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Class B Commercial Driver’s License Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3762",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TDT",
+              "number": "116",
+              "title": "Basic Vehicle Operations – Class B Commercial Driver&#039;s License",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDT",
+              "number": "117",
+              "title": "Basic Driving Maneuvers – Class B Commercial Driver&#039;s License",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 6 Credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Clinical Research Coordinator, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3707",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRC",
+              "number": "100",
+              "title": "Leadership for Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRP",
+              "number": "100",
+              "title": "Success in Health Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRP",
+              "number": "101",
+              "title": "Medical Terminology for Health Professions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRC",
+              "number": "151",
+              "title": "Introduction to Clinical Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRP",
+              "number": "103",
+              "title": "Basic Health Professions Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRP",
+              "number": "105",
+              "title": "Introduction to Health Professions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRC",
+              "number": "201",
+              "title": "Clinical Research Regulatory Compliance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRC",
+              "number": "202",
+              "title": "Investigational Product Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRC",
+              "number": "230",
+              "title": "Clinical Research Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRC",
+              "number": "240",
+              "title": "Pharmacology for Clinical Trials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRC",
+              "number": "245",
+              "title": "Data Management and Informatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRC",
+              "number": "255",
+              "title": "Study and Site Coordination",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRC",
+              "number": "273",
+              "title": "Clinical Trial Operations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Clinical Research Professional, Post Degree Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3791",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRC",
+              "number": "100",
+              "title": "Leadership for Health Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRC",
+              "number": "151",
+              "title": "Introduction to Clinical Research",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRC",
+              "number": "201",
+              "title": "Clinical Research Regulatory Compliance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRC",
+              "number": "202",
+              "title": "Investigational Product Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRC",
+              "number": "230",
+              "title": "Clinical Research Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRC",
+              "number": "245",
+              "title": "Data Management and Informatics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRC",
+              "number": "255",
+              "title": "Study and Site Coordination",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRC",
+              "number": "273",
+              "title": "Clinical Trial Operations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer-Aided Design, Parametric Modeler Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3810",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Total: 44 Credits",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Numerical Control (CNC) Operator Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3745",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "117",
+              "title": "Print Reading with CAD for Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "100",
+              "title": "Introduction to Machine Tool",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "172",
+              "title": "Geometric Dimensioning and Tolerancing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "125",
+              "title": "Inspection Quality Assurance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "150",
+              "title": "Introduction to Computer Numerical Control (CNC) Operations (Mill and Lathe)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "155",
+              "title": "Computer Numerical Control (CNC) Mill Programming II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "160",
+              "title": "Computer Numerical Control (CNC) Lathe Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 29 Credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer-Aided Design, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3811",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Contemporary Global/International Awareness or Historical Awareness",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3788",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AFA",
+              "number": "130",
+              "title": "The African Diaspora",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "101",
+              "title": "Introduction to American Indian Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "102",
+              "title": "Introduction to Cultural Anthropology and Linguistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "110",
+              "title": "Buried Cities and Lost Tribes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "112",
+              "title": "Exploring Non-Western Cultures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "202",
+              "title": "Sexuality, Gender and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "210",
+              "title": "Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "110",
+              "title": "Buried Cities and Lost Tribes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "Exploring Art and Visual Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "Art and Culture: Prehistoric through Gothic [SUN# ART 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Art and Culture: Late Gothic through Modern Periods [SUN# ART 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Biomedical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAS",
+              "number": "120",
+              "title": "Systems, Logic &amp; Sustainability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "102",
+              "title": "Introduction to Communication [SUN# COM 1100]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "110",
+              "title": "Public Speaking and Presentations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "120",
+              "title": "Business and Professional Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "150",
+              "title": "An Economic Perspective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "201",
+              "title": "Intermediate French I [SUN# FRE 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "202",
+              "title": "Intermediate French II [SUN# FRE 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "103",
+              "title": "Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "104",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "201",
+              "title": "Intermediate German I [SUN# GER 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "202",
+              "title": "Intermediate German II [SUN# GER 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLS",
+              "number": "110",
+              "title": "Introduction to Cities and Global Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "202",
+              "title": "Sexuality, Gender and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Introduction to Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Introduction to Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "103",
+              "title": "World History Before 1500 [SUN# HIS 1100]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "World History After 1500 [SUN# HIS 1111]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "113",
+              "title": "Chinese Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "114",
+              "title": "Japanese Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "141",
+              "title": "History of the United States I [SUN# HIS 1131]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "142",
+              "title": "History of the United States II [SUN# HIS 1132]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "147",
+              "title": "History of Arizona",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "160",
+              "title": "Latin America Before Independence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "161",
+              "title": "Modern Latin America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "274",
+              "title": "The Holocaust",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "251",
+              "title": "Western Humanities I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "253",
+              "title": "Western Humanities III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "201",
+              "title": "Intermediate Japanese I [SUN# JPN 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "202",
+              "title": "Intermediate Japanese II [SUN# JPN 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JRN",
+              "number": "102",
+              "title": "Survey of Media Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "261",
+              "title": "Modern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "280",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "165",
+              "title": "Mexican American Culture, Community and Identity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "219",
+              "title": "Mexican American Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "201",
+              "title": "History and Literature of Music I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "202",
+              "title": "History and Literature of Music II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "100",
+              "title": "Introduction to Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "202",
+              "title": "Introduction to International Relations [SUN# POS 1120]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "204",
+              "title": "Introduction to Comparative Politics [SUN# POS 2204]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "240",
+              "title": "Understanding Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "132",
+              "title": "Psychology and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "130",
+              "title": "Asian Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "110",
+              "title": "Introduction to Cities and Global Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "120",
+              "title": "Current Social Problems [SUN# SOC 2250]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Race, Ethnicity, Minority Groups and Social Justice [SUN# SOC 2215]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "215",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "103",
+              "title": "Beginning Spanish for Heritage and Bilingual Learners",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "201",
+              "title": "Intermediate Spanish I [SUN# SPA 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "202",
+              "title": "Intermediate Spanish II [SUN# SPA 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "203",
+              "title": "Writing &amp; Oral Skills for Heritage &amp; Bilingual Learners",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "253",
+              "title": "Intermediate Spanish for Heritage and Bilingual Learners",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer-Aided Design, Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3812",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Total: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CTE - Arts & Humanities",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3784",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fine Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Basic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "Exploring Art and Visual Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Survey of Painting Materials and Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I [SUN# ART 1111]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Color and Composition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "120",
+              "title": "3D Design [SUN# ART 1115]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "250",
+              "title": "Computer 2D Animation: Adobe After Effects",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "251",
+              "title": "Computer 3D Animation: Maya",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "252",
+              "title": "Interactive Design I: UX/UI Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FDC",
+              "number": "132",
+              "title": "Global Fashion and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FDC",
+              "number": "141",
+              "title": "Introduction to Fashion Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102",
+              "title": "Music Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "108",
+              "title": "Pima Jazz Band I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "109",
+              "title": "Pima Jazz Band II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "111",
+              "title": "Exploring Music through Piano",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "116",
+              "title": "Pima Community College Orchestra I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "117",
+              "title": "Pima Community College Orchestra II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "120",
+              "title": "Concert Band I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Concert Band II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "125",
+              "title": "Structure of Music I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "127",
+              "title": "Aural Perception I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "130",
+              "title": "Chorale (SATB)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "College Singers (SATB)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "Exploring Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "160",
+              "title": "Popular Music in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "105",
+              "title": "Theater Appreciation [SUN# THE 1100]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WRT",
+              "number": "205",
+              "title": "Introduction to Poetry Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WRT",
+              "number": "206",
+              "title": "Short Story Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFA",
+              "number": "130",
+              "title": "The African Diaspora",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "112",
+              "title": "Exploring Non-Western Cultures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "Art and Culture: Prehistoric through Gothic [SUN# ART 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Art and Culture: Late Gothic through Modern Periods [SUN# ART 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Biomedical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "108",
+              "title": "Literature/Social Studies for Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "100",
+              "title": "Introduction to Feminist Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "201",
+              "title": "La Chicana",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Introduction to Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Introduction to Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "103",
+              "title": "World History Before 1500 [SUN# HIS 1100]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "World History After 1500 [SUN# HIS 1111]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "113",
+              "title": "Chinese Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "114",
+              "title": "Japanese Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "141",
+              "title": "History of the United States I [SUN# HIS 1131]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "142",
+              "title": "History of the United States II [SUN# HIS 1132]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "160",
+              "title": "Latin America Before Independence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "161",
+              "title": "Modern Latin America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "274",
+              "title": "The Holocaust",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "251",
+              "title": "Western Humanities I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "253",
+              "title": "Western Humanities III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "260",
+              "title": "Intercultural Perspectives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "224",
+              "title": "Southwestern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "225",
+              "title": "Science Fiction Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "231",
+              "title": "Introduction to Shakespeare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "261",
+              "title": "Modern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "265",
+              "title": "Major American Writers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "280",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "289",
+              "title": "Literature and Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "201",
+              "title": "La Chicana",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "201",
+              "title": "History and Literature of Music I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "202",
+              "title": "History and Literature of Music II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy [SUN# PHI 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "122",
+              "title": "God, Mind, and Matter",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "130",
+              "title": "Introductory Studies in Ethics and Social Philosophy [SUN# PHI 1105]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "140",
+              "title": "Philosophy of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "130",
+              "title": "Asian Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "140",
+              "title": "Philosophy of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "200",
+              "title": "Religion in Popular Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "220",
+              "title": "Old Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "221",
+              "title": "New Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "184",
+              "title": "Introductory Ethics: A Social Services Perspective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "World Languages",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARB",
+              "number": "101",
+              "title": "Elementary Modern Standard Arabic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARB",
+              "number": "102",
+              "title": "Elementary Modern Standard Arabic II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "201",
+              "title": "American Sign Language III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "202",
+              "title": "American Sign Language IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHI",
+              "number": "101",
+              "title": "Elementary Chinese (Mandarin) I [SUN# CHI 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHI",
+              "number": "102",
+              "title": "Elementary Chinese (Mandarin) II [SUN# CHI 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "101",
+              "title": "Elementary French I [SUN# FRE 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "102",
+              "title": "Elementary French II [SUN# FRE 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "201",
+              "title": "Intermediate French I [SUN# FRE 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "202",
+              "title": "Intermediate French II [SUN# FRE 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "101",
+              "title": "Elementary German I [SUN# GER 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "102",
+              "title": "Elementary German II [SUN# GER 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "201",
+              "title": "Intermediate German I [SUN# GER 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GER",
+              "number": "202",
+              "title": "Intermediate German II [SUN# GER 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "101",
+              "title": "Elementary Japanese I [SUN# JPN 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "102",
+              "title": "Elementary Japanese II [SUN# JPN 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "201",
+              "title": "Intermediate Japanese I [SUN# JPN 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JPN",
+              "number": "202",
+              "title": "Intermediate Japanese II [SUN# JPN 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KOR",
+              "number": "101",
+              "title": "Elementary Korean I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KOR",
+              "number": "102",
+              "title": "Elementary Korean II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Elementary Spanish I [SUN# SPA 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "102",
+              "title": "Elementary Spanish II [SUN# SPA 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "103",
+              "title": "Beginning Spanish for Heritage and Bilingual Learners",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "201",
+              "title": "Intermediate Spanish I [SUN# SPA 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "202",
+              "title": "Intermediate Spanish II [SUN# SPA 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "203",
+              "title": "Writing &amp; Oral Skills for Heritage &amp; Bilingual Learners",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "253",
+              "title": "Intermediate Spanish for Heritage and Bilingual Learners",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "County Corrections Training Academy Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3769",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COR",
+              "number": "110",
+              "title": "County Correctional Officer Training Academy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COR",
+              "number": "115",
+              "title": "Corrections Training Officer",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 21 Credits",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "CTE - Communication",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3782",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GTW",
+              "number": "101",
+              "title": "Writing for Trades and Technical Occupations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WRT",
+              "number": "101",
+              "title": "English Composition I [SUN# ENG 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WRT",
+              "number": "101S",
+              "title": "English Composition I / Integrated Studio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WRT",
+              "number": "102",
+              "title": "English Composition II [SUN# ENG 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WRT",
+              "number": "154",
+              "title": "Career Communications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CTE - Mathematics or Science",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3786",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVM",
+              "number": "103",
+              "title": "Applied Technical Mathematics for Aviation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "Mathematics of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GTM",
+              "number": "105",
+              "title": "Applied Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "106",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "275",
+              "title": "Applied Metallurgy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "CTE - Social & Behavioral Science",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3783",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social & Behavioral Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFA",
+              "number": "120",
+              "title": "The African American Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "101",
+              "title": "Introduction to American Indian Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "225",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "101",
+              "title": "Human Origins and Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "102",
+              "title": "Introduction to Cultural Anthropology and Linguistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "110",
+              "title": "Buried Cities and Lost Tribes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "112",
+              "title": "Exploring Non-Western Cultures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "202",
+              "title": "Sexuality, Gender and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "210",
+              "title": "Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "101",
+              "title": "Human Origins and Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "110",
+              "title": "Buried Cities and Lost Tribes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAS",
+              "number": "110",
+              "title": "Food, People and the Planet",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAS",
+              "number": "111",
+              "title": "Sustainable Cities &amp; Societies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAS",
+              "number": "120",
+              "title": "Systems, Logic &amp; Sustainability",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "107",
+              "title": "Human Development and Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "117",
+              "title": "Child Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "150",
+              "title": "An Economic Perspective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "201",
+              "title": "Microeconomic Principles [SUN# ECN 2202]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "202",
+              "title": "Macroeconomic Principles [SUN# ECN 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "103",
+              "title": "Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "104",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "105",
+              "title": "Climate Change",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLS",
+              "number": "110",
+              "title": "Introduction to Cities and Global Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "202",
+              "title": "Sexuality, Gender and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Introduction to Western Civilization I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Introduction to Western Civilization II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "103",
+              "title": "World History Before 1500 [SUN# HIS 1100]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "World History After 1500 [SUN# HIS 1111]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "113",
+              "title": "Chinese Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "114",
+              "title": "Japanese Civilization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "141",
+              "title": "History of the United States I [SUN# HIS 1131]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "142",
+              "title": "History of the United States II [SUN# HIS 1132]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "147",
+              "title": "History of Arizona",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "160",
+              "title": "Latin America Before Independence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "161",
+              "title": "Modern Latin America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "254",
+              "title": "History of Women in the United States: The 20th Century",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "274",
+              "title": "The Holocaust",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "260",
+              "title": "Intercultural Perspectives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JRN",
+              "number": "102",
+              "title": "Survey of Media Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIS",
+              "number": "150",
+              "title": "Social Media and Ourselves",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "165",
+              "title": "Mexican American Culture, Community and Identity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "219",
+              "title": "Mexican American Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "101",
+              "title": "Introduction to Philosophy [SUN# PHI 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "130",
+              "title": "Introductory Studies in Ethics and Social Philosophy [SUN# PHI 1105]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "140",
+              "title": "Philosophy of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "100",
+              "title": "Introduction to Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "201",
+              "title": "American National Government and Politics [SUN# POS 1110]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "202",
+              "title": "Introduction to International Relations [SUN# POS 1120]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "203",
+              "title": "Introduction to Political Ideas",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "204",
+              "title": "Introduction to Comparative Politics [SUN# POS 2204]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "210",
+              "title": "National and State Constitutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "240",
+              "title": "Understanding Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology [SUN# PSY 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "132",
+              "title": "Psychology and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "216",
+              "title": "Psychology of Gender",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "218",
+              "title": "Health Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Psychological Measurements and Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "140",
+              "title": "Philosophy of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "200",
+              "title": "Religion in Popular Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "220",
+              "title": "Old Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "221",
+              "title": "New Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology [SUN# SOC 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "110",
+              "title": "Introduction to Cities and Global Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "120",
+              "title": "Current Social Problems [SUN# SOC 2250]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "127",
+              "title": "Relationships, Families and Marriage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Race, Ethnicity, Minority Groups and Social Justice [SUN# SOC 2215]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "204",
+              "title": "Gender Identities, Interactions and Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "215",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "110",
+              "title": "Introduction to Social Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "182",
+              "title": "A Social Services Perspective of Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "International and Multi-Cultural Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "105",
+              "title": "Exploring Art and Visual Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "Art and Culture: Prehistoric through Gothic [SUN# ART 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Art and Culture: Late Gothic through Modern Periods [SUN# ART 1102]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Biomedical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "251",
+              "title": "Western Humanities I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "253",
+              "title": "Western Humanities III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "224",
+              "title": "Southwestern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "261",
+              "title": "Modern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "130",
+              "title": "Asian Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "105",
+              "title": "Theater Appreciation [SUN# THE 1100]",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CTE - Options Category",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3785",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "104",
+              "title": "Computer Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "120",
+              "title": "Computer Applications for Business [SUN# CIS 1120]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "102",
+              "title": "Introduction to Communication [SUN# COM 1100]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "120",
+              "title": "Business and Professional Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "140",
+              "title": "Interpersonal Communication [SUN# COM 1110]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "209",
+              "title": "Introduction to Communication Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JRN",
+              "number": "101",
+              "title": "Introduction to Reporting and Media Writing [SUN# JRN 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "one more course from CTE - Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting Education Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3711",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAE",
+              "number": "159",
+              "title": "Introduction to Health Care for Dental Assisting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "160",
+              "title": "Orientation to Dental Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "161",
+              "title": "Biomedical Dental Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "162",
+              "title": "Dental Assisting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "163",
+              "title": "Oral Radiography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "164",
+              "title": "Dental Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "165",
+              "title": "Dental Assisting Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAE",
+              "number": "166",
+              "title": "Dental Assisting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "167",
+              "title": "Dental Assisting III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAE",
+              "number": "169",
+              "title": "Dental Assisting Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 29.5 Credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CyberSecurity, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3710",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "103",
+              "title": "Microsoft Windows Operating System Professional Admin",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "136",
+              "title": "Computer Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "137",
+              "title": "Introduction to the Linux Operating System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "119",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "188",
+              "title": "Scripting for Automation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "227",
+              "title": "Cyber Law and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "216",
+              "title": "Introduction to Wireshark and Network Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "221",
+              "title": "Deploying and Managing Windows Servers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "225",
+              "title": "Linux System and Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "228",
+              "title": "Fundamentals of Network Security",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "219",
+              "title": "Introduction to Cloud Computing with Amazon Web Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "234",
+              "title": "Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "245",
+              "title": "Cyber Defense",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "247",
+              "title": "Ethical Hacking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "284",
+              "title": "Information Technology Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 61-62 Credits",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Digital Arts, Web Design Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3714",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "102",
+              "title": "Fundamentals of Digital Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "112",
+              "title": "Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "120",
+              "title": "Applied Computer Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "122",
+              "title": "DeskTop Graphics: Adobe Illustrator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "221",
+              "title": "Photo Image Editing: Adobe PhotoShop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "256",
+              "title": "Web Design I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "226",
+              "title": "DeskTop Publishing for Digital Arts: Adobe InDesign",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "252",
+              "title": "Interactive Design I: UX/UI Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "257",
+              "title": "Web Design II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "254",
+              "title": "Interactive Design II: UX/UI Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "259",
+              "title": "Mobile Application Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "288",
+              "title": "Digital Arts Business and Portfolio Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 63-64 Credits",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3712",
+      "total_credits": 73,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHE",
+              "number": "101",
+              "title": "Dental Hygiene I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "104",
+              "title": "Dental and Oral Morphology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "107",
+              "title": "Oral Embryology and Histology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "112",
+              "title": "Preventive Dentistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "116",
+              "title": "Oral Radiography",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHE",
+              "number": "119",
+              "title": "Periodontology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "120",
+              "title": "Oral Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "122",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "132",
+              "title": "Dental Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "150",
+              "title": "Dental Hygiene II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DHE",
+              "number": "208",
+              "title": "Pain and Anxiety Control for Dental Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "209",
+              "title": "Ethics and Practice Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "212",
+              "title": "Nutrition for Oral Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "250",
+              "title": "Dental Hygiene III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMN",
+              "number": "120",
+              "title": "Business and Professional Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "213",
+              "title": "Advanced Periodontal Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "216",
+              "title": "Community and Dental Health Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DHE",
+              "number": "255",
+              "title": "Dental Hygiene IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Arts, Design Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3713",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "101",
+              "title": "Color Rendering and Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "102",
+              "title": "Fundamentals of Digital Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "120",
+              "title": "Applied Computer Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "111",
+              "title": "Typography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "112",
+              "title": "Graphic Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "122",
+              "title": "DeskTop Graphics: Adobe Illustrator",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "210",
+              "title": "Digital Arts Design Studio: Advertising Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "221",
+              "title": "Photo Image Editing: Adobe PhotoShop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "226",
+              "title": "DeskTop Publishing for Digital Arts: Adobe InDesign",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "212",
+              "title": "Digital Arts Design Studio: Collateral Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "230",
+              "title": "Production Techniques for Print",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "288",
+              "title": "Digital Arts Business and Portfolio Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 63-64 Credits",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Assistant Educator Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3719",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSA",
+              "number": "100",
+              "title": "Computer Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "108",
+              "title": "Literature/Social Studies for Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "117",
+              "title": "Child Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "125",
+              "title": "Nutrition, Health, and Safety for the Young Child",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "211",
+              "title": "Inclusion of Young Children with Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "226",
+              "title": "Positive Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ECE/CDA electives 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Digital Film Arts and Animation, Digital and Film Arts Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3776",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "103",
+              "title": "Introduction to Digital Video and Film Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "115",
+              "title": "Digital Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "125",
+              "title": "Digital Cinematography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "124",
+              "title": "Writing for Film and Television",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "173",
+              "title": "History of American Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "175",
+              "title": "The Art of Digital Cinematography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "225",
+              "title": "Digital Cinematography II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "205",
+              "title": "Lighting for Film and Video",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "275",
+              "title": "Basic Audio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "285",
+              "title": "Documentary Television and Film",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "217",
+              "title": "Post Production for Film",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "286",
+              "title": "Digital Cinematography Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 61 Credits",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Film Arts and Animation, Digital Animation Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3715",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "101",
+              "title": "Color Rendering and Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "103",
+              "title": "Introduction to Digital Video and Film Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "120",
+              "title": "Applied Computer Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "115",
+              "title": "Digital Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "122",
+              "title": "DeskTop Graphics: Adobe Illustrator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "140",
+              "title": "Digital Arts Illustration Studio:Illustration Technique &amp; Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "176",
+              "title": "Digital Animation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "173",
+              "title": "History of American Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "221",
+              "title": "Photo Image Editing: Adobe PhotoShop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "251",
+              "title": "Computer 3D Animation: Maya",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAR",
+              "number": "124",
+              "title": "Writing for Film and Television",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAR",
+              "number": "258",
+              "title": "Advanced Computer 3D Animation: Maya",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 62-64 Credits",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Studies, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3720",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSA",
+              "number": "100",
+              "title": "Computer Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "115",
+              "title": "Supervision and Administration of Early Childhood Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "226",
+              "title": "Positive Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "228",
+              "title": "The Young Child: Family, Culture, and Community",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "125",
+              "title": "Nutrition, Health, and Safety for the Young Child",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "211",
+              "title": "Inclusion of Young Children with Special Needs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "251",
+              "title": "Authentic Assessment and Curriculum Integration for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "292",
+              "title": "Early Childhood Education: Theory to Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Electives* (11 credits)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 60 Credits",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Studies, Child Development Associate (CDA) Preparation Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3718",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDA",
+              "number": "103",
+              "title": "Curriculum Planning and Schedule Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDA",
+              "number": "138",
+              "title": "Building Parent and Classroom Connections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDA",
+              "number": "161",
+              "title": "Principles of Social Competence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDA",
+              "number": "222",
+              "title": "Elements of Children&#039;s Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 13 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Education, BA",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3945",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "257",
+              "title": "21st Century Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "281",
+              "title": "U.S. Constitution for Teachers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "282",
+              "title": "Arizona Constitution for Teachers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "287",
+              "title": "Structured English Immersion – Elementary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "324",
+              "title": "Classroom Management: Elementary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "390",
+              "title": "Field Experience: General Education Traditional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "420",
+              "title": "Elementary Methods: English Language Arts and The Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "421",
+              "title": "Elementary Methods: Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "422",
+              "title": "Elementary Methods: Reading/Phonics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "423",
+              "title": "Elementary Methods: Science/Social Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "490",
+              "title": "Capstone Internship: Elementary (BA)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "219",
+              "title": "Literacy Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "251",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "352",
+              "title": "Survey of Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "354",
+              "title": "Understanding Students with Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "355",
+              "title": "Classroom Management: Mild-Moderate Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "390",
+              "title": "Field Experience: Mild-Moderate Disabilities Traditional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "470",
+              "title": "Instructional Methods for Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "472",
+              "title": "Developmental Reading: Instruction, Assessment, Remediation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "473",
+              "title": "Diagnosis and Assessment of Mild-Moderate Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "490",
+              "title": "Capstone Internship: Mild-Moderate Disabilities (BA)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "146",
+              "title": "Mathematics for Elementary Teachers I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total 120 Credits",
+          "credits_required": 120,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education, Secondary Teacher Certification, Post-Baccalaureate Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3722",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "257",
+              "title": "21st Century Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "281",
+              "title": "U.S. Constitution for Teachers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "282",
+              "title": "Arizona Constitution for Teachers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "346",
+              "title": "Classroom Management: Secondary",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "288",
+              "title": "Structured English Immersion – Secondary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "390",
+              "title": "Field Experience: General Education Traditional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "441",
+              "title": "Secondary Teaching Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "251",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "352",
+              "title": "Survey of Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "442",
+              "title": "Secondary Methods: Instruction Across the Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "492",
+              "title": "Capstone Internship: Secondary",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 33 Credits",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education, Elementary Teacher Certification, Post-Baccalaureate Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3721",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "257",
+              "title": "21st Century Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "281",
+              "title": "U.S. Constitution for Teachers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "324",
+              "title": "Classroom Management: Elementary",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "EDC",
+                  "number": "390",
+                  "title": ""
+                }
+              ]
+            },
+            {
+              "prefix": "ESE",
+              "number": "251",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "352",
+              "title": "Survey of Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "287",
+              "title": "Structured English Immersion – Elementary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "420",
+              "title": "Elementary Methods: English Language Arts and The Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "421",
+              "title": "Elementary Methods: Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "422",
+              "title": "Elementary Methods: Reading/Phonics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "423",
+              "title": "Elementary Methods: Science/Social Studies",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "282",
+              "title": "Arizona Constitution for Teachers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "491",
+              "title": "Capstone Internship: Elementary",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "472",
+              "title": "Developmental Reading: Instruction, Assessment, Remediation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 42 Credits",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education, Special Education Mild-Moderate Disabilities Teacher Post-Baccalaureate Certification",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3723",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "257",
+              "title": "21st Century Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "281",
+              "title": "U.S. Constitution for Teachers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "251",
+              "title": "Educational Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "352",
+              "title": "Survey of Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "355",
+              "title": "Classroom Management: Mild-Moderate Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "390",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "287",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "422",
+              "title": "Elementary Methods: Reading/Phonics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "354",
+              "title": "Understanding Students with Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "470",
+              "title": "Instructional Methods for Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "473",
+              "title": "Diagnosis and Assessment of Mild-Moderate Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "282",
+              "title": "Arizona Constitution for Teachers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "472",
+              "title": "Developmental Reading: Instruction, Assessment, Remediation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "491",
+              "title": "Capstone Internship: Mild-Moderate Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 42 Credits",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education, Special Education Endorsement for Certified Teachers Post-Baccalaureate Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3724",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ESE",
+              "number": "352",
+              "title": "Survey of Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "355",
+              "title": "Classroom Management: Mild-Moderate Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "470",
+              "title": "Instructional Methods for Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "473",
+              "title": "Diagnosis and Assessment of Mild-Moderate Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3725",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMT",
+              "number": "100",
+              "title": "Emergency Medical Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 9 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3701",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "120",
+              "title": "Blueprint Reading for Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "172",
+              "title": "Electrical I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "100",
+              "title": "Computer Literacy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "135",
+              "title": "National Electrical Code Residential Wiring Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "173",
+              "title": "Electrical II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "174",
+              "title": "Electrical III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 32-33 Credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technology — Paramedic, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3726",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMT",
+              "number": "170",
+              "title": "Advanced Life Support Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "205",
+              "title": "ALS Pharmacology and Medication Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "214",
+              "title": "ALS Advanced Special Considerations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "218",
+              "title": "Paramedic National Registry Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "219",
+              "title": "ALS Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "221",
+              "title": "ALS Airway and Ventilation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "222",
+              "title": "ALS Patient Assessment and Assessment Based Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "223",
+              "title": "ALS Trauma Emergencies and Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "224",
+              "title": "ALS Medical Emergencies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "225",
+              "title": "ALS Special Medical Considerations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "230",
+              "title": "Basic ECG Interpretation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "242",
+              "title": "ALS Advanced Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "244",
+              "title": "ALS Advanced Medical Emergencies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "250",
+              "title": "Advanced Cardiac Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "252",
+              "title": "Pediatric Advanced Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "254",
+              "title": "Advanced ECG Interpretation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMT",
+              "number": "295",
+              "title": "ALS Independent Research",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurship Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3819",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "200",
+              "title": "Small Business Management/Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "111",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "eCommerce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "296",
+              "title": "Independent Study in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "200",
+              "title": "Business Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "280",
+              "title": "Business Organization and Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 24 Credits",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Ethnic/Race/Gender/Class Awareness",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3787",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AFA",
+              "number": "120",
+              "title": "The African American Experience",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFA",
+              "number": "130",
+              "title": "The African Diaspora",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "101",
+              "title": "Introduction to American Indian Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIS",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "112",
+              "title": "Exploring Non-Western Cultures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "202",
+              "title": "Sexuality, Gender and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "206",
+              "title": "Contemporary Native Americans of the Southwest",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "205",
+              "title": "Introduction to Southwestern Prehistory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "201",
+              "title": "American Sign Language III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "202",
+              "title": "American Sign Language IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Biomedical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "102",
+              "title": "Introduction to Communication [SUN# COM 1100]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "110",
+              "title": "Public Speaking and Presentations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "120",
+              "title": "Business and Professional Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "100",
+              "title": "Introduction to Feminist Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "201",
+              "title": "La Chicana",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "202",
+              "title": "Sexuality, Gender and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "Tohono O&#039;odham History and Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "124",
+              "title": "History and Culture of the Yaqui People",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "130",
+              "title": "History and Cultures of the Southwest Borderlands",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "141",
+              "title": "History of the United States I [SUN# HIS 1131]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "142",
+              "title": "History of the United States II [SUN# HIS 1132]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "147",
+              "title": "History of Arizona",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "148",
+              "title": "History of Indians of North America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "160",
+              "title": "Latin America Before Independence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "161",
+              "title": "Modern Latin America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "254",
+              "title": "History of Women in the United States: The 20th Century",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "253",
+              "title": "Western Humanities III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "260",
+              "title": "Intercultural Perspectives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "224",
+              "title": "Southwestern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "261",
+              "title": "Modern Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIT",
+              "number": "280",
+              "title": "Introduction to Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "165",
+              "title": "Mexican American Culture, Community and Identity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "201",
+              "title": "La Chicana",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAS",
+              "number": "219",
+              "title": "Mexican American Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "160",
+              "title": "Popular Music in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "201",
+              "title": "American National Government and Politics [SUN# POS 1110]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POS",
+              "number": "204",
+              "title": "Introduction to Comparative Politics [SUN# POS 2204]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "216",
+              "title": "Psychology of Gender",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "200",
+              "title": "Religion in Popular Culture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology [SUN# SOC 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "120",
+              "title": "Current Social Problems [SUN# SOC 2250]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "201",
+              "title": "Race, Ethnicity, Minority Groups and Social Justice [SUN# SOC 2215]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "204",
+              "title": "Gender Identities, Interactions and Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "215",
+              "title": "Human Sexuality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "110",
+              "title": "Introduction to Social Welfare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "105",
+              "title": "Theater Appreciation [SUN# THE 1100]",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Academy Track Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3727",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMT",
+              "number": "100",
+              "title": "Emergency Medical Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "101",
+              "title": "Principles of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "110",
+              "title": "Rope I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "127",
+              "title": "Principles of Emergency Services Safety and Survival",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "130",
+              "title": "Strength and Fitness for the Fire Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "149",
+              "title": "Fire Operations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "150",
+              "title": "Fire Operations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "153",
+              "title": "Hazardous Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "160",
+              "title": "Wildland Firefighting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "173",
+              "title": "Records and Reports",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 28.75 Credits",
+          "credits_required": 75,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Field Archaeology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3687",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "275",
+              "title": "Archaeological Excavation I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "180",
+              "title": "Artifact Identification: Tucson Basin",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "276",
+              "title": "Archaeological Surveying I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "181",
+              "title": "Global Positioning Systems Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "275",
+              "title": "Archaeological Excavation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "181",
+              "title": "Global Positioning Systems Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "250",
+              "title": "Archaeology Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "276",
+              "title": "Archaeological Surveying I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "281",
+              "title": "Global Positioning Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "276",
+              "title": "Archaeological Surveying I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "284",
+              "title": "Computer Cartography and CAD",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GIS",
+              "number": "181",
+              "title": "Global Positioning Systems Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GIS",
+              "number": "281",
+              "title": "Global Positioning Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "275",
+              "title": "Archaeological Excavation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "267",
+              "title": "Geographic Information Systems I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 21-26 Credits",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fitness Professional Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3729",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSS",
+              "number": "208",
+              "title": "Group Fitness Instructor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "218",
+              "title": "Strength Training: Applied Principles and Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "234",
+              "title": "Fundamentals of Exercise Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "236",
+              "title": "Health Communication: Behavioral Change",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "241",
+              "title": "Nutrition for Exercise and Sport",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "276",
+              "title": "Exercise Testing and Prescription",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "277",
+              "title": "Cardiorespiratory Assessment and Program Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "281",
+              "title": "Capstone: Certified Personal Trainer",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "291",
+              "title": "Fitness Professional Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 18 Credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire and Emergency Services Higher Education (FESHE), AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3728",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMT",
+              "number": "100",
+              "title": "Emergency Medical Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "101",
+              "title": "Principles of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "110",
+              "title": "Rope I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "120",
+              "title": "Fire Behavior and Combustion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "123",
+              "title": "Building Construction Related to the Fire Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "124",
+              "title": "Fire Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "126",
+              "title": "Fire Protection Systems in the Fire Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "127",
+              "title": "Principles of Emergency Services Safety and Survival",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "130",
+              "title": "Strength and Fitness for the Fire Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "149",
+              "title": "Fire Operations I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "150",
+              "title": "Fire Operations II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "153",
+              "title": "Hazardous Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "160",
+              "title": "Wildland Firefighting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "173",
+              "title": "Records and Reports",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "174",
+              "title": "Fire Investigation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "252",
+              "title": "Fire Service Strategy and Tactics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 61.75 Credits",
+          "credits_required": 75,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health and Wellness Coach Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3730",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSS",
+              "number": "147",
+              "title": "Health Coach Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "149",
+              "title": "Health, Wellness, and Physical Activity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "154",
+              "title": "Healthy Living and Mind-Body Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "234",
+              "title": "Fundamentals of Exercise Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "241",
+              "title": "Nutrition for Exercise and Sport",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "280",
+              "title": "Weight Management Specialist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSS",
+              "number": "292",
+              "title": "Health and Wellness Coach Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Professions Readiness Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3818",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRP",
+              "number": "100",
+              "title": "Success in Health Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRP",
+              "number": "101",
+              "title": "Medical Terminology for Health Professions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Biomedical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRP",
+              "number": "103",
+              "title": "Basic Health Professions Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRP",
+              "number": "105",
+              "title": "Introduction to Health Professions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 25-29 Credits",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies, AGS",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3731",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Total: 60 Credits",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Health Information Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3732",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "101",
+              "title": "Introduction to ICD Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "108",
+              "title": "Health Information Employment Policies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "102",
+              "title": "CPT Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Pathophysiology and Pharmacology for HIT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "150",
+              "title": "Introduction to Health Management Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Health Insurance and Medical Billing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "175",
+              "title": "Research for Health Information Technology (HIT) Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "210",
+              "title": "Medical Quality Assurance and Supervision",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "201",
+              "title": "Advanced ICD Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "202",
+              "title": "Advanced Classification Systems Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "211",
+              "title": "Medicolegal Aspects in Health Information Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "225",
+              "title": "Advanced Health Management Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "290",
+              "title": "Health Information Technology Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 60-61 Credits",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Honors Program Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3734",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HON",
+              "number": "101",
+              "title": "Honors Colloquium",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Electives - select a minimum of 12 credits from the following",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "210",
+              "title": "College Honors Advisory Council",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HON",
+              "number": "296",
+              "title": "Honors Independent Study Project",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Honors courses in any prefix (3-12 credits)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 15 Credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality Leadership, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3796",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Food Service Nutrition and Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "140",
+              "title": "Culinary Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "100",
+              "title": "Introduction to the Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "130",
+              "title": "Savory Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "185",
+              "title": "Catering Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "140",
+              "title": "Introduction to Bar and Beverage Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "104",
+              "title": "Hotel Food and Beverage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "210",
+              "title": "Managing Customer Service for the Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Electives (6 Credits)*",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 61 Credits",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality, Advanced Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3773",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Food Service Nutrition and Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "140",
+              "title": "Culinary Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "130",
+              "title": "Savory Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "150",
+              "title": "Garde Manger",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "160",
+              "title": "Bakery and Pastry Production I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "189",
+              "title": "Culinary Arts Capstone I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "101",
+              "title": "Principles of Restaurant Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "174",
+              "title": "From Garden to Table",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "163",
+              "title": "Sauces",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "170",
+              "title": "Dining Room Operations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "104",
+              "title": "Computer Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "180",
+              "title": "Food in History",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 35 Credits",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality, Baking and Pastry Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3774",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Food Service Nutrition and Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "140",
+              "title": "Culinary Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "160",
+              "title": "Bakery and Pastry Production I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "162",
+              "title": "Art of Chocolate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "168",
+              "title": "Specialty and Hearth Breads",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "189",
+              "title": "Culinary Arts Capstone I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "244",
+              "title": "Confections, Show Pieces, &amp; Plated Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "260",
+              "title": "Pastry Arts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "266",
+              "title": "Ice Creams/Bavarians/Mousse/Sauces",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "276",
+              "title": "Pastry Production",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 29 Credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Resources Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3735",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRS",
+              "number": "101",
+              "title": "Introduction to Human Resources Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRS",
+              "number": "102",
+              "title": "Human Resource Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRS",
+              "number": "103",
+              "title": "Benefits and Compensation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRS",
+              "number": "104",
+              "title": "Job Requirements, Recruitment, and Personnel Selection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRS",
+              "number": "105",
+              "title": "Training and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRS",
+              "number": "106",
+              "title": "Labor Relations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 19 Credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality, Hotel and Restaurant Management Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3775",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "100",
+              "title": "Introduction to the Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "210",
+              "title": "Managing Customer Service for the Hospitality Industry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "104",
+              "title": "Computer Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "101",
+              "title": "Front Office Procedures",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "104",
+              "title": "Hotel Food and Beverage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "110",
+              "title": "Food Service Systems Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "150",
+              "title": "Hospitality Property Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 22 Credits",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hospitality, Fundamentals Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3772",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "105",
+              "title": "Food Service Nutrition and Sanitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "140",
+              "title": "Culinary Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second eight weeks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "130",
+              "title": "Savory Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "150",
+              "title": "Garde Manger",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "160",
+              "title": "Bakery and Pastry Production I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "189",
+              "title": "Culinary Arts Capstone I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "IT Support Specialist Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3779",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "103",
+              "title": "Microsoft Windows Operating System Professional Admin",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "136",
+              "title": "Computer Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "137",
+              "title": "Introduction to the Linux Operating System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "119",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "188",
+              "title": "Scripting for Automation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "227",
+              "title": "Cyber Law and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 31 Credits",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC-R Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3702",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "105",
+              "title": "Professionalism in Service, Construction Math, Basic Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "107",
+              "title": "Basic Safety, Hand &amp; Power Tools, Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "106",
+              "title": "Soldering and Brazing for BCT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "120",
+              "title": "Blueprint Reading for Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "132",
+              "title": "Residential and Industrial HVAC I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "100",
+              "title": "Computer Literacy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BCT",
+              "number": "133",
+              "title": "Residential and Industrial HVAC II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BCT",
+              "number": "134",
+              "title": "Residential and Industrial HVAC III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 32-33 Credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Justice Professions, Administration of Justice Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3737",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "101",
+              "title": "Introduction to Administration of Justice Systems [SUN# AJS 1101]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "109",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "123",
+              "title": "Corrections as a Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "SOC elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "115",
+              "title": "Criminal Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "124",
+              "title": "Ethics and the Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMN",
+              "number": "120",
+              "title": "Business and Professional Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "204",
+              "title": "Criminal Investigations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "212",
+              "title": "Juvenile Justice Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "270",
+              "title": "Contemporary Issues in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "Introduction to Psychology [SUN# PSY 1101]",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "205",
+              "title": "Forensic Pathology and Death Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "260",
+              "title": "Criminal Justice Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "265",
+              "title": "Issues in Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "290",
+              "title": "Administration of Justice Studies Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "SSE elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 61-62 Credits",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Justice Professions, Law Enforcement Concentration, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3738",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LEA",
+              "number": "110",
+              "title": "Law Enforcement Academy Part I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEA",
+              "number": "210",
+              "title": "Law Enforcement Academy Part II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 60 Credits",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "IT Support Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3778",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "136",
+              "title": "Computer Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "137",
+              "title": "Introduction to the Linux Operating System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Law Enforcement Academy Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3736",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LEA",
+              "number": "110",
+              "title": "Law Enforcement Academy Part I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LEA",
+              "number": "210",
+              "title": "Law Enforcement Academy Part II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 45 Credits",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Liberal Arts, AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3941",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Total: 60-64 Credits",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Logistics and Supply Chain Management Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3742",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LGM",
+              "number": "101",
+              "title": "Principles of Logistics and Supply Chain Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGM",
+              "number": "102",
+              "title": "Inventory Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGM",
+              "number": "104",
+              "title": "Computerized Logistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGM",
+              "number": "105",
+              "title": "Warehouse Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 16 Credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Logistics and Supply Chain Management, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3743",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LGM",
+              "number": "101",
+              "title": "Principles of Logistics and Supply Chain Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGM",
+              "number": "102",
+              "title": "Inventory Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGM",
+              "number": "104",
+              "title": "Computerized Logistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGM",
+              "number": "105",
+              "title": "Warehouse Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGM",
+              "number": "106",
+              "title": "Transportation and Traffic Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "110",
+              "title": "Human Relations in Business and Industry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "eCommerce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "110",
+              "title": "Spreadsheets: Microsoft Excel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "103",
+              "title": "Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGM",
+              "number": "103",
+              "title": "Contracts and Freight Claims",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGM",
+              "number": "108",
+              "title": "International Logistics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LGM",
+              "number": "107",
+              "title": "Introduction to Purchasing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "230",
+              "title": "Dynamics of Leadership",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 61 Credits",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Machine Tool Technology, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3746",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "117",
+              "title": "Print Reading with CAD for Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "100",
+              "title": "Introduction to Machine Tool",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "110",
+              "title": "Manual Machine Shop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "130",
+              "title": "Machine Setup and Fixture Making",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "150",
+              "title": "Introduction to Computer Numerical Control (CNC) Operations (Mill and Lathe)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "155",
+              "title": "Computer Numerical Control (CNC) Mill Programming II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "125",
+              "title": "Inspection Quality Assurance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "172",
+              "title": "Geometric Dimensioning and Tolerancing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "257",
+              "title": "Computer-Aided Machining (CAM) Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "258",
+              "title": "Computer Aided Machining (CAM) Programming II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "160",
+              "title": "Computer Numerical Control (CNC) Lathe Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "259",
+              "title": "Computer Aided Machining (CAM) III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 62 Credits",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machining Inspection and Quality Assurance Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3744",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "117",
+              "title": "Print Reading with CAD for Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "100",
+              "title": "Introduction to Machine Tool",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "172",
+              "title": "Geometric Dimensioning and Tolerancing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "125",
+              "title": "Inspection Quality Assurance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 17 Credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Billing and Coding Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3733",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "104",
+              "title": "Computer Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "100",
+              "title": "Introduction to Health Information Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "101",
+              "title": "Introduction to ICD Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "102",
+              "title": "CPT Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "105",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "108",
+              "title": "Health Information Employment Policies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Health Insurance and Medical Billing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "125",
+              "title": "Pathophysiology and Pharmacology for HIT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "201",
+              "title": "Advanced ICD Coding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 30.5-32 Credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mathematics",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3792",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "151",
+              "title": "Mathematics of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Statistical Methods in Economics and Business [SUN# BUS 2201]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "Topics in College Mathematics [SUN# MAT 1142]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "College Algebra [SUN# MAT 1151]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "167",
+              "title": "Introductory Statistics [SUN# MAT 1160]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Finite Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "187",
+              "title": "Precalculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "189",
+              "title": "Trigonometry [SUN# MAT 1187]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "212",
+              "title": "Topics in Calculus [SUN# MAT 2212]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus I [SUN# MAT 2220]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "227",
+              "title": "Discrete Mathematics in Computer Science [SUN# MAT 2227]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "231",
+              "title": "Calculus II [SUN# MAT 2230]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "241",
+              "title": "Calculus III [SUN# MAT 2241]",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "252",
+              "title": "Introduction to Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "262",
+              "title": "Differential Equations [SUN# MAT 2262]",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "mathematics"
+    },
+    {
+      "title": "Medical Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3747",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HCA",
+              "number": "103",
+              "title": "Orientation to Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCA",
+              "number": "119",
+              "title": "Orientation to Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRP",
+              "number": "100",
+              "title": "Success in Health Professions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "120",
+              "title": "Medical Assistant Profession",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "124",
+              "title": "Medical Terminology for Medical Professionals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDA",
+              "number": "121",
+              "title": "Medical Assistant Skills for Success",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "127",
+              "title": "Administrative Procedures for Medical Assistants",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "130",
+              "title": "Clinical Safety and Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "135",
+              "title": "Clinical Coding, Billing, and Insurance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDA",
+              "number": "191",
+              "title": "Medical Assistant Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 29 Credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Networking/Cyber Defense, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3709",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "103",
+              "title": "Microsoft Windows Operating System Professional Admin",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "136",
+              "title": "Computer Hardware Components",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "137",
+              "title": "Introduction to the Linux Operating System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "STU",
+              "number": "100",
+              "title": "College Success and Career Planning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "119",
+              "title": "Network Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "188",
+              "title": "Scripting for Automation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "227",
+              "title": "Cyber Law and Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "216",
+              "title": "Introduction to Wireshark and Network Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "221",
+              "title": "Deploying and Managing Windows Servers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "225",
+              "title": "Linux System and Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "228",
+              "title": "Fundamentals of Network Security",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "219",
+              "title": "Introduction to Cloud Computing with Amazon Web Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "223",
+              "title": "Implementing Azure Active Directory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "226",
+              "title": "Advanced Linux Networking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "284",
+              "title": "Information Technology Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CIS elective (3 credits)*",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 61 Credits",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technician, AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.pima.edu/preview_program.php?catoid=17&poid=3748",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRP",
+              "number": "100",
+              "title": "Success in Health Professions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "199",
+              "title": "Introductory Co-op: Phlebotomy Lab Assisting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MLT",
+              "number": "299",
+              "title": "Advanced Co-op: Medical Laboratory Technician",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Total: 63 Credits",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/az/programs/yavapai-college.json
+++ b/data/az/programs/yavapai-college.json
@@ -1,0 +1,13199 @@
+{
+  "college_slug": "yavapai-college",
+  "catalog_year": "2020-2021",
+  "catalog_url": "https://catalog.yc.edu",
+  "scraped_at": "2026-06-05T01:36:37.125Z",
+  "programs": [
+    {
+      "title": "3-D Printing and Manufacturing Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9017",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MET",
+              "number": "200",
+              "title": "SolidWorks for Non-Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDP",
+              "number": "101",
+              "title": "Introduction to 3-D Printing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDP",
+              "number": "108",
+              "title": "3-D Printer Operation and Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDP",
+              "number": "201",
+              "title": "Slicing and Software for 3-D Printing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDP",
+              "number": "210",
+              "title": "3-D Model Optimization and Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDP",
+              "number": "250",
+              "title": "Industrial Projects for 3-D Printing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "AAFA - Performing Arts Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9022",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (AGEC) (35 credits)",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major and Elective Studies (25 credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Performing Arts Core Requirements (11 credits)",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAN",
+              "number": "110",
+              "title": "Ballet I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "131",
+              "title": "Acting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "133",
+              "title": "Musical Theater I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "141",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Performing Arts Electives (14 credits)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAN",
+              "number": "114",
+              "title": "Jazz I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "115",
+              "title": "Tap I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "120",
+              "title": "Ballet II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "151",
+              "title": "Applied Dance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "134",
+              "title": "Singing for the Actor",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "Applied Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "132",
+              "title": "Acting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "134",
+              "title": "Musical Theater II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "144",
+              "title": "Production Workshop Practicum: Costuming and Make-up",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "145",
+              "title": "Production Workshop Practicum: Stage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "146",
+              "title": "Production Workshop Practicum: Set Building and Props",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "147",
+              "title": "Production Workshop Practicum: Theater Production Crew",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "150",
+              "title": "Theater Rehearsal and Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "150",
+              "title": "may be taken for a total of 3 credit hours.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "151",
+              "title": "Scene Study for Actors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "160",
+              "title": "Lighting Design for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "161",
+              "title": "Sound Design for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "164",
+              "title": "Scenic Design for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "218",
+              "title": "Directing for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "AAFA - Music Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9021",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (AGEC) (35 credits)",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major and Elective Studies (28 credits)",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Music Core Requirements (24 credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "103",
+              "title": "Piano Class I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "104",
+              "title": "Piano Class II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "Basic Integrated Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Basic Integrated Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "Applied Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "203",
+              "title": "Piano Class III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "204",
+              "title": "Piano Class IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "231",
+              "title": "Advanced Integrated Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "232",
+              "title": "Advanced Integrated Theory II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Music Electives: Select 4 credit hours",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Private Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "105",
+              "title": "Voice Class I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Concert Band",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "111",
+              "title": "Symphonic Band",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "113",
+              "title": "Big Band I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "114",
+              "title": "Big Band II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "115",
+              "title": "Instrumental Ensemble",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "116",
+              "title": "Jazz Combo",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "117",
+              "title": "Symphony Orchestra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "129",
+              "title": "Music Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "222",
+              "title": "Chamber Singers:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "223",
+              "title": "Vocal Ensemble",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "224",
+              "title": "Master Chorale",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "225",
+              "title": "Community Chorale",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "227",
+              "title": "Treble Choir:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "296",
+              "title": "Internship: Music",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8913",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Basic Tax Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "121",
+              "title": "Introductory Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "131",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "132",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "160",
+              "title": "Computer Accounting with QuickBooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "210",
+              "title": "Data Analytics for Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "233",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "234",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "233",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "296",
+              "title": "Internship: Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "131",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "237",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "132",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "AAFA - Visual Arts Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9020",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (AGEC) (35 credits)",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major and Elective Studies (27 credits)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Visual Arts Core Requirements (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Drawing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Three-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "139",
+              "title": "Fundamentals of Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Visual Arts Electives: Select 9 credit hours",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "120",
+              "title": "Ceramics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Ceramics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "137",
+              "title": "Adobe Photoshop I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "139",
+              "title": "Fundamentals of Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "140",
+              "title": "Jewelry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "144",
+              "title": "Furniture and Woodworking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "160",
+              "title": "Printmaking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "182",
+              "title": "Welded Metal Sculpture I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "183",
+              "title": "Welded Metal Sculpture II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "190",
+              "title": "Oil/Acrylic Painting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "191",
+              "title": "Oil/Acrylic Painting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "194",
+              "title": "Watercolor I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "210",
+              "title": "Life Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "214",
+              "title": "Digital Illustration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "100",
+              "title": "Digital Design Studio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Accounting - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8910",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (36 credits)",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Basic Tax Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "117",
+              "title": "Advanced Tax Planning and Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "121",
+              "title": "Introductory Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "131",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "132",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "160",
+              "title": "Computer Accounting with QuickBooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "210",
+              "title": "Data Analytics for Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "233",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "234",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "131",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "296",
+              "title": "Internship: Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "237",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "236",
+              "title": "Principles of Economics-Micro",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "132",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "233",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Administration of Justice - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8911",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "101",
+              "title": "Introduction to Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "109",
+              "title": "Substantive Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "170",
+              "title": "Forensic Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "200",
+              "title": "Current Issues in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "225",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "230",
+              "title": "The Police Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "240",
+              "title": "The Correction Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "260",
+              "title": "Procedural Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "270",
+              "title": "Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "290",
+              "title": "Constitutional Law: Civil Liberties and Civil Rights",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "103",
+              "title": "Public Safety Report Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "106",
+              "title": "Public Safety Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "192",
+              "title": "Serial Killers and Mass Murderers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "212",
+              "title": "Juvenile Justice Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "226",
+              "title": "Victimology and Crisis Intervention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "252",
+              "title": "Homeland Security and Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "275",
+              "title": "Criminal Investigations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "278",
+              "title": "Neuroscience and the Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "296",
+              "title": "Internship: Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "298",
+              "title": "Special Justic Topics:",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Technology - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8927",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Core Requirements (44 credits)",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "101",
+              "title": "Microcomputers in Agriculture",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CSA",
+                  "number": "126",
+                  "title": "Microsoft Office for Windows"
+                }
+              ]
+            },
+            {
+              "prefix": "AIT",
+              "number": "105",
+              "title": "Modern Maintenance Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "110",
+              "title": "Mechanical Power Transmission Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "115",
+              "title": "Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "120",
+              "title": "Pneumatic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "101",
+              "title": "CNC Machine Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "102",
+              "title": "CNC Machine Setup",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "201",
+              "title": "Computer Aided Programming for CNC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "101",
+              "title": "Basic Electricity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "135",
+              "title": "Robot Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "165",
+              "title": "Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPT",
+              "number": "261",
+              "title": "Machine Shop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "116",
+              "title": "Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "200",
+              "title": "SolidWorks for Non-Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "112",
+              "title": "Oxyacetylene Welding for Non-Welding Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "113",
+              "title": "SMAW/GMAW Welding for Non-Welding Majors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "250",
+              "title": "Welded Metal Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mining Concentration (13 credits)",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IPT",
+              "number": "295",
+              "title": "Apprenticeship: Industrial Plant",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPT",
+              "number": "295",
+              "title": "Apprenticeship: Industrial Plant",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "150",
+              "title": "Surface Mine Safety Training",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Bookkeeping Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8915",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Basic Tax Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "121",
+              "title": "Introductory Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Payroll Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "131",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "160",
+              "title": "Computer Accounting with QuickBooks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "210",
+              "title": "Data Analytics for Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture Technology Management Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9034",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements (36 credits)",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "120",
+              "title": "Introduction to the Animal Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "157",
+              "title": "Community Supported Agriculture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "202",
+              "title": "Summer Horticulture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "215",
+              "title": "Agricultural Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "250",
+              "title": "Horticulture Fall Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "252",
+              "title": "Horticulture Spring Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "261",
+              "title": "Aquaculture Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "264",
+              "title": "Aquaculture Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "280",
+              "title": "Zoo and Domestic Animal Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "282",
+              "title": "Zoo and Domestic Animal Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Aerospace Science Airplane Operations AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8922",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (36 credits)",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVT",
+              "number": "137",
+              "title": "Private Pilot Ground",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "138",
+              "title": "Private Pilot Simulation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "139",
+              "title": "Private Pilot Flight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "149",
+              "title": "Instrument Intro Flight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "157",
+              "title": "Instrument Pilot Ground",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "159",
+              "title": "Instrument Pilot Flight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "257",
+              "title": "Commercial Pilot Ground",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "259",
+              "title": "Commercial Pilot Flight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "267",
+              "title": "Flight Instructor Ground",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "269",
+              "title": "Flight Instructor Flight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "277",
+              "title": "Instrument Flight Instructor Ground",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "279",
+              "title": "Instrument Flight Instructor Flight",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "287",
+              "title": "Multi-Engine Ground",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "289",
+              "title": "Multi-Engine Flight",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVT",
+              "number": "262",
+              "title": "Flight Endorsement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "102",
+              "title": "Career Search and Success: Skills for Entering and Succeeding in the Workplace",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "134",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "130H",
+              "title": "Weight Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "130J",
+              "title": "Weight Loss and Health with Whole Food",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "205",
+              "title": "Stress Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "100",
+              "title": "Introduction to UAS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "132",
+              "title": "UAS Flight Operations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Traffic Control Academy Prep Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9048",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AVT",
+              "number": "122",
+              "title": "Fundamentals of Air Traffic Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "123",
+              "title": "Air Traffic Control Tower Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AVT",
+              "number": "124",
+              "title": "Fundamentals of Air Traffic Control Radar Operation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Animal Care and Management Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8934",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "100",
+              "title": "Introductory Equine Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "101",
+              "title": "Microcomputers in Agriculture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "120",
+              "title": "Introduction to the Animal Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "261",
+              "title": "Aquaculture Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "264",
+              "title": "Aquaculture Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "280",
+              "title": "Zoo and Domestic Animal Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "282",
+              "title": "Zoo and Domestic Animal Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Applied Pre-Engineering - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8920",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (AGEC) (35 credits)",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (20 credits)",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "101",
+              "title": "CNC Machine Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "201",
+              "title": "Computer Aided Programming for CNC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "102",
+              "title": "Introduction to Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "110",
+              "title": "Introduction to Digital Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "130",
+              "title": "Introduction to Robotics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "230",
+              "title": "Calculus and Analytic Geometry II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (6 credits)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "102",
+              "title": "CNC Machine Setup",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "202",
+              "title": "3-D Programming and Rapid Prototyping for CNC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "180",
+              "title": "CAD (Computer Aided-Drawing) with SolidWorks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "210",
+              "title": "Introduction to Electrical Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "182",
+              "title": "Precalculus (Algebra)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "183",
+              "title": "Precalculus (Trigonometry)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "241",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "262",
+              "title": "Elementary Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Agriculture Technology Management - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8912",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (25 credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "101",
+              "title": "Microcomputers in Agriculture",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CSA",
+                  "number": "126",
+                  "title": "Microsoft Office for Windows"
+                }
+              ]
+            },
+            {
+              "prefix": "AGS",
+              "number": "102",
+              "title": "Agribusiness Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "105",
+              "title": "Soils",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "107",
+              "title": "Entomology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "120",
+              "title": "Introduction to the Animal Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "157",
+              "title": "Community Supported Agriculture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "215",
+              "title": "Agricultural Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "274",
+              "title": "Water Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (16 credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "250",
+              "title": "Horticulture Fall Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "252",
+              "title": "Horticulture Spring Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "261",
+              "title": "Aquaculture Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "264",
+              "title": "Aquaculture Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "280",
+              "title": "Zoo and Domestic Animal Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "282",
+              "title": "Zoo and Domestic Animal Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Arizona General Education Curriculum",
+      "credential": "other",
+      "program_code": "AGEC",
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9047",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (AGEC) (32-35 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Artificial Intelligence and Machine Learning Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9413",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIM",
+              "number": "101",
+              "title": "Introduction to Generative AI",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "104",
+              "title": "AI Ethics Foundation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "205",
+              "title": "Introduction to Machine Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "221",
+              "title": "Computer Vision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIM",
+              "number": "232",
+              "title": "Natural Language Processing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "250",
+              "title": "Introduction to Artificial Intelligence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "105",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "113",
+              "title": "Programming: Python",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8908",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (AGEC) (32-35 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major and Elective Studies (25-28 credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Arts in Elementary Education",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8909",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (AGEC) (34-35 credits)",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major and Elective Studies (27 credits)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "180",
+              "title": "Educational Technology: Teaching and Learning in a Digital Age",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Introduction to Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "210",
+              "title": "Cultural Diversity in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "222",
+              "title": "Introduction to the Exceptional Learner",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "230",
+              "title": "Language and Literacy Experiences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "240",
+              "title": "Family and Community Partnerships",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "242",
+              "title": "The Science of Reading and Structured Literacy Instruction in the K-5 Classroom",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "156",
+              "title": "Mathematics for Elementary Teachers I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "157",
+              "title": "Mathematics for Elementary Teachers II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of Business",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8917",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (AGEC) (34 credits)",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "131",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "132",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "131",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "232",
+              "title": "Business Statistical Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "236",
+              "title": "Principles of Economics-Micro",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSA",
+              "number": "237",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "238",
+              "title": "Advanced Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "110",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*Students planning to transfer to ASU, NAU, or UofA should select this course as a program elective.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "110",
+              "title": "Economics of Sports",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Finite Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "212",
+              "title": "Topics in Calculus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*Students planning to transfer to ASU, NAU, or UofA should select this course as a program elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Associate of Arts in Fine Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8916",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8919",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (AGEC) (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major and Elective Studies (28 credits)",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Auto Body Paint and Collision Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8936",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "105",
+              "title": "Introduction to Auto Body Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "106",
+              "title": "Automotive/Motorcycle Custom Painting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "107",
+              "title": "Autographics/Airbrushing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "110",
+              "title": "Advanced Airbrushing Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Auto Body Welding and Collision Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "275",
+              "title": "Basic Automotive Upholstery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "276",
+              "title": "Advanced Upholstery",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Associate of General Studies",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8918",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (28 credits)",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major and Elective Studies (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Automated Industrial Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9029",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements (24-26 credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIT",
+              "number": "105",
+              "title": "Modern Maintenance Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "110",
+              "title": "Mechanical Power Transmission Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "115",
+              "title": "Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "120",
+              "title": "Pneumatic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "225",
+              "title": "Basic Industrial Motor Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "101",
+              "title": "Basic Electricity",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ELT",
+                  "number": "111",
+                  "title": "DC Electrical Systems"
+                }
+              ]
+            },
+            {
+              "prefix": "ELT",
+              "number": "102",
+              "title": "Power Electronic Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "126",
+              "title": "Solid State Devices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "165",
+              "title": "Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8921",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (16 credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "103",
+              "title": "Automotive/Diesel Preventative Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "109",
+              "title": "Auto/Diesel Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "122",
+              "title": "Automatic Transmissions and Transaxles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "123",
+              "title": "Automotive Brakes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "124",
+              "title": "Auto/Diesel Manual Drive Trains",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "126",
+              "title": "Auto/Diesel Suspension and Steering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "128",
+              "title": "Auto/Diesel Heating and Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "153",
+              "title": "Auto Engine Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "230",
+              "title": "Advanced Light/Medium Duty Diesel Diagnosis 1500-4500 Series",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "231",
+              "title": "Auto Engine Diagnostics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IPT",
+              "number": "261",
+              "title": "Machine Shop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTC",
+              "number": "105",
+              "title": "Introduction to Motorcycle and UTV Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTC",
+              "number": "215",
+              "title": "Motorcycle and UTV Service Procedures",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "WLD",
+                  "number": "112",
+                  "title": "Oxyacetylene Welding for Non-Welding Majors"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Master Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8937",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "103",
+              "title": "Automotive/Diesel Preventative Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "109",
+              "title": "Auto/Diesel Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "122",
+              "title": "Automatic Transmissions and Transaxles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "123",
+              "title": "Automotive Brakes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "124",
+              "title": "Auto/Diesel Manual Drive Trains",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "126",
+              "title": "Auto/Diesel Suspension and Steering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "128",
+              "title": "Auto/Diesel Heating and Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "153",
+              "title": "Auto Engine Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "230",
+              "title": "Advanced Light/Medium Duty Diesel Diagnosis 1500-4500 Series",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "231",
+              "title": "Auto Engine Diagnostics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IPT",
+              "number": "261",
+              "title": "Machine Shop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTC",
+              "number": "105",
+              "title": "Introduction to Motorcycle and UTV Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTC",
+              "number": "215",
+              "title": "Motorcycle and UTV Service Procedures",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "WLD",
+                  "number": "112",
+                  "title": "Oxyacetylene Welding for Non-Welding Majors"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Bachelor of Applied Science in Business",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9049",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Lower Division Requirements (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "131",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "131",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "232",
+              "title": "Business Statistical Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "236",
+              "title": "Principles of Economics-Micro",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Business Foundations Requirements (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSA",
+              "number": "237",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "140",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "220",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "233",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Upper Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSA",
+              "number": "300",
+              "title": "Global Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "305",
+              "title": "Principles of Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "310",
+              "title": "Logistics and Supply Chain Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "360",
+              "title": "Project Management Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "394",
+              "title": "Mentorship: Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "400",
+              "title": "Business Policy and Strategic Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "410",
+              "title": "Business Analytics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BSA",
+                  "number": "494",
+                  "title": "Capstone Project: Business"
+                }
+              ]
+            },
+            {
+              "prefix": "LDR",
+              "number": "300",
+              "title": "Fundamentals of Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "340",
+              "title": "Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Automotive Technician (MLR) Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8938",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "103",
+              "title": "Automotive/Diesel Preventative Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "109",
+              "title": "Auto/Diesel Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "123",
+              "title": "Automotive Brakes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "126",
+              "title": "Auto/Diesel Suspension and Steering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "153",
+              "title": "Auto Engine Repair",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Bachelor of Design in Visual Design",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9421",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (34 credits)",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Lower Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "139",
+              "title": "Fundamentals of Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "214",
+              "title": "Digital Illustration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "100",
+              "title": "Digital Design Studio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "101",
+              "title": "Principles of Visual Communication I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "102",
+              "title": "Letters and Typography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "103",
+              "title": "Principles of Visual Communication II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "204",
+              "title": "Web Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "138",
+              "title": "VFX and Motion Graphics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Upper Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DES",
+              "number": "305",
+              "title": "Applied Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "306",
+              "title": "Use Experience Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "307",
+              "title": "Applied Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "308",
+              "title": "Interaction Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "310",
+              "title": "Experiential Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "409",
+              "title": "Design Project Research and Production I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "410",
+              "title": "Brand Strategy: Tactics &amp; Digital Tools",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "411",
+              "title": "Design Project Research and Production II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "413",
+              "title": "Design Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "414",
+              "title": "Portfolio",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Bachelor of Science in Computer Science",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9050",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (AGEC) (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Lower Division Requirements (24 credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "105",
+              "title": "Cybersecurity Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "135",
+              "title": "Security+: Implementing and Maintaining Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "110",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "214",
+              "title": "Foundations of Data Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "250",
+              "title": "Introduction to Artificial Intelligence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "281",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "105",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "113",
+              "title": "Programming: Python",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lower Division Electives (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Upper Division Requirements (45 credits)",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSA",
+              "number": "310",
+              "title": "Advanced Artificial Intelligence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "315",
+              "title": "Software Engineering for the Cloud",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "320",
+              "title": "Advanced Data Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "345",
+              "title": "Information Technology Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "355",
+              "title": "Advanced Programming Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "390",
+              "title": "IT Project Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "420",
+              "title": "Ethics in Information Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "440",
+              "title": "Software Assurance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "450",
+              "title": "Big Data Architecture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "470",
+              "title": "Disruptive Technologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "494",
+              "title": "Project Capstone: Computer Science",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CSA",
+                  "number": "496",
+                  "title": "Internship: Computer Science"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Bachelor of Science in Business",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9025",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Bachelor of Science in Nursing (RN - BSN)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9032",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (31 credits)",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Credit for Prior Nursing Degree and RN Licensure (40.5 credits)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (30.5 credits)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "310",
+              "title": "Transition and Concepts of Professional Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "320",
+              "title": "Nursing Practice in a Multicultural Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "330",
+              "title": "Advanced Assessment and Health Promotion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "340",
+              "title": "Nursing Informatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "350",
+              "title": "Nursing Research and Evidence Translation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "410",
+              "title": "Issues in Professional Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "420",
+              "title": "Population-Based Nursing in the Community",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "430",
+              "title": "Aging and End of Life",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "440",
+              "title": "Global Health: Ethics and Human Rights",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "450",
+              "title": "Nursing Leadership",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Bachelors of Applied Science in Public Safety Administration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9425",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "BAS in PSA - Paralegal Studies Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9429",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Lower Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "100",
+              "title": "Introduction to Paralegal Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "102",
+              "title": "Legal Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "103",
+              "title": "Ethics and the Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "107",
+              "title": "Law Office Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "109",
+              "title": "Substantive Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "217",
+              "title": "Legal Research &amp; Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "218",
+              "title": "Legal Research and Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "220",
+              "title": "Civil Procedure I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "221",
+              "title": "Civil Procedure II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "232",
+              "title": "Evidence",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Upper Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PUB",
+              "number": "310",
+              "title": "Current Issues &amp; Trends in Public Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "330",
+              "title": "Adaptive Leadership in Public Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "350",
+              "title": "Emergency Operations &amp; Crisis Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "370",
+              "title": "Community Engagement &amp; Crisis Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "390",
+              "title": "Multi-Agency Response &amp; Coordination",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "410",
+              "title": "Emergency Policy &amp; Governance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "430",
+              "title": "Incident Investigation &amp; After-Action Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "450",
+              "title": "Grant Writing &amp; Public Safety Funding Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "470",
+              "title": "Public Safety Leadership &amp; Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "490",
+              "title": "Capstone: Applied Public Safety Project",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "BAS in PSA - Administration of Justice Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9428",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Lower Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "101",
+              "title": "Introduction to Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "109",
+              "title": "Substantive Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "170",
+              "title": "Forensic Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "200",
+              "title": "Current Issues in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "225",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "230",
+              "title": "The Police Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "240",
+              "title": "The Correction Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "260",
+              "title": "Procedural Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "270",
+              "title": "Community Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "275",
+              "title": "Criminal Investigations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Upper Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PUB",
+              "number": "310",
+              "title": "Current Issues &amp; Trends in Public Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "330",
+              "title": "Adaptive Leadership in Public Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "350",
+              "title": "Emergency Operations &amp; Crisis Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "370",
+              "title": "Community Engagement &amp; Crisis Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "390",
+              "title": "Multi-Agency Response &amp; Coordination",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "410",
+              "title": "Emergency Policy &amp; Governance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "430",
+              "title": "Incident Investigation &amp; After-Action Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "450",
+              "title": "Grant Writing &amp; Public Safety Funding Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "470",
+              "title": "Public Safety Leadership &amp; Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "490",
+              "title": "Capstone: Applied Public Safety Project",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "BAS in PSA - Fire Science Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9427",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Lower Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "100",
+              "title": "Principles of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "102",
+              "title": "Principles of Fire and Emergency Services Safety &amp; Survival",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "104",
+              "title": "Hazardous Materials First Responder Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "135",
+              "title": "Fire Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "137",
+              "title": "Fire Protection Hydraulics and Water Supply",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "210",
+              "title": "Advanced Fire Behavior and Combustion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "234",
+              "title": "Fire Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "235",
+              "title": "Fire Protection Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "236",
+              "title": "Occupational Safety and Health for Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "241",
+              "title": "Building Construction for Fire Protection",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Upper Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PUB",
+              "number": "310",
+              "title": "Current Issues &amp; Trends in Public Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "330",
+              "title": "Adaptive Leadership in Public Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "350",
+              "title": "Emergency Operations &amp; Crisis Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "370",
+              "title": "Community Engagement &amp; Crisis Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "390",
+              "title": "Multi-Agency Response &amp; Coordination",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "410",
+              "title": "Emergency Policy &amp; Governance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "430",
+              "title": "Incident Investigation &amp; After-Action Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "450",
+              "title": "Grant Writing &amp; Public Safety Funding Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "470",
+              "title": "Public Safety Leadership &amp; Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "490",
+              "title": "Capstone: Applied Public Safety Project",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Carpentry Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9002",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Option 1:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CBT",
+              "number": "100",
+              "title": "Basic Carpentry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "110",
+              "title": "Basic Carpentry II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Option 2:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CBT",
+              "number": "101",
+              "title": "Plan Reading, Drawings, and Codes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "102",
+              "title": "Framing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "103",
+              "title": "Masonry &amp; Concrete",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "104",
+              "title": "Framing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "105",
+              "title": "Interior Finishes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "106",
+              "title": "Remodeling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "107",
+              "title": "Exterior Finishes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "108",
+              "title": "Trim Work",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Behavioral Health Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9019",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BHS",
+              "number": "150",
+              "title": "Introduction to Behavioral Health and Social Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "155",
+              "title": "Professional Resiliency and Well-Being",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "160",
+              "title": "Ethical, Legal and Professional Issues in Behavioral Health and Social Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "165",
+              "title": "Applied Therapeutic Communication Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "170",
+              "title": "Case Management and Clinical Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BHS",
+              "number": "180",
+              "title": "Child, Family, and Adult Advocacy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Residential Trades Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9009",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CBT",
+              "number": "100",
+              "title": "Basic Carpentry I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CBT",
+                  "number": "101",
+                  "title": ""
+                }
+              ]
+            },
+            {
+              "prefix": "CBT",
+              "number": "110",
+              "title": "Basic Carpentry II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CBT",
+                  "number": "105",
+                  "title": ""
+                }
+              ]
+            },
+            {
+              "prefix": "CBT",
+              "number": "115",
+              "title": "Residential Wiring Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "120",
+              "title": "Basic Residential Plumbing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Tax Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8939",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Basic Tax Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "117",
+              "title": "Advanced Tax Planning and Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "121",
+              "title": "Introductory Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "131",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "296",
+              "title": "Internship: Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "BAS in PSA - Paramedicine Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9426",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Lower Division Requirements (31 credits)",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "ECG Rhythm Analysis &amp; Interpretation for EMS Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "252",
+              "title": "Pharmacology in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "267",
+              "title": "Technical Operations in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "269",
+              "title": "Trauma Patient Management in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "271",
+              "title": "Medical Emergencies in Paramedicine I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "271L",
+              "title": "Medical Emergencies in Paramedicine Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "272",
+              "title": "Medical Emergencies in Paramedicine II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "272L",
+              "title": "Comprehensive Patient Assessment in Paramedicine I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "273",
+              "title": "Medical Emergencies in Paramedicine III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "273L",
+              "title": "Comprehensive Patient Assessment in Paramedicine II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Upper Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PUB",
+              "number": "310",
+              "title": "Current Issues &amp; Trends in Public Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "330",
+              "title": "Adaptive Leadership in Public Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "350",
+              "title": "Emergency Operations &amp; Crisis Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "370",
+              "title": "Community Engagement &amp; Crisis Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "390",
+              "title": "Multi-Agency Response &amp; Coordination",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "410",
+              "title": "Emergency Policy &amp; Governance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "430",
+              "title": "Incident Investigation &amp; After-Action Reporting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "450",
+              "title": "Grant Writing &amp; Public Safety Funding Strategies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "470",
+              "title": "Public Safety Leadership &amp; Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PUB",
+              "number": "490",
+              "title": "Capstone: Applied Public Safety Project",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Bone Densitometry Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9044",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICE",
+              "number": "150",
+              "title": "Bone Densitometry Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICE",
+              "number": "155",
+              "title": "Bone Densitometry Clinical Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Bookkeeping Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8940",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Basic Tax Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "121",
+              "title": "Introductory Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "BS in Business - Accounting Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9027",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Lower Division Requirements (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "131",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "131",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "232",
+              "title": "Business Statistical Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "236",
+              "title": "Principles of Economics-Micro",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Accounting Lower Division Requirements (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Basic Tax Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "132",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "210",
+              "title": "Data Analytics for Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "238",
+              "title": "Advanced Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lower Division Electives (14 credits)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Upper Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSA",
+              "number": "300",
+              "title": "Global Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "305",
+              "title": "Principles of Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "310",
+              "title": "Logistics and Supply Chain Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "360",
+              "title": "Project Management Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "394",
+              "title": "Mentorship: Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "400",
+              "title": "Business Policy and Strategic Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "410",
+              "title": "Business Analytics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BSA",
+                  "number": "494",
+                  "title": "Capstone Project: Business"
+                }
+              ]
+            },
+            {
+              "prefix": "LDR",
+              "number": "300",
+              "title": "Fundamentals of Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "340",
+              "title": "Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Accounting Upper Division Requirements (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "310",
+              "title": "Accounting Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "320",
+              "title": "Cost Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "410",
+              "title": "Forensic Accounting and Fraud Examination",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "420",
+              "title": "Governmental and Nonprofit Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "430",
+              "title": "Auditing and Assurance Services",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "BS in Business - Digital Marketing Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9040",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Lower Division Requirements (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "131",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "131",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "232",
+              "title": "Business Statistical Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "236",
+              "title": "Principles of Economics-Micro",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lower Division Electives (26 credits)",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Upper Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSA",
+              "number": "300",
+              "title": "Global Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "305",
+              "title": "Principles of Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "310",
+              "title": "Logistics and Supply Chain Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "360",
+              "title": "Project Management Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "394",
+              "title": "Mentorship: Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "400",
+              "title": "Business Policy and Strategic Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "410",
+              "title": "Business Analytics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BSA",
+                  "number": "494",
+                  "title": "Capstone Project: Business"
+                }
+              ]
+            },
+            {
+              "prefix": "LDR",
+              "number": "300",
+              "title": "Fundamentals of Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "340",
+              "title": "Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Digital Marketing Upper Division Requirements (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "BS in Business - Entrepreneurship Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9028",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Lower Division Requirements (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "131",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "131",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "232",
+              "title": "Business Statistical Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "236",
+              "title": "Principles of Economics-Micro",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lower Division Electives (26 credits)",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Upper Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSA",
+              "number": "300",
+              "title": "Global Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "305",
+              "title": "Principles of Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "310",
+              "title": "Logistics and Supply Chain Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "360",
+              "title": "Project Management Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "394",
+              "title": "Mentorship: Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "400",
+              "title": "Business Policy and Strategic Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "410",
+              "title": "Business Analytics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BSA",
+                  "number": "494",
+                  "title": "Capstone Project: Business"
+                }
+              ]
+            },
+            {
+              "prefix": "LDR",
+              "number": "300",
+              "title": "Fundamentals of Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "340",
+              "title": "Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Entrepreneurship Upper Division Requirements (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LDR",
+              "number": "485",
+              "title": "Entrepreneurial Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "380",
+              "title": "Introduction to Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "385",
+              "title": "Customer Relations and Service Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "480",
+              "title": "Strategic Digital Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "490",
+              "title": "Entrepreneurial Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "BS in Business - Organizational Management and Leadership Concentration",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9026",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Lower Division Requirements (18 credits)",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "131",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "131",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "232",
+              "title": "Business Statistical Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "236",
+              "title": "Principles of Economics-Micro",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lower Division Electives (26 credits)",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Upper Division Requirements (30 credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSA",
+              "number": "300",
+              "title": "Global Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "305",
+              "title": "Principles of Finance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "310",
+              "title": "Logistics and Supply Chain Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "360",
+              "title": "Project Management Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "394",
+              "title": "Mentorship: Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "400",
+              "title": "Business Policy and Strategic Planning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "410",
+              "title": "Business Analytics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BSA",
+                  "number": "494",
+                  "title": "Capstone Project: Business"
+                }
+              ]
+            },
+            {
+              "prefix": "LDR",
+              "number": "300",
+              "title": "Fundamentals of Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "340",
+              "title": "Marketing Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Org Management & Leadership Upper Division Requirements (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LDR",
+              "number": "420",
+              "title": "Leadership and Change Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "425",
+              "title": "Leadership Application and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "430",
+              "title": "Managing Talent and Developing Leaders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "320",
+              "title": "Business Process Improvement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "325",
+              "title": "Supportive and Collaborative Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Foundations Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9046",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSA",
+              "number": "237",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "140",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "220",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "233",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Cisco Networking Specialist Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8941",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "101",
+              "title": "Networking and Cybersecurity Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "110",
+              "title": "A+ Computer Technician Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "140",
+              "title": "Cisco Routing and Switching I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "150",
+              "title": "Cisco Routing and Switching II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "160",
+              "title": "Cisco Routing and Switching III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "190",
+              "title": "Programming and Scripting for Network Admins",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computed Tomography Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8942",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICE",
+              "number": "100",
+              "title": "Computed Tomography Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICE",
+              "number": "110",
+              "title": "Computed Tomography Clinical Education I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Networking Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8943",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "101",
+              "title": "Networking and Cybersecurity Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "110",
+              "title": "A+ Computer Technician Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "118",
+              "title": "Operating System Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "120",
+              "title": "Introduction to Windows Server",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "140",
+              "title": "Cisco Routing and Switching I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Commercial Driver Training Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9003",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDT",
+              "number": "250",
+              "title": "Commercial License Prep",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: If the student has a valid CDL permit this requirement will be waived.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDT",
+              "number": "255",
+              "title": "Commercial Behind the Wheel",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Numerical Controlled (CNC) Machining Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8944",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "101",
+              "title": "CNC Machine Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "102",
+              "title": "CNC Machine Setup",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "201",
+              "title": "Computer Aided Programming for CNC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "202",
+              "title": "3-D Programming and Rapid Prototyping for CNC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "250",
+              "title": "Projects in Manufacturing Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Choose one of the following electives (3 credits):",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNC",
+              "number": "260",
+              "title": "Advanced Multi-Axis CNC Machining",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "102",
+              "title": "Introduction to Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "180",
+              "title": "CAD (Computer Aided-Drawing) with SolidWorks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IPT",
+              "number": "261",
+              "title": "Machine Shop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "200",
+              "title": "SolidWorks for Non-Engineers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Networking: Cybersecurity - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8902",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (44 credits)",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "101",
+              "title": "Networking and Cybersecurity Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "105",
+              "title": "Cybersecurity Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "110",
+              "title": "A+ Computer Technician Certification",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CNT",
+                  "number": "118",
+                  "title": "Operating System Fundamentals"
+                }
+              ]
+            },
+            {
+              "prefix": "CNT",
+              "number": "131",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "135",
+              "title": "Security+: Implementing and Maintaining Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "140",
+              "title": "Cisco Routing and Switching I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "150",
+              "title": "Cisco Routing and Switching II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "190",
+              "title": "Programming and Scripting for Network Admins",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "235",
+              "title": "Cybersecurity Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "250",
+              "title": "Securing Network Devices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "260",
+              "title": "Cybersecurity Forensics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "275",
+              "title": "Penetration Testing and Vulnerability Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "293",
+              "title": "CNT Project: Cybersecurity",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Programming Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8999",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSA",
+              "number": "282",
+              "title": "Database Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "105",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "113",
+              "title": "Programming: Python",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "125",
+              "title": "Programming: C# Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "205",
+              "title": "Programming: JavaScript, HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "211",
+              "title": "Programming: PHP and MySQL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "220",
+              "title": "Programming: Java",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Systems and Applications - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8903",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "105",
+              "title": "Cybersecurity Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "107",
+              "title": "Technology Networking Tools (TNT)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "110",
+              "title": "Introduction to Computer Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "214",
+              "title": "Foundations of Data Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "250",
+              "title": "Introduction to Artificial Intelligence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "281",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "282",
+              "title": "Database Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "294",
+              "title": "CSA Project",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: CSA 294 must be taken for a minimum of 1 credit hour.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "105",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "113",
+              "title": "Programming: Python",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "125",
+              "title": "Programming: C# Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "205",
+              "title": "Programming: JavaScript, HTML &amp; CSS",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (9 credits)",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "101",
+              "title": "Networking and Cybersecurity Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "110",
+              "title": "A+ Computer Technician Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "118",
+              "title": "Operating System Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "135",
+              "title": "Security+: Implementing and Maintaining Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "126",
+              "title": "Microsoft Office for Windows",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "211",
+              "title": "Programming: PHP and MySQL",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "220",
+              "title": "Programming: Java",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VGD",
+              "number": "121",
+              "title": "Video Game Development for Game Engines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VGD",
+              "number": "171",
+              "title": "Video Game Development - Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity Specialist Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8998",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "101",
+              "title": "Networking and Cybersecurity Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "105",
+              "title": "Cybersecurity Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "135",
+              "title": "Security+: Implementing and Maintaining Network Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "140",
+              "title": "Cisco Routing and Switching I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "150",
+              "title": "Cisco Routing and Switching II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "190",
+              "title": "Programming and Scripting for Network Admins",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "250",
+              "title": "Securing Network Devices",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Culinary Arts Fundamentals Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8946",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "101",
+              "title": "Culinary Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "102",
+              "title": "Culinary Fundamentals: Hot Foods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "103",
+              "title": "Culinary Fundamentals: Breakfast &amp; Garde Manger",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "104",
+              "title": "Culinary Fundamentals: Baking &amp; Pastry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Critical Care Provider",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9031",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements (10 credits)",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Pre-hospital Trauma Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "292",
+              "title": "Critical Care Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "293",
+              "title": "Critical Care Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Custom Firearms Design and Manufacturing Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8962",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GST",
+              "number": "211",
+              "title": "Firearms Part Design and CNC Simulation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "224",
+              "title": "CNC Machining for Gunsmithing Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "230",
+              "title": "Precision Gun Parts Maufacturing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "240",
+              "title": "Guild-Level Firearms Manufacturing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9415",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "100",
+              "title": "Introduction to Diagnostic Medical Sonography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "101",
+              "title": "Sonography Principles and Instrumentation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "102",
+              "title": "Sonography Principles and Instrumentation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "110",
+              "title": "Sonography Clinical Education I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "111",
+              "title": "Sonography Clinical Education II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "112",
+              "title": "Sonography Clinical Education III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "120",
+              "title": "Abdomen and Superficial Structures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "121",
+              "title": "Introduction to OB-GYN Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "122",
+              "title": "Abdomen and Superficial Structures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "123",
+              "title": "Introduction to Vascular Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "124",
+              "title": "Vascular Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "130",
+              "title": "Sonography Registry Review and Professional Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9004",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CNT",
+              "number": "101",
+              "title": "Networking and Cybersecurity Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "105",
+              "title": "Cybersecurity Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "110",
+              "title": "A+ Computer Technician Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNT",
+              "number": "135",
+              "title": "Security+: Implementing and Maintaining Network Security",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Detention Officer Training Academy Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9414",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "294",
+              "title": "Detention Officer Training Academy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technician - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8904",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (44 credits)",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "101",
+              "title": "Microcomputers in Agriculture",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CSA",
+                  "number": "126",
+                  "title": "Microsoft Office for Windows"
+                }
+              ]
+            },
+            {
+              "prefix": "AIT",
+              "number": "115",
+              "title": "Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "103",
+              "title": "Automotive/Diesel Preventative Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "108",
+              "title": "Diesel Engine Repair Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "109",
+              "title": "Auto/Diesel Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "124",
+              "title": "Auto/Diesel Manual Drive Trains",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "128",
+              "title": "Auto/Diesel Heating and Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "135",
+              "title": "Diesel Braking Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "208",
+              "title": "Advanced Diesel Engine Repair",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "225",
+              "title": "Diesel Engine Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "230",
+              "title": "Advanced Light/Medium Duty Diesel Diagnosis 1500-4500 Series",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "113",
+              "title": "SMAW/GMAW Welding for Non-Welding Majors",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Diesel Technician Concentration (4 credits)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "126",
+              "title": "Auto/Diesel Suspension and Steering",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mining Concentration (14 credits)",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "295",
+              "title": "Apprenticeship: Diesel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "295",
+              "title": "Apprenticeship: Diesel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: AUT 295 must be taken four times for a total of 12 credit hours.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "116",
+              "title": "Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "150",
+              "title": "Surface Mine Safety Training",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8947",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "103",
+              "title": "Automotive/Diesel Preventative Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "108",
+              "title": "Diesel Engine Repair Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "109",
+              "title": "Auto/Diesel Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "124",
+              "title": "Auto/Diesel Manual Drive Trains",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "126",
+              "title": "Auto/Diesel Suspension and Steering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "128",
+              "title": "Auto/Diesel Heating and Air Conditioning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "135",
+              "title": "Diesel Braking Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "225",
+              "title": "Diesel Engine Performance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "230",
+              "title": "Advanced Light/Medium Duty Diesel Diagnosis 1500-4500 Series",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education Advanced Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8948",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "200",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "202",
+              "title": "Early Childhood Curriculum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "222",
+              "title": "Introduction to the Exceptional Learner",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "230",
+              "title": "Language and Literacy Experiences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "234",
+              "title": "Child Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "240",
+              "title": "Family and Community Partnerships",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "250",
+              "title": "Leadership and Management in Early Childhood Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "260",
+              "title": "Child Guidance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "270",
+              "title": "Health, Safety and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "280",
+              "title": "Observation and Assessment of the Young Child",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "291",
+              "title": "Early Childhood Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education Basic Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8949",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "200",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "230",
+              "title": "Language and Literacy Experiences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "240",
+              "title": "Family and Community Partnerships",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "270",
+              "title": "Health, Safety and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "280",
+              "title": "Observation and Assessment of the Young Child",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education Industry Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9416",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "200",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "240",
+              "title": "Family and Community Partnerships",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "270",
+              "title": "Health, Safety and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Electric Utility Lineworker Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8950",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CDT",
+              "number": "250",
+              "title": "Commercial License Prep",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CDT",
+              "number": "255",
+              "title": "Commercial Behind the Wheel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Basic First Aid, CPR and AED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EUT",
+              "number": "101",
+              "title": "Basic Electricity For Lineworkers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EUT",
+              "number": "120",
+              "title": "Energy Industry Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EUT",
+              "number": "201",
+              "title": "Introduction to Linework I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EUT",
+              "number": "202",
+              "title": "Field Training I (Lineworker)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "100",
+              "title": "Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Instrumentation Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8951",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "101",
+              "title": "Microcomputers in Agriculture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "115",
+              "title": "Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "120",
+              "title": "Pneumatic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "111",
+              "title": "DC Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "112",
+              "title": "AC Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "126",
+              "title": "Solid State Devices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "162",
+              "title": "Microprocessors &amp; Microcontrollers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "165",
+              "title": "Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "183",
+              "title": "Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "258",
+              "title": "Electronic Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "271",
+              "title": "Process Control Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "272",
+              "title": "Motors and Motor Controls",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics - Digital Electronics Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8992",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "162",
+              "title": "Microprocessors &amp; Microcontrollers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "183",
+              "title": "Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics - Analog Electronics Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8991",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "111",
+              "title": "DC Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "112",
+              "title": "AC Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "126",
+              "title": "Solid State Devices",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9014",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CBT",
+              "number": "111",
+              "title": "Basic Electricity for the Trades",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "114",
+              "title": "Blueprint Reading and Electrical Codes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "115",
+              "title": "Residential Wiring Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "116",
+              "title": "Conduits and Raceways",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "117",
+              "title": "Advanced Residential Wiring",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "118",
+              "title": "Electrical Troubleshooting and Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "119",
+              "title": "Commercial Wiring Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "121",
+              "title": "Solar Applications for Electricians",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics - Industrial Electronics Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8993",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "111",
+              "title": "DC Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "112",
+              "title": "AC Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "126",
+              "title": "Solid State Devices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "165",
+              "title": "Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "271",
+              "title": "Process Control Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "272",
+              "title": "Motors and Motor Controls",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8953",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "143",
+              "title": "Emergency Medical Technician Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "144",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "144L",
+              "title": "Emergency Medical Technician Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8952",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "111",
+              "title": "DC Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "112",
+              "title": "AC Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "126",
+              "title": "Solid State Devices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "162",
+              "title": "Microprocessors &amp; Microcontrollers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "165",
+              "title": "Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "183",
+              "title": "Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "221",
+              "title": "Communication Systems and Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "258",
+              "title": "Electronic Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Enology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8954",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "130",
+              "title": "Fundamental Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "121",
+              "title": "Wines of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "122",
+              "title": "Sensory Evaluation of Wine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "195E",
+              "title": "Winemaking Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: Students must complete VEN 195E in Fall and Spring for a total of 4 credits.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "200",
+              "title": "Science of Winemaking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "201",
+              "title": "Science of Winemaking II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "202",
+              "title": "Science of Winemaking III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Service - Advanced Firefighter Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8956",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "143",
+              "title": "Emergency Medical Technician Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "144",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "144L",
+              "title": "Emergency Medical Technician Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "104",
+              "title": "Hazardous Materials First Responder Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "105",
+              "title": "Firefighter I &amp; II Certification Academy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "155",
+              "title": "Basic Wildland Firefighting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8925",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Core Requirements (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "100",
+              "title": "Principles of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "102",
+              "title": "Principles of Fire and Emergency Services Safety &amp; Survival",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "135",
+              "title": "Fire Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "210",
+              "title": "Advanced Fire Behavior and Combustion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "235",
+              "title": "Fire Protection Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "236",
+              "title": "Occupational Safety and Health for Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "241",
+              "title": "Building Construction for Fire Protection",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "A. Fire Service Operations Concentration (31 credits)",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "143",
+              "title": "Emergency Medical Technician Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "144",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "144L",
+              "title": "Emergency Medical Technician Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "104",
+              "title": "Hazardous Materials First Responder Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "105",
+              "title": "Firefighter I &amp; II Certification Academy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "B. Fire Service Administration Concentration (22 credits)",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "137",
+              "title": "Fire Protection Hydraulics and Water Supply",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "225",
+              "title": "Legal Aspects of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "234",
+              "title": "Fire Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "238",
+              "title": "Strategy and Tactics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "239",
+              "title": "Fire Department Company Officer",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "240",
+              "title": "Principles of Fire and Emergency Service Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "100",
+              "title": "Introduction to UAS",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical & Instrumentation Technology - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8924",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (16 credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (34-36 credits)",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "101",
+              "title": "Microcomputers in Agriculture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "115",
+              "title": "Hydraulic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIT",
+              "number": "120",
+              "title": "Pneumatic Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "111",
+              "title": "DC Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "112",
+              "title": "AC Electrical Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "126",
+              "title": "Solid State Devices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "162",
+              "title": "Microprocessors &amp; Microcontrollers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "165",
+              "title": "Programmable Logic Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "183",
+              "title": "Digital Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "221",
+              "title": "Communication Systems and Circuits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "258",
+              "title": "Electronic Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "271",
+              "title": "Process Control Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "272",
+              "title": "Motors and Motor Controls",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "A. Electrical & Instrumentation Technology Concentration (8-10 credits)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EGR",
+              "number": "180",
+              "title": "CAD (Computer Aided-Drawing) with SolidWorks",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: Duplicate credit for EGR 180 and MET 200 will not be awarded.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDP",
+              "number": "108",
+              "title": "3-D Printer Operation and Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "115",
+              "title": "Conduits and Raceways",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "130",
+              "title": "Introduction to Robotics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "135",
+              "title": "Robot Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "140",
+              "title": "Machine Vision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "141",
+              "title": "Electrical Apparatus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "198",
+              "title": "Electronics Topics:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "220",
+              "title": "National Electrical Codes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "114",
+              "title": "Blueprint Reading and Electrical Codes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "230",
+              "title": "Robot End Effectors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "235",
+              "title": "Integrated Manufacturing Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "279",
+              "title": "Tools for Electronic Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "296",
+              "title": "Internship: Electrical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: ELT 296 may be taken for a total of 6 credit hours.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "116",
+              "title": "Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "113",
+              "title": "SMAW/GMAW Welding for Non-Welding Majors",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "B. Mining Concentration (16 credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "295",
+              "title": "Apprenticeship: Electrical Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "295",
+              "title": "Apprenticeship: Electrical Instrumentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: ELT 295 must be taken four times for a total of 12 credit hours.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "116",
+              "title": "Rigging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MET",
+              "number": "150",
+              "title": "Surface Mine Safety Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "113",
+              "title": "SMAW/GMAW Welding for Non-Welding Majors",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Service Community Risk Reduction Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8957",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "104",
+              "title": "Hazardous Materials First Responder Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "135",
+              "title": "Fire Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "210",
+              "title": "Advanced Fire Behavior and Combustion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "225",
+              "title": "Legal Aspects of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "234",
+              "title": "Fire Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "235",
+              "title": "Fire Protection Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "241",
+              "title": "Building Construction for Fire Protection",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Service Company Officer Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8959",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "210",
+              "title": "Advanced Fire Behavior and Combustion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "225",
+              "title": "Legal Aspects of Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "236",
+              "title": "Occupational Safety and Health for Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "238",
+              "title": "Strategy and Tactics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "239",
+              "title": "Fire Department Company Officer",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "240",
+              "title": "Principles of Fire and Emergency Service Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "241",
+              "title": "Building Construction for Fire Protection",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fitness Trainer/Instructor Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8960",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EXW",
+              "number": "100M",
+              "title": "Foundations of Mind-Body Exercise",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "130H",
+              "title": "Weight Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "152",
+              "title": "Personal Health and Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "157",
+              "title": "Performance Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "251",
+              "title": "Integrated and Applied Exercise Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "252",
+              "title": "ACE Personal Trainer Preparation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Service Driver/Operator Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8958",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "137",
+              "title": "Fire Protection Hydraulics and Water Supply",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "235",
+              "title": "Fire Protection Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "236",
+              "title": "Occupational Safety and Health for Emergency Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "238",
+              "title": "Strategy and Tactics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "239",
+              "title": "Fire Department Company Officer",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "241",
+              "title": "Building Construction for Fire Protection",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8961",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "112",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "139",
+              "title": "Fundamentals of Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "201",
+              "title": "Art History: Pre-Renaissance through the 21st Century",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "100",
+              "title": "Digital Design Studio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "101",
+              "title": "Principles of Visual Communication I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "102",
+              "title": "Letters and Typography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "103",
+              "title": "Principles of Visual Communication II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "101H",
+                  "title": "College Composition I Honors"
+                }
+              ]
+            },
+            {
+              "prefix": "FMA",
+              "number": "138",
+              "title": "VFX and Motion Graphics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Gunsmithing - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8926",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (48 credits)",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GST",
+              "number": "101",
+              "title": "Gunsmithing Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "151",
+              "title": "Novice Gunsmithing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "201",
+              "title": "Intermediate Gunsmithing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "251",
+              "title": "Advanced Gunsmithing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (8 credits)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GST",
+              "number": "191",
+              "title": "Basic Engraving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "192",
+              "title": "Advanced Engraving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "195A",
+              "title": "Gunsmithing Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "195B",
+              "title": "Gunsmithing Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "291",
+              "title": "Professional Engraving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "295A",
+              "title": "Advanced Gunsmithing Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "295B",
+              "title": "Advanced Gunsmithing Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "101",
+              "title": "CNC Machine Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "102",
+              "title": "CNC Machine Setup",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "113",
+              "title": "SMAW/GMAW Welding for Non-Welding Majors",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fundamentals of Agriculture Science Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9045",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "100",
+              "title": "Introductory Equine Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "120",
+              "title": "Introduction to the Animal Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "215",
+              "title": "Agricultural Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "250",
+              "title": "Horticulture Fall Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "274",
+              "title": "Water Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC Installation & Maintenance Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9012",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HVA",
+              "number": "100",
+              "title": "Introduction to HVAC I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "110",
+              "title": "Introduction to HVAC II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "111",
+              "title": "Basic Electricity for HVAC Technicians",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "112",
+              "title": "EPA Refrigerant Certification Prep",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "215",
+              "title": "Refrigerant Technology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "220",
+              "title": "HVAC Circuits and Motors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "225",
+              "title": "Heating Technologies I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "230",
+              "title": "HVAC Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrative Health (Fitness/Reiki Trainer) - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9422",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (41 credits)",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENT",
+              "number": "210",
+              "title": "Vision to Business Plan - Entrepreneur&#039;s Institute",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "100M",
+              "title": "Foundations of Mind-Body Exercise",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "130H",
+              "title": "Weight Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "130J",
+              "title": "Weight Loss and Health with Whole Food",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "152",
+              "title": "Personal Health and Wellness",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "157",
+              "title": "Performance Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "160",
+              "title": "Health and Wellness Coaching",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "205",
+              "title": "Stress Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "210",
+              "title": "Introduction to Mindfulness Meditation and Self-Compassion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "230",
+              "title": "Complementary and Integrative Health Therapies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "251",
+              "title": "Integrated and Applied Exercise Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "252",
+              "title": "ACE Personal Trainer Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHF",
+              "number": "110",
+              "title": "Meditation for Well-Being",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHF",
+              "number": "130",
+              "title": "Hatha Yoga",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHF",
+              "number": "160",
+              "title": "T&#039;ai Chi",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHF",
+              "number": "190",
+              "title": "Reiki",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHF",
+              "number": "220",
+              "title": "Herbal Remedies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NTR",
+              "number": "135",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "HVAC Service Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9417",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HVA",
+              "number": "113",
+              "title": "Advanced HVAC Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "114",
+              "title": "Advanced Refrigeration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "115",
+              "title": "Advanced Electrical Practices for HVAC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "116",
+              "title": "NATE Certification Prep Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "235",
+              "title": "Water Management and Distribution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "240",
+              "title": "HVAC Controls and Automation Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "245",
+              "title": "Chiller Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVA",
+              "number": "250",
+              "title": "HVAC Service Diagnostics and Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Gunsmithing Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8963",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GST",
+              "number": "101",
+              "title": "Gunsmithing Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "151",
+              "title": "Novice Gunsmithing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "201",
+              "title": "Intermediate Gunsmithing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "251",
+              "title": "Advanced Gunsmithing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GST",
+              "number": "191",
+              "title": "Basic Engraving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "192",
+              "title": "Advanced Engraving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "195A",
+              "title": "Gunsmithing Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "195B",
+              "title": "Gunsmithing Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "291",
+              "title": "Professional Engraving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "295A",
+              "title": "Advanced Gunsmithing Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GST",
+              "number": "295B",
+              "title": "Advanced Gunsmithing Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "101",
+              "title": "CNC Machine Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CNC",
+              "number": "102",
+              "title": "CNC Machine Setup",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "113",
+              "title": "SMAW/GMAW Welding for Non-Welding Majors",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrative Health (Reflexology) - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9424",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (44 credits)",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "173",
+              "title": "Legal and Ethical Issues in Healthcare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "210",
+              "title": "Vision to Business Plan - Entrepreneur&#039;s Institute",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "100M",
+              "title": "Foundations of Mind-Body Exercise",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "130J",
+              "title": "Weight Loss and Health with Whole Food",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "160",
+              "title": "Health and Wellness Coaching",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "205",
+              "title": "Stress Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "230",
+              "title": "Complementary and Integrative Health Therapies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "110",
+              "title": "Western Approach to Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "130",
+              "title": "Pathology &amp; Assessment in Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "150",
+              "title": "Emotional Balance in Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "170",
+              "title": "Auriculotherapy in Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "190",
+              "title": "Reflexology Assessment I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "200",
+              "title": "Introduction to Energetic Acupressure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "210",
+              "title": "Aromatherapy &amp; Foot Chakra Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "230",
+              "title": "Reflexology Assessment II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "240",
+              "title": "Polarity in Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "250",
+              "title": "Thai Foot Massage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "260",
+              "title": "East Indian Massage: Head Acupressure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "270",
+              "title": "Hand Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "280",
+              "title": "Face-Lift Acupressure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NTR",
+              "number": "135",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Justice Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8966",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "101",
+              "title": "Introduction to Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "123",
+              "title": "Ethics and Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "192",
+              "title": "Serial Killers and Mass Murderers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "200",
+              "title": "Current Issues in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "212",
+              "title": "Juvenile Justice Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "225",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "226",
+              "title": "Victimology and Crisis Intervention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "278",
+              "title": "Neuroscience and the Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Law Enforcement Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8967",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "295",
+              "title": "Police Training Academy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Legal Office Clerk Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8968",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "100",
+              "title": "Introduction to Paralegal Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "102",
+              "title": "Legal Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "103",
+              "title": "Ethics and the Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "107",
+              "title": "Law Office Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "233",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrative Health (Massage Therapy) - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9423",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (44 credits)",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "240",
+              "title": "Human Disease Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "131",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "210",
+              "title": "Vision to Business Plan - Entrepreneur&#039;s Institute",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "130J",
+              "title": "Weight Loss and Health with Whole Food",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "160",
+              "title": "Health and Wellness Coaching",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "205",
+              "title": "Stress Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "230",
+              "title": "Complementary and Integrative Health Therapies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "130",
+              "title": "Applied Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "150",
+              "title": "Therapeutic Massage I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "155",
+              "title": "Practicum: Relaxation Massage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "170",
+              "title": "Therapeutic Massage II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "175",
+              "title": "Practicum: Therapeutic Massage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "210",
+              "title": "Therapeutic Massage III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "215",
+              "title": "Practicum: Massage Therapy for Special Populations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "230",
+              "title": "Therapeutic Massage IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "235",
+              "title": "Practicum: Spa/Hydrotherapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "250",
+              "title": "Therapeutic Massage V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NTR",
+              "number": "135",
+              "title": "Human Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Magnetic Resonance Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8969",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICE",
+              "number": "200",
+              "title": "Magnetic Resonance Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICE",
+              "number": "210",
+              "title": "Magnetic Resonance Clinical Education I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Paraprofessional Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9024",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Program Requirements (21 credits)",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "100",
+              "title": "Introduction to Paralegal Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "103",
+              "title": "Ethics and the Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "217",
+              "title": "Legal Research &amp; Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "218",
+              "title": "Legal Research and Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "220",
+              "title": "Civil Procedure I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "221",
+              "title": "Civil Procedure II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "232",
+              "title": "Evidence",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Advocacy (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "291",
+              "title": "Trial Advocacy",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "LAW",
+                  "number": "296",
+                  "title": "Internship: Paralegal Studies"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Select one Legal Paraprofessional Concentration and complete the requirements (3-6 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Administrative Law",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "230",
+              "title": "Administrative Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Civil Practice",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "270",
+              "title": "Mediation and Negotiation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Criminal Law",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "109",
+              "title": "Substantive Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "260",
+              "title": "Procedural Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Family Law",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "203",
+              "title": "Family Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Juvenile Dependency Law",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "214",
+              "title": "Juvenile Dependency Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Limited X-Ray Machine Operator Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9041",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Biology Requirement (4 credits)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Intro to Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Limited X-Ray Machine Operator Core (30 Credits)",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "100",
+              "title": "Introduction to Medical Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "101",
+              "title": "Limited Radiographic Positioning I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "103",
+              "title": "Limited Radiographic Positioning II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "104",
+              "title": "Limited Radiographic Positioning Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "105",
+              "title": "Limited Radiographic Positioning Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "115",
+              "title": "Introduction to Bone Densitometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "135",
+              "title": "Radiation Physics and Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "158",
+              "title": "Radiographic Image Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "161",
+              "title": "Radiology Clinical Education I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "162",
+              "title": "Radiology Clinical Education II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "170",
+              "title": "Radiology Patient Care and Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "175",
+              "title": "Radiation Biology and Protection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "185",
+              "title": "Radiographic Image Analysis",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Management - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8928",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (27 credits)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LDR",
+              "number": "111",
+              "title": "Leadership &amp; Innovation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "112",
+              "title": "Leadership &amp; Collaboration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "113",
+              "title": "Leadership &amp; Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "120",
+              "title": "Supervision Techniques",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MGT",
+                  "number": "132",
+                  "title": "Ethics in Business"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*Students transferring to the Bachelor of Science in Business or Bachelor of Applied Science in Business should take PHI 232 to fulfill the Arts and Humanities requirement.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "140",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "220",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "223",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "229",
+              "title": "Strategic Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "233",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (15 credits)",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "131",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "102",
+              "title": "Career Search and Success: Skills for Entering and Succeeding in the Workplace",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "131",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "237",
+              "title": "Legal Environment of Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "238",
+              "title": "Advanced Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "296",
+              "title": "Internship: Business Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "232",
+              "title": "Business Statistical Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECN",
+              "number": "236",
+              "title": "Principles of Economics-Micro",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "112",
+              "title": "Leadership &amp; Collaboration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "113",
+              "title": "Leadership &amp; Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "201",
+              "title": "Leadership Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "202",
+              "title": "Strategic Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "203",
+              "title": "Organizational Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "183",
+              "title": "Managing Business Finances",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "188",
+              "title": "Competitor Differentiation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "281",
+              "title": "High Performance Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "283",
+              "title": "Operations Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "285",
+              "title": "Growing your Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "288",
+              "title": "Business Plan Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "231",
+              "title": "Social Media Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "280",
+              "title": "Marketing Tactics and Techniques",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Management - Foundations of Leadership Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9035",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LDR",
+              "number": "111",
+              "title": "Leadership &amp; Innovation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "112",
+              "title": "Leadership &amp; Collaboration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "113",
+              "title": "Leadership &amp; Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Management - Entrepreneurship Principles and Practice Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9011",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGT",
+              "number": "183",
+              "title": "Managing Business Finances",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "188",
+              "title": "Competitor Differentiation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "280",
+              "title": "Marketing Tactics and Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "281",
+              "title": "High Performance Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "283",
+              "title": "Operations Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "285",
+              "title": "Growing your Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "288",
+              "title": "Business Plan Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Management Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8984",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGT",
+              "number": "140",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "220",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "223",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "229",
+              "title": "Strategic Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: It is recommended that students take MGT 229 in the final semester of their program.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "233",
+              "title": "Business Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "A. Organizational Management Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MGT",
+              "number": "120",
+              "title": "Supervision Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "132",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "B. Retail Management Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "131",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "228",
+              "title": "Professional Productivity Solutions",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Massage Therapy Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9420",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "240",
+              "title": "Human Disease Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Intro to Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BSA",
+              "number": "131",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXW",
+              "number": "230",
+              "title": "Complementary and Integrative Health Therapies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "130",
+              "title": "Applied Massage Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "150",
+              "title": "Therapeutic Massage I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "155",
+              "title": "Practicum: Relaxation Massage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "170",
+              "title": "Therapeutic Massage II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "175",
+              "title": "Practicum: Therapeutic Massage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "210",
+              "title": "Therapeutic Massage III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "215",
+              "title": "Practicum: Massage Therapy for Special Populations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "230",
+              "title": "Therapeutic Massage IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "235",
+              "title": "Practicum: Spa/Hydrotherapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHM",
+              "number": "250",
+              "title": "Therapeutic Massage V",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Media Editing and Post-Production Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9036",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements (27 credits)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FMA",
+              "number": "100",
+              "title": "Animation Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "102",
+              "title": "Film and Media Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "107",
+              "title": "Post-Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "138",
+              "title": "VFX and Motion Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "139",
+              "title": "Fundamentals of Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "150",
+              "title": "History of American Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "160",
+              "title": "Lighting Design for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "161",
+              "title": "Sound Design for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "218",
+              "title": "Directing for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8970",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "105",
+              "title": "Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Assistant Administrative Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "121",
+              "title": "Medical Assistant Clinical Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "130",
+              "title": "Medical Terminology for Patient Care Staff",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "140",
+              "title": "Pharmacology for Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "173",
+              "title": "Legal and Ethical Issues in Healthcare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "240",
+              "title": "Human Disease Process",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "295",
+              "title": "AHS Practicum: Medical Assistant",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Intro to Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Management - Strategic Leadership Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9015",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LDR",
+              "number": "201",
+              "title": "Leadership Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "202",
+              "title": "Strategic Leadership",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LDR",
+              "number": "203",
+              "title": "Organizational Leadership",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Medical Records Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8971",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Fundamentals of Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "130",
+              "title": "Medical Terminology for Patient Care Staff",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "173",
+              "title": "Legal and Ethical Issues in Healthcare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Intro to Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "126",
+              "title": "Microsoft Office for Windows",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "134",
+              "title": "Introduction to Health Information Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9000",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Fundamentals of Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "120",
+              "title": "Medical Assistant Administrative Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "130",
+              "title": "Medical Terminology for Patient Care Staff",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "173",
+              "title": "Legal and Ethical Issues in Healthcare",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Intro to Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSA",
+              "number": "126",
+              "title": "Microsoft Office for Windows",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "142",
+              "title": "College Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8929",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education (16 credits)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Anatomy & Physiology I & II (8 credits)",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "201",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "202",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Microbiology (4 credits)",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Nursing Core (40.5 credits)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "140",
+              "title": "Nursing Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "142",
+              "title": "Application of Nursing Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "143",
+              "title": "Development of Nursing Practice I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "144",
+              "title": "Mental Health Nursing Theory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "145",
+              "title": "Pharmacology for Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "151",
+              "title": "Nursing Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "152",
+              "title": "Application of Nursing Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "153",
+              "title": "Development of Nursing Practice II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "154",
+              "title": "Maternal/Child Nursing Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "155",
+              "title": "Pharmacology for Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "241",
+              "title": "Nursing Theory III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "242",
+              "title": "Application of Nursing Theory III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "260",
+              "title": "Mental Health Nursing Theory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Theory IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "272",
+              "title": "Application of Nursing Theory IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "280",
+              "title": "Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8972",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "114",
+              "title": "Nursing Assistant",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "114C",
+              "title": "Nursing Assistant Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "114L",
+              "title": "Nursing Assistant Skills Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Paramedicine - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8931",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (41 credits)",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "162",
+              "title": "Introduction to Pharmacology for EMS Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "ECG Rhythm Analysis &amp; Interpretation for EMS Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Advanced Cardiac Life Support Initial Provider in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Pediatric Advanced Life Support Initial Provider in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Pre-hospital Trauma Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "239",
+              "title": "Airway and Ventilatory Management in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "252",
+              "title": "Pharmacology in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Paramedic Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "265",
+              "title": "Paramedic Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "267",
+              "title": "Technical Operations in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "269",
+              "title": "Trauma Patient Management in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "271",
+              "title": "Medical Emergencies in Paramedicine I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "271L",
+              "title": "Medical Emergencies in Paramedicine Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "272",
+              "title": "Medical Emergencies in Paramedicine II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "272L",
+              "title": "Comprehensive Patient Assessment in Paramedicine I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "273",
+              "title": "Medical Emergencies in Paramedicine III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "273L",
+              "title": "Comprehensive Patient Assessment in Paramedicine II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8974",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "100",
+              "title": "Fundamentals of Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "105",
+              "title": "Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "296",
+              "title": "Internship: Allied Health Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: Students must enroll in AHS 296 within 3 semesters of completing AHS 105, as well as complete all Phlebotomy requirements and receive program director permission prior to enrollment.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Studies - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8983",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (24 credits)",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "100",
+              "title": "Introduction to Paralegal Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "102",
+              "title": "Legal Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "103",
+              "title": "Ethics and the Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "217",
+              "title": "Legal Research &amp; Writing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "218",
+              "title": "Legal Research and Writing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "220",
+              "title": "Civil Procedure I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "221",
+              "title": "Civil Procedure II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "232",
+              "title": "Evidence",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "104",
+              "title": "Wills, Trusts and Probate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "107",
+              "title": "Law Office Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "109",
+              "title": "Substantive Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "202",
+              "title": "Real Estate Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "203",
+              "title": "Family Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "204",
+              "title": "Business Organizations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "205",
+              "title": "Contracts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "212",
+              "title": "Juvenile Justice Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "214",
+              "title": "Juvenile Dependency Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "230",
+              "title": "Administrative Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "260",
+              "title": "Procedural Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "270",
+              "title": "Mediation and Negotiation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "275",
+              "title": "Bankruptcy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "290",
+              "title": "Constitutional Law: Civil Liberties and Civil Rights",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "296",
+              "title": "Internship: Paralegal Studies",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedicine Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8973",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "160",
+              "title": "Intro to Human Anatomy and Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "162",
+              "title": "Introduction to Pharmacology for EMS Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "ECG Rhythm Analysis &amp; Interpretation for EMS Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "201",
+              "title": "Advanced Cardiac Life Support Initial Provider in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "Pediatric Advanced Life Support Initial Provider in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Pre-hospital Trauma Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "239",
+              "title": "Airway and Ventilatory Management in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "252",
+              "title": "Pharmacology in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "254",
+              "title": "Paramedic Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "265",
+              "title": "Paramedic Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "267",
+              "title": "Technical Operations in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "269",
+              "title": "Trauma Patient Management in Paramedicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "271",
+              "title": "Medical Emergencies in Paramedicine I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "271L",
+              "title": "Medical Emergencies in Paramedicine Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "272",
+              "title": "Medical Emergencies in Paramedicine II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "272L",
+              "title": "Comprehensive Patient Assessment in Paramedicine I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "273",
+              "title": "Medical Emergencies in Paramedicine III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "273L",
+              "title": "Comprehensive Patient Assessment in Paramedicine II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9013",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CBT",
+              "number": "100",
+              "title": "Basic Carpentry I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CBT",
+                  "number": "101",
+                  "title": ""
+                }
+              ]
+            },
+            {
+              "prefix": "CBT",
+              "number": "112",
+              "title": "Plumbing Codes &amp; Standards, Blueprint, and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "120",
+              "title": "Basic Residential Plumbing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CBT",
+              "number": "212",
+              "title": "Drain, Waste, and Vent Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing Transition Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9030",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements (1.5 credits)",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LPN",
+              "number": "190",
+              "title": "Practical Nursing Transition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Practical Nursing Fast Track Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9039",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LPN",
+              "number": "101",
+              "title": "Fundamentals of Practical Nursing Care I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPN",
+              "number": "105",
+              "title": "Development of Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPN",
+              "number": "110",
+              "title": "Application of Practical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPN",
+              "number": "115",
+              "title": "Pharmacology for Practical Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPN",
+              "number": "201",
+              "title": "Fundamentals of Practical Nursing Care II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPN",
+              "number": "205",
+              "title": "Advanced Development of Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPN",
+              "number": "210",
+              "title": "Application of Practical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LPN",
+              "number": "215",
+              "title": "Pharmacology for Practical Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Radiologic Technology - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8932",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Radiologic Technology Core (43 credits)",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "100",
+              "title": "Introduction to Medical Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "111",
+              "title": "Radiographic Positioning I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "112",
+              "title": "Radiographic Positioning Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "135",
+              "title": "Radiation Physics and Equipment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "141",
+              "title": "Radiographic Positioning II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "142",
+              "title": "Radiographic Positioning Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "158",
+              "title": "Radiographic Image Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "161",
+              "title": "Radiology Clinical Education I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "162",
+              "title": "Radiology Clinical Education II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "170",
+              "title": "Radiology Patient Care and Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "175",
+              "title": "Radiation Biology and Protection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "185",
+              "title": "Radiographic Image Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "201",
+              "title": "Radiology Clinical Education III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "202",
+              "title": "Radiology Clinical Education IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "250",
+              "title": "Radiographic Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "255",
+              "title": "Radiology Registry Prep and Professional Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Studies (2-4 credits)",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICE",
+              "number": "100",
+              "title": "Computed Tomography Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICE",
+              "number": "150",
+              "title": "Bone Densitometry Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICE",
+              "number": "200",
+              "title": "Magnetic Resonance Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICE",
+              "number": "250",
+              "title": "Mammography Initial Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "215",
+              "title": "Advanced Imaging Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Production Horticulture Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8975",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements (32 credits)",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "103",
+              "title": "Plant Biology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "105",
+              "title": "Soils",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "107",
+              "title": "Entomology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "156",
+              "title": "Organic Home Gardening",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "157",
+              "title": "Community Supported Agriculture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "202",
+              "title": "Summer Horticulture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "215",
+              "title": "Agricultural Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "250",
+              "title": "Horticulture Fall Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "252",
+              "title": "Horticulture Spring Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "255",
+              "title": "Micro Propagation of Plant Tissue",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "274",
+              "title": "Water Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Script Supervisor Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9037",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements (12 credits)",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FMA",
+              "number": "102",
+              "title": "Film and Media Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "103",
+              "title": "Screenwriting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "110",
+              "title": "Pre-Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "218",
+              "title": "Directing for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Robotics Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9418",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELT",
+              "number": "130",
+              "title": "Introduction to Robotics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "135",
+              "title": "Robot Operator",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "140",
+              "title": "Machine Vision",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "230",
+              "title": "Robot End Effectors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "235",
+              "title": "Integrated Manufacturing Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELT",
+              "number": "240",
+              "title": "Advanced Applications in Robotics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Stage and Media Production Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8987",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FMA",
+              "number": "100",
+              "title": "Animation Principles",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "FMA",
+                  "number": "113",
+                  "title": "Stop Motion Animation"
+                }
+              ]
+            },
+            {
+              "prefix": "FMA",
+              "number": "102",
+              "title": "Film and Media Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "103",
+              "title": "Screenwriting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "107",
+              "title": "Post-Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "110",
+              "title": "Pre-Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "116",
+              "title": "The Business of Content Creation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "117",
+              "title": "Cinematography and Lighting",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "FMA",
+                  "number": "218",
+                  "title": "Directing for Stage and Media"
+                }
+              ]
+            },
+            {
+              "prefix": "FMA",
+              "number": "138",
+              "title": "VFX and Motion Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "139",
+              "title": "Fundamentals of Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "150",
+              "title": "History of American Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "160",
+              "title": "Lighting Design for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "161",
+              "title": "Sound Design for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Reflexology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9419",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IHR",
+              "number": "110",
+              "title": "Western Approach to Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "130",
+              "title": "Pathology &amp; Assessment in Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "150",
+              "title": "Emotional Balance in Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "170",
+              "title": "Auriculotherapy in Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "190",
+              "title": "Reflexology Assessment I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "200",
+              "title": "Introduction to Energetic Acupressure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "210",
+              "title": "Aromatherapy &amp; Foot Chakra Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "230",
+              "title": "Reflexology Assessment II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "240",
+              "title": "Polarity in Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "250",
+              "title": "Thai Foot Massage",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "260",
+              "title": "East Indian Massage: Head Acupressure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "270",
+              "title": "Hand Reflexology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IHR",
+              "number": "280",
+              "title": "Face-Lift Acupressure",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Theater in Stagecraft Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9016",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THR",
+              "number": "141",
+              "title": "Stagecraft",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "144",
+              "title": "Production Workshop Practicum: Costuming and Make-up",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "145",
+              "title": "Production Workshop Practicum: Stage Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "146",
+              "title": "Production Workshop Practicum: Set Building and Props",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "147",
+              "title": "Production Workshop Practicum: Theater Production Crew",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "160",
+              "title": "Lighting Design for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "161",
+              "title": "Sound Design for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THR",
+              "number": "164",
+              "title": "Scenic Design for Stage and Media",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Unmanned Aircraft Systems Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9018",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "UAS",
+              "number": "100",
+              "title": "Introduction to UAS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "103",
+              "title": "UAS Simulations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "110",
+              "title": "UAS Fixed-Wing Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "115",
+              "title": "UAS Multirotor Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "120",
+              "title": "UAS Sensing Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "132",
+              "title": "UAS Flight Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "216",
+              "title": "UAS Geographic Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "250",
+              "title": "UAS Applications and Analytics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Video Game Developer Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8976",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "105",
+              "title": "Introduction to Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "125",
+              "title": "Programming: C# Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VGD",
+              "number": "121",
+              "title": "Video Game Development for Game Engines",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VGD",
+              "number": "151",
+              "title": "3D Modeling and Animation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VGD",
+              "number": "171",
+              "title": "Video Game Development - Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VGD",
+              "number": "180",
+              "title": "Game Theory and Design Principles",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Victim Advocacy Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9042",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AJS",
+              "number": "101",
+              "title": "Introduction to Administration of Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "123",
+              "title": "Ethics and Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "226",
+              "title": "Victimology and Crisis Intervention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "227",
+              "title": "Victim Advocacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AJS",
+              "number": "228",
+              "title": "Gender-Related Violence",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Design - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8988",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (25 credits)",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (33 credits)",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "110",
+              "title": "Drawing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "Three-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Color",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "139",
+              "title": "Fundamentals of Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "214",
+              "title": "Digital Illustration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "100",
+              "title": "Digital Design Studio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "101",
+              "title": "Principles of Visual Communication I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "102",
+              "title": "Letters and Typography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "103",
+              "title": "Principles of Visual Communication II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "204",
+              "title": "Web Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "138",
+              "title": "VFX and Motion Graphics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives (3 credits)",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "160",
+              "title": "Printmaking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "296",
+              "title": "Internship: Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "100",
+              "title": "Animation Principles",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "108",
+              "title": "Social Media Planning and Implementation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "113",
+              "title": "Stop Motion Animation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Viticulture and Enology - AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8933",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "AAS General Education Requirements (19 credits)",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Program Requirements (44 credits)",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "105",
+              "title": "Soils",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "107",
+              "title": "Entomology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "274",
+              "title": "Water Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "100",
+              "title": "Introduction to Viticulture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "101",
+              "title": "Establishing a Vinifera Vineyard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "103",
+              "title": "Maintaining a Vinifera Vineyard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "121",
+              "title": "Wines of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "122",
+              "title": "Sensory Evaluation of Wine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "195E",
+              "title": "Winemaking Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: Students must complete VEN 195E in Fall and Spring for a total of 4 credits.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "195V",
+              "title": "Viticulture Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: Students must complete VEN 195V in Fall and Spring for a total of 4 credits.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "200",
+              "title": "Science of Winemaking I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "201",
+              "title": "Science of Winemaking II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "202",
+              "title": "Science of Winemaking III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Viticulture Fundamentals Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9005",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "105",
+              "title": "Soils",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "274",
+              "title": "Water Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "100",
+              "title": "Introduction to Viticulture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "101",
+              "title": "Establishing a Vinifera Vineyard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "103",
+              "title": "Maintaining a Vinifera Vineyard",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding - Gas Metal Arc Welding Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8978",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Oxyacetylene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Arc I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Arc II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "156",
+              "title": "Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "210",
+              "title": "Gas Metal Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "250",
+              "title": "Welded Metal Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Viticulture Advanced Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8977",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGS",
+              "number": "105",
+              "title": "Soils",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "107",
+              "title": "Entomology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGS",
+              "number": "274",
+              "title": "Water Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "100",
+              "title": "Introduction to Viticulture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "101",
+              "title": "Establishing a Vinifera Vineyard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "103",
+              "title": "Maintaining a Vinifera Vineyard",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEN",
+              "number": "195V",
+              "title": "Viticulture Practicum",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Note: Students must complete VEN 195V in Fall and Spring for a total of 4 credits.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding - Gas Tungsten Arc Welding Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8979",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Oxyacetylene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Arc I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Arc II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "156",
+              "title": "Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "200",
+              "title": "Gas Tungsten Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "250",
+              "title": "Welded Metal Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding - Structural Welding Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8981",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Oxyacetylene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Arc I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Arc II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "156",
+              "title": "Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Women's Health Imaging Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=9038",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements (7 credits)",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ICE",
+              "number": "250",
+              "title": "Mammography Initial Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ICE",
+              "number": "255",
+              "title": "Mammography Clinical Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Writing for the Screen Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8986",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FMA",
+              "number": "103",
+              "title": "Screenwriting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "104",
+              "title": "Podcasting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "110",
+              "title": "Pre-Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "116",
+              "title": "The Business of Content Creation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "121",
+              "title": "Screenwriting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "150",
+              "title": "History of American Cinema",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMA",
+              "number": "190",
+              "title": "Foundations of Documentary and Docudrama Storytelling",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding - Pipe Welding Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.yc.edu/preview_program.php?catoid=29&poid=8980",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "130",
+              "title": "Oxyacetylene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "140",
+              "title": "Arc I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "145",
+              "title": "Arc II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "156",
+              "title": "Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "250",
+              "title": "Welded Metal Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "282",
+              "title": "Pipe Welding I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/lib/states/az/config.ts
+++ b/lib/states/az/config.ts
@@ -77,9 +77,14 @@ const azConfig: StateConfig = {
     transfers: [
       { scripts: ["scripts/az/scrape-transfer-aztransfer.ts"], runner: "http" },
     ],
-    // manual-only: programs — scripts/az/scrape-programs.ts wrapper exists
-    //   but each of the 4 Acalog catalogs needs manual navoid identification
-    //   (auto-discovery finds catoid but not navoids — same as NV/CSN).
+    // Programs: 4 Acalog catalogs (pima, yavapai, mohave, coconino) scraped via
+    // search_advanced.php discovery (navoid auto-discovery finds 0 on these).
+    // The Maricopa Coursedog catalog publishes no programs, and the other
+    // Coursedog colleges (cochise/eastern-arizona/central-arizona) expose no
+    // plannable requirements — see scripts/az/scrape-programs.ts for details.
+    programs: [
+      { scripts: ["scripts/az/scrape-programs.ts"], runner: "http" },
+    ],
   },
   documentedCeilings: {
     courses: [

--- a/scripts/az/scrape-programs.ts
+++ b/scripts/az/scrape-programs.ts
@@ -1,45 +1,62 @@
 /**
- * scrape-programs.ts — degree/program requirements for AZ.
+ * scrape-programs.ts — degree/certificate program requirements for AZ
+ * community colleges.
  *
- * Seeded from scripts/lib/discover-programs.ts (Phase 6) and then hand-
- * verified — the discoverer's domain-fallback heuristic produced 5
- * cross-state false positives (e.g. catalog.south.edu = South College
- * Tennessee, not South Mountain CC in AZ). Only catalogs whose body
- * actually identifies the AZ college are wired here.
+ * Active: 4 Acalog colleges. Program lists on these catalogs are JS-rendered,
+ * so we discover them through search_advanced.php (useSearchDiscovery) — the
+ * navoid auto-discovery finds 0 on these, which is why the 2026-05-24 seed
+ * (navoids-only) produced no data.
  *
- * Verified (2026-05-24):
- *   cochise-county-community-college-district → catalog.cochise.edu (coursedog)
- *   mohave-community-college                  → catalog.mohave.edu  (acalog)
- *   pima-community-college                    → catalog.pima.edu    (acalog)
- *   coconino-community-college                → catalog.coconino.edu (acalog)
+ *   pima      → catalog.pima.edu      (~100 programs)
+ *   yavapai   → catalog.yc.edu        (~139)
+ *   mohave    → catalog.mohave.edu    (~108)
+ *   coconino  → catalog.coconino.edu  (~53)
  *
- * Dropped (false-positive cross-state catalogs):
- *   rio-salado-college               → catalog.rio.edu      = University of Rio Grande (OH)
- *   arizona-western-college          → catalog.arizona.edu  = University of Arizona
- *   eastern-arizona-college          → catalog.eastern.edu  = Eastern University (PA)
- *   northland-pioneer-college        → catalog.northland.edu = Northland College (WI)
- *   south-mountain-community-college → catalog.south.edu    = South College (TN)
+ * NOT scraped (no usable public program data — verified live 2026-06):
+ *   - 10 Maricopa district colleges (chandler-gilbert, estrella-mountain,
+ *     gateway, glendale, mesa, paradise-valley, phoenix, rio-salado,
+ *     scottsdale, south-mountain): share one Coursedog catalog at
+ *     catalog.maricopa.edu whose programs section is EMPTY ("Results (0) — No
+ *     Programs Found"); the tenant (maricopa_peoplesoft_direct) is a
+ *     courses-only PeopleSoft feed with no published degree requirements.
+ *   - cochise (catalog.cochise.edu, Coursedog): catalog returns 0 programs.
+ *   - eastern-arizona (catalog.eac.edu, Coursedog): 200 program shells, but
+ *     none expose requirements in the requisitesSimple structure this scraper
+ *     reads — nothing plannable.
+ *   - central-arizona (catalog.centralaz.edu, Coursedog): 63 programs, but
+ *     they list narrative requirements rather than course codes (only ~1 had
+ *     >=5 real courses) — not plannable, so omitted.
+ *   - arizona-western, northland-pioneer, dine, tohono-oodham: no public
+ *     catalog on any supported platform.
  *
  * Usage:
  *   npx tsx scripts/az/scrape-programs.ts
+ *   npx tsx scripts/az/scrape-programs.ts --college pima-community-college
  */
 
 import * as fs from "fs";
 import * as path from "path";
 import { applyProgramMatching } from "../../lib/programs/matcher.js";
 import { scrapeAcalogPrograms } from "../lib/scrape-acalog-programs.js";
-import { scrapeCoursedogPrograms } from "../lib/scrape-coursedog-programs.js";
+import type { AcalogProgramConfig } from "../lib/scrape-acalog-programs.js";
+
+const ACALOG: AcalogProgramConfig[] = [
+  { collegeSlug: "pima-community-college", baseUrl: "https://catalog.pima.edu", catoidFallback: 17, programNavoids: [], autoDiscoverCatoid: true, useSearchDiscovery: true },
+  { collegeSlug: "yavapai-college", baseUrl: "https://catalog.yc.edu", catoidFallback: 29, programNavoids: [], autoDiscoverCatoid: true, useSearchDiscovery: true },
+  { collegeSlug: "mohave-community-college", baseUrl: "https://catalog.mohave.edu", catoidFallback: 71, programNavoids: [], autoDiscoverCatoid: true, useSearchDiscovery: true },
+  { collegeSlug: "coconino-community-college", baseUrl: "https://catalog.coconino.edu", catoidFallback: 14, programNavoids: [], autoDiscoverCatoid: true, useSearchDiscovery: true },
+];
 
 async function run(
   slug: string,
   scrape: () => Promise<{ programs: unknown[]; catalog_year: string; catalog_url: string; college_slug: string; scraped_at: string }>,
-): Promise<void> {
+): Promise<number> {
   console.log(`\n=== ${slug} ===`);
   try {
     const data = await scrape();
     if (data.programs.length === 0) {
-      console.log(`  No programs found for ${slug}.`);
-      return;
+      console.log(`  No programs found for ${slug} (file not written).`);
+      return 0;
     }
     const { matched, unmatched } = applyProgramMatching(data.programs as never);
     console.log(`  Matcher: ${matched} matched / ${unmatched} unmatched`);
@@ -48,56 +65,28 @@ async function run(
     const outPath = path.join(outDir, `${slug}.json`);
     fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
     console.log(`  ✓ Wrote ${data.programs.length} programs → ${outPath}`);
+    return data.programs.length;
   } catch (e) {
     console.error(`  ✗ ${slug} failed: ${e}`);
+    return -1;
   }
 }
 
 async function main() {
+  const args = process.argv.slice(2);
+  const flag = args.indexOf("--college");
+  const only = flag >= 0 ? args[flag + 1] : null;
+
   console.log("AZ program scraper");
+  const summary: { slug: string; programs: number }[] = [];
 
-  // cochise-county-community-college-district (coursedog)
-  await run("cochise-county-community-college-district", () =>
-    scrapeCoursedogPrograms({
-      collegeSlug: "cochise-county-community-college-district",
-      catalogDomain: "catalog.cochise.edu",
-      catalogYear: "2025-2026",
-    }),
-  );
+  for (const c of ACALOG) {
+    if (only && c.collegeSlug !== only) continue;
+    summary.push({ slug: c.collegeSlug, programs: await run(c.collegeSlug, () => scrapeAcalogPrograms(c)) });
+  }
 
-  // mohave-community-college (acalog) — operator must fill catoidFallback
-  // and programNavoids after first run (auto-discovery often finds 0 navoids).
-  await run("mohave-community-college", () =>
-    scrapeAcalogPrograms({
-      collegeSlug: "mohave-community-college",
-      baseUrl: "https://catalog.mohave.edu",
-      catoidFallback: 0,
-      programNavoids: [],
-      autoDiscoverCatoid: true,
-    }),
-  );
-
-  // pima-community-college (acalog)
-  await run("pima-community-college", () =>
-    scrapeAcalogPrograms({
-      collegeSlug: "pima-community-college",
-      baseUrl: "https://catalog.pima.edu",
-      catoidFallback: 0,
-      programNavoids: [],
-      autoDiscoverCatoid: true,
-    }),
-  );
-
-  // coconino-community-college (acalog)
-  await run("coconino-community-college", () =>
-    scrapeAcalogPrograms({
-      collegeSlug: "coconino-community-college",
-      baseUrl: "https://catalog.coconino.edu",
-      catoidFallback: 0,
-      programNavoids: [],
-      autoDiscoverCatoid: true,
-    }),
-  );
+  console.log(`\n${"=".repeat(60)}\nDone. ${summary.filter((s) => s.programs > 0).length} college(s) with programs:`);
+  for (const s of summary) console.log(`  ${s.slug}: ${s.programs < 0 ? "ERROR" : s.programs}`);
 }
 
 main().catch((e) => {


### PR DESCRIPTION
## What changes for someone using the site

Students at **four Arizona community colleges — Pima, Yavapai, Mohave, and Coconino** — can now build a degree plan on the site. Until now AZ had course schedules, transfer guides, and prerequisites, but **no program/degree data**, so the degree-path planner couldn't run for any AZ college. This adds **400 programs (316 of them fully plannable)** pulled from those colleges' official catalogs — e.g. a Pima student can now pull up "Accounting, AAS" and see all nine semesters of required courses (ACC 105, ACC 150, …), then drop it into the planner.

This covers 4 of AZ's 21 colleges. The other 17 genuinely don't publish machine-readable degree requirements right now (details below) — that's named honestly, not hidden.

## State-data impact

AZ goes from **0 → 4 colleges with plannable programs**. AZ's other dimensions were already strong (transfers A, prereqs A, scorecard A, courses B), so programs was the missing dataset blocking the planner. The audit doesn't grade programs directly, so this is verified by a file-based oracle (count of programs with ≥5 real course codes), not a letter grade.

| College | Programs | Plannable (≥5 real courses) |
|---|---|---|
| pima | 100 | 79 |
| yavapai | 139 | 106 |
| mohave | 108 | 93 |
| coconino | 53 | 38 |
| **total** | **400** | **316** |

## How it works

`scripts/az/scrape-programs.ts` finishes a stub left by the 2026-05-24 auto-add-state run. Those four catalogs run on **Acalog**, which renders its program lists in JavaScript — so the original navoid-based seed found nothing. Switching to `search_advanced.php` discovery (`useSearchDiscovery`) + auto-catoid surfaces every program. Output files are named exactly `{institution.college_slug}.json` so the planner's loader finds them (the MS/TN filename-mismatch bug). Wired into `lib/states/az/config.ts` under `scrapers.programs`, replacing the old `manual-only` marker.

## Why only 4 colleges — the honest scope

The original plan hoped to anchor on the **Maricopa district's 10 colleges** sharing one Coursedog catalog. Probing it live disproved that: `catalog.maricopa.edu` renders **"Results (0) — No Programs Found"** — its tenant (`maricopa_peoplesoft_direct`) is a courses-only PeopleSoft feed with no published degree requirements. The remaining colleges:

- **cochise** (Coursedog) — catalog returns 0 programs.
- **eastern-arizona** (Coursedog) — 200 program shells, but none expose requirements the scraper can read.
- **central-arizona** (Coursedog) — 63 programs, but they list narrative requirements rather than course codes (only ~1 had ≥5 real courses) — omitted rather than ship hollow data.
- **arizona-western, northland-pioneer, dine, tohono-oodham** — no public catalog on a supported platform.

All of this is documented in the scraper header so it's re-checkable later (e.g. when Maricopa loads its 26-27 catalog).

## Test plan

- Per-file `countRealCourses(p) >= 5` oracle → 316 plannable programs across 4 colleges.
- Filenames verified `== institution.college_slug` for all 4.
- One program spot-checked end-to-end: pima "Accounting, AAS" → 9 requirement groups, real `ACC`/`CSA`/`STU` codes, `catalog_year` 2026-2027.
- `npm run typecheck` clean; `npm run check:scrapers` OK (programs declaration recognized).
- Visual planner confirm is the **post-merge prod check** — the programs read path is Supabase-first, so local dev shows stale-empty until `import-on-merge` runs.

## Scope / safety

- Stages only `scripts/az/scrape-programs.ts`, `lib/states/az/config.ts`, and the 4 new `data/az/programs/*.json`. No `git add -A`, no derived-data churn.
- No fabricated data — colleges whose catalogs yielded no real course requirements were omitted and named, per invariant #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
