### PR TITLE
programs: paginate CourseDog fetch → cape-fear (NC) 100 → 228 plannable

### DIFF
--- a/data/nc/DEFERRED-programs.md
+++ b/data/nc/DEFERRED-programs.md
@@ -4,7 +4,7 @@ Programs rollout for North Carolina (NCCCS, 58 colleges). Catalog platform per
 college is fingerprinted by `scripts/nc/discover-catalogs.ts` →
 `data/nc/catalog-discovery.json`, then scraped by the matching platform wrapper.
 
-## Shipped — 18 colleges, 2,624 programs scraped; **2,010 plannable across 17 colleges**
+## Shipped — 18 colleges, 2,795 programs scraped; **2,138 plannable across 17 colleges**
 
 Verified via `countRealCourses >= PLAN_MIN_COURSES`. The Acalog parser fix on
 2026-06-04 unlocked **gaston (0 → 96)** and **guilford-technical (0 → 224)**; a
@@ -37,14 +37,18 @@ the codes were never behind links.
 **CourseDog — Colleague-Ethos variant.** These tenants emit requirements as an inline
 HTML blob in `requisites.requisitesFreeform` instead of the structured
 `requisitesSimple` rule tree the lib walked, so it parsed 0.
-- **cape-fear — RESOLVED 2026-06-05 (0 → 100 plannable).** `parseFreeformRequisites` in
+- **cape-fear — RESOLVED 2026-06-05 (0 → 228 plannable).** `parseFreeformRequisites` in
   `scrape-coursedog-programs.ts` parses the freeform HTML (reusing the Acalog
-  `parseCourseFromLabel`). NOTE: only the first 200 of cape-fear's 473 programs are
-  scraped (the lib's single-page `PROGRAMS_PAGE_SIZE` cap — pagination is a follow-up),
-  and a few umbrella/transfer degrees (AA, Associate in General Education) list very large
-  elective pools (up to ~1,400 courses), reflecting the catalog's own structure.
-- **central-carolina — still deferred.** Same freeform shape, but the program-detail
-  endpoint returned mostly empty requisites in probing; needs a focused look.
+  `parseCourseFromLabel`). Pagination (2026-06-05) lifted it from 100 → 228: `listAllPrograms`
+  now pages through `skip += PROGRAMS_PAGE_SIZE` instead of fetching a single 200-row page,
+  so all 469 programs are scraped (275 with parseable requirements). A few umbrella/transfer
+  degrees (AA, Associate in General Education) list very large elective pools (up to ~1,400
+  courses), reflecting the catalog's own structure.
+- **central-carolina — deferred (empty requirement data).** Pagination now fetches all 644
+  programs, but their CourseDog program-detail `requisites` come back **`{}`** — no
+  requisitesSimple AND no requisitesFreeform (verified 2026-06-05). The catalog simply
+  doesn't publish machine-readable requirements here; not a parser gap. Same for **del-mar
+  (TX)** (282 fetched, all empty). Would need a different source (HTML catalog pages / PDF).
 - **isothermal — different problem (NOT freeform).** Re-scrapes 153 programs whose
   requirement GROUPS parse but whose course IDs don't resolve to courses → 0 plannable.
   Separate fix.

--- a/data/nc/programs/cape-fear.json
+++ b/data/nc/programs/cape-fear.json
@@ -2,7 +2,7 @@
   "college_slug": "cape-fear",
   "catalog_year": "2025-2026",
   "catalog_url": "https://catalog.cfcc.edu/programs",
-  "scraped_at": "2026-06-05T01:28:50.193Z",
+  "scraped_at": "2026-06-05T01:39:21.699Z",
   "programs": [
     {
       "title": "Associate in Arts",
@@ -50979,6 +50979,15183 @@
         }
       ],
       "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Medical Office Administration Certificate",
+      "credential": "other",
+      "program_code": "C25310",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25310",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "163",
+              "title": "Basic Anat & Physiology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "121",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "122",
+              "title": "Medical Terminology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "149",
+              "title": "Medical Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office Administration Pathway",
+      "credential": "other",
+      "program_code": "C25310CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25310CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "163",
+              "title": "Basic Anat & Physiology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "121",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "122",
+              "title": "Medical Terminology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OST",
+              "number": "149",
+              "title": "Medical Legal Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Analytics Certificate",
+      "credential": "other",
+      "program_code": "C25350",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25350",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Intro to Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "121",
+              "title": "Data Visualization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "150",
+              "title": "Intro to Analytical Program.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "220",
+              "title": "Appl. Analytical Program.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Analytics Pathway",
+      "credential": "other",
+      "program_code": "C25350CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25350CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Intro to Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "121",
+              "title": "Data Visualization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "150",
+              "title": "Intro to Analytical Program.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "220",
+              "title": "Appl. Analytical Program.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Paralegal Technology - Civil Litigation Certificate",
+      "credential": "other",
+      "program_code": "C25380C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25380C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LEX",
+              "number": "130",
+              "title": "Civil Injuries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "140",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "141",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "150",
+              "title": "Commercial Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "240",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "250",
+              "title": "Wills, Estates, & Trusts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - Civil Litigation Pathway",
+      "credential": "other",
+      "program_code": "C25380CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25380CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LEX",
+              "number": "130",
+              "title": "Civil Injuries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "140",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "141",
+              "title": "Civil Litigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "150",
+              "title": "Commercial Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "240",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "250",
+              "title": "Wills, Estates, & Trusts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - Elder Law Certificate",
+      "credential": "other",
+      "program_code": "C25380E",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25380E",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LEX",
+              "number": "120",
+              "title": "Legal Research/Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "210",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "240",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "250",
+              "title": "Wills, Estates, & Trusts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "280",
+              "title": "Ethics & Professionalism",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "288",
+              "title": "Elder Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "111",
+              "title": "Work-Based Learning I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Technology - Real Property Certificate",
+      "credential": "other",
+      "program_code": "C25380R",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25380R",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LEX",
+              "number": "150",
+              "title": "Commercial Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "210",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "211",
+              "title": "Real Property II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "240",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "250",
+              "title": "Wills, Estates, & Trusts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "260",
+              "title": "Bankruptcy and Collections",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Simulation and Game Development Certificate",
+      "credential": "other",
+      "program_code": "C25450",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25450",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SGD",
+              "number": "111",
+              "title": "Introduction to SGD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "112",
+              "title": "SGD Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "113",
+              "title": "SGD Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "114",
+              "title": "SGD 3D Modeling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "116",
+              "title": "SGD Graphic Design Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "212",
+              "title": "SGD Design II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Game Development 3D Modeling and Animation Certificate",
+      "credential": "other",
+      "program_code": "C25450B",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25450B",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SGD",
+              "number": "114",
+              "title": "SGD 3D Modeling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "116",
+              "title": "SGD Graphic Design Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "117",
+              "title": "Art for Games",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "162",
+              "title": "SGD 3D Animation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "214",
+              "title": "SGD 3D Modeling II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "262",
+              "title": "SGD 3D Animation II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Simulation and Game Development - Game Environment Certificate",
+      "credential": "other",
+      "program_code": "C25450C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25450C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "111",
+              "title": "Intro to Arch Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "114",
+              "title": "Architectural CAD",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "114A",
+              "title": "Architectural CAD Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "225",
+              "title": "Architectural BIM I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "225A",
+              "title": "Architectural BIM I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "114",
+              "title": "SGD 3D Modeling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "117",
+              "title": "Art for Games",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "214",
+              "title": "SGD 3D Modeling II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Simulation and Game Development Pathway",
+      "credential": "other",
+      "program_code": "C25450CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25450CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SGD",
+              "number": "111",
+              "title": "Introduction to SGD",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "112",
+              "title": "SGD Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "113",
+              "title": "SGD Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "114",
+              "title": "SGD 3D Modeling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "116",
+              "title": "SGD Graphic Design Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGD",
+              "number": "212",
+              "title": "SGD Design II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology - Cybersecurity & Networking Certificate",
+      "credential": "other",
+      "program_code": "C25590C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25590C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCT",
+              "number": "250",
+              "title": "Network Vulnerabilities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "130",
+              "title": "Operating System Prin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "125",
+              "title": "Introduction to Networks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "126",
+              "title": "Switching and Routing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEC",
+              "number": "110",
+              "title": "Security Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEC",
+              "number": "160",
+              "title": "Security Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Technology - Cyber Security Pathway",
+      "credential": "other",
+      "program_code": "C25590CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25590CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCT",
+              "number": "250",
+              "title": "Network Vulnerabilities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "130",
+              "title": "Operating System Prin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "125",
+              "title": "Introduction to Networks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "126",
+              "title": "Switching and Routing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEC",
+              "number": "110",
+              "title": "Security Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEC",
+              "number": "160",
+              "title": "Security Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Technology - Software Development Certificate",
+      "credential": "other",
+      "program_code": "C25590E",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25590E",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "115",
+              "title": "Intro to Prog & Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "120",
+              "title": "Computing Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "227",
+              "title": "Cloud Application Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DBA",
+              "number": "120",
+              "title": "Database Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Technology - Software Development Pathway",
+      "credential": "other",
+      "program_code": "C25590EP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25590EP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "115",
+              "title": "Intro to Prog & Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "120",
+              "title": "Computing Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "227",
+              "title": "Cloud Application Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DBA",
+              "number": "120",
+              "title": "Database Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Technology - Operating Systems Administration Certificate",
+      "credential": "other",
+      "program_code": "C25590F",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25590F",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "130",
+              "title": "Operating System Prin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "245",
+              "title": "Internet Servers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTI",
+              "number": "120",
+              "title": "Network & Sec Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "120",
+              "title": "Hardware/Software Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "220",
+              "title": "Adv Hard/Software Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TNE",
+              "number": "255",
+              "title": "Network Servers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Technology - Operating Systems Administration Pathway",
+      "credential": "other",
+      "program_code": "C25590FP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25590FP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "130",
+              "title": "Operating System Prin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "245",
+              "title": "Internet Servers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTI",
+              "number": "120",
+              "title": "Network & Sec Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "120",
+              "title": "Hardware/Software Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "220",
+              "title": "Adv Hard/Software Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TNE",
+              "number": "245",
+              "title": "Netwk Perimeter Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Technology - Web Designer Certficate",
+      "credential": "other",
+      "program_code": "C25590W",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25590W",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTI",
+              "number": "110",
+              "title": "Web, Pgm, & Db Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "110",
+              "title": "Intro to Digital Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEB",
+              "number": "111",
+              "title": "Intro to Web Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEB",
+              "number": "115",
+              "title": "Web Markup and Scripting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEB",
+              "number": "210",
+              "title": "Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEB",
+              "number": "213",
+              "title": "Internet Mkt & Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Technology - Web Designer Pathway",
+      "credential": "other",
+      "program_code": "C25590WP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25590WP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTI",
+              "number": "110",
+              "title": "Web, Pgm, & Db Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DME",
+              "number": "110",
+              "title": "Intro to Digital Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEB",
+              "number": "111",
+              "title": "Intro to Web Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEB",
+              "number": "115",
+              "title": "Web Markup and Scripting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEB",
+              "number": "210",
+              "title": "Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEB",
+              "number": "213",
+              "title": "Internet Mkt & Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Accounting and Finance Certificate",
+      "credential": "other",
+      "program_code": "C25800",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25800",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Prin of Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Prin of Financial Acct II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "140",
+              "title": "Payroll Accounting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Accounting Software Appl",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "130",
+              "title": "Spreadsheet",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Forensic Accounting Analytics Certificate",
+      "credential": "other",
+      "program_code": "C25800A",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25800A",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Prin of Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Prin of Financial Acct II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "267",
+              "title": "Fraud Examination",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Intro to Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "121",
+              "title": "Data Visualization",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Forensic Accounting Analytics Pathway",
+      "credential": "other",
+      "program_code": "C25800AP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25800AP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Prin of Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Prin of Financial Acct II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "267",
+              "title": "Fraud Examination Credits 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Intro to Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "121",
+              "title": "Data Visualization",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting Analytics Certificate",
+      "credential": "other",
+      "program_code": "C25800B",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25800B",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Prin of Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Prin of Financial Acct II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Accounting Software Appl",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Intro to Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "121",
+              "title": "Data Visualization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting Fraud Network Security  & Cybersecurity Certificate",
+      "credential": "other",
+      "program_code": "C25800C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25800C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Prin of Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Prin of Financial Acct II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "267",
+              "title": "Fraud Examination",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCT",
+              "number": "121",
+              "title": "Computer Crime Invest.",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTI",
+              "number": "120",
+              "title": "Network & Sec Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Accounting and Finance Pathway",
+      "credential": "other",
+      "program_code": "C25800CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25800CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Prin of Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Prin of Financial Acct II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "140",
+              "title": "Payroll Accounting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Accounting Software Appl",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "130",
+              "title": "Spreadsheet",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting and Finance - Bookkeeping Certificate",
+      "credential": "other",
+      "program_code": "C25800D",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C25800D",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Prin of Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "140",
+              "title": "Payroll Accounting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Accounting Software Appl",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "180",
+              "title": "Practices in Bookkeeping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "130",
+              "title": "Spreadsheet",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Graphic Design Certificate",
+      "credential": "other",
+      "program_code": "C30100",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C30100",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Two-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "110",
+              "title": "Typography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "142",
+              "title": "Graphic Design II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "151",
+              "title": "Computer Design Basics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Graphic Design - Animation & Illustration Certificate",
+      "credential": "other",
+      "program_code": "C30100A",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C30100A",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "131",
+              "title": "Illustration I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "132",
+              "title": "Illustration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "151",
+              "title": "Computer Design Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "271",
+              "title": "Multimedia and Video I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "275",
+              "title": "Animation I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Graphic Design Pathway",
+      "credential": "other",
+      "program_code": "C30100CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C30100CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Two-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "110",
+              "title": "Typography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "142",
+              "title": "Graphic Design II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GRD",
+              "number": "151",
+              "title": "Computer Design Basics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "Film and Video Production Technology Certificate",
+      "credential": "other",
+      "program_code": "C30140",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C30140",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "111",
+              "title": "Intro. to Film and Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "114",
+              "title": "Camera & Lighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "115",
+              "title": "Camera & Lighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "116",
+              "title": "Sound Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "220",
+              "title": "Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Film and Video Production Technology Pathway",
+      "credential": "other",
+      "program_code": "C30140CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C30140CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "111",
+              "title": "Intro. to Film and Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "114",
+              "title": "Camera & Lighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "115",
+              "title": "Camera & Lighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "116",
+              "title": "Sound Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "220",
+              "title": "Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Interior Design Certificate",
+      "credential": "other",
+      "program_code": "C30220",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C30220",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DES",
+              "number": "110",
+              "title": "Architectural Graphics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "120",
+              "title": "CAD for Interior Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "125",
+              "title": "Visual Presentation I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "135",
+              "title": "Prin & Elem of Design I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "220",
+              "title": "Interior Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Interior Design Pathway",
+      "credential": "other",
+      "program_code": "C30220CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C30220CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DES",
+              "number": "110",
+              "title": "Architectural Graphics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "120",
+              "title": "CAD for Interior Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "125",
+              "title": "Visual Presentation I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "135",
+              "title": "Prin & Elem of Design I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "220",
+              "title": "Interior Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning, Heating & Refrigeration Technology Certificate",
+      "credential": "other",
+      "program_code": "C35100",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35100",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHR",
+              "number": "110",
+              "title": "Intro to Refrigeration",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "111",
+              "title": "HVACR Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "114",
+              "title": "Heat Pump Technology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning, Heating & Refrigeration Technology Pathway",
+      "credential": "other",
+      "program_code": "C35100CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35100CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHR",
+              "number": "110",
+              "title": "Intro to Refrigeration",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "111",
+              "title": "HVACR Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "114",
+              "title": "Heat Pump Technology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning, Heating & Refrigeration Technology - Commercial Refrigeration Certificate",
+      "credential": "other",
+      "program_code": "C35100R",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35100R",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHR",
+              "number": "110",
+              "title": "Intro to Refrigeration",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "111",
+              "title": "HVACR Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "115",
+              "title": "Refrigeration Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "215",
+              "title": "Commercial HVAC Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "245",
+              "title": "Chiller Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning, Heating & Refrigeration Technology- Commercial Refrigeration Pathway",
+      "credential": "other",
+      "program_code": "C35100RP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35100RP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHR",
+              "number": "110",
+              "title": "Intro to Refrigeration",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "111",
+              "title": "HVACR Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "115",
+              "title": "Refrigeration Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "215",
+              "title": "Commercial HVAC Controls",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHR",
+              "number": "245",
+              "title": "Chiller Systems",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Boat Building Certificate",
+      "credential": "other",
+      "program_code": "C35120",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35120",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTB",
+              "number": "101A",
+              "title": "Boat Bldg I (part 1)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTB",
+              "number": "101B",
+              "title": "Boat Bldg I (part 2)",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "100",
+              "title": "Marine Drafting",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Boat Building Pathway",
+      "credential": "other",
+      "program_code": "C35120CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35120CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTB",
+              "number": "101",
+              "title": "Boat Building I",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "100",
+              "title": "Marine Drafting",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Systems Technology Certificate",
+      "credential": "other",
+      "program_code": "C35130",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35130",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "112",
+              "title": "DC/AC Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "113",
+              "title": "Residential Wiring",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "117",
+              "title": "Motors and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISC",
+              "number": "112",
+              "title": "Industrial Safety",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Systems Technology Pathway",
+      "credential": "other",
+      "program_code": "C35130CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35130CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "112",
+              "title": "DC/AC Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "113",
+              "title": "Residential Wiring",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "117",
+              "title": "Motors and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISC",
+              "number": "112",
+              "title": "Industrial Safety",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Management Technology Certificate",
+      "credential": "other",
+      "program_code": "C35190",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35190",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "210",
+              "title": "Construction Management Fund",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "212",
+              "title": "Total Safety Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "214",
+              "title": "Planning and Scheduling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "241",
+              "title": "Planning/Estimating I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Construction Management Technology - Project Management Certificate",
+      "credential": "other",
+      "program_code": "C35190A",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35190A",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "120",
+              "title": "Codes and Inspections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "210",
+              "title": "Construction Management Fund",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "218",
+              "title": "Human Relations Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Construction Management Technology Pathway",
+      "credential": "other",
+      "program_code": "C35190CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35190CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "210",
+              "title": "Construction Management Fund",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "212",
+              "title": "Total Safety Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "214",
+              "title": "Planning and Scheduling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "241",
+              "title": "Planning/Estimating I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Construction Management Technology - Framing Certificate",
+      "credential": "other",
+      "program_code": "C35190F",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35190F",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "111",
+              "title": "Construction I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "112",
+              "title": "Construction II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "120",
+              "title": "Codes and Inspections",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Construction Management Technology - Framing Pathway",
+      "credential": "other",
+      "program_code": "C35190FP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35190FP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CMT",
+              "number": "120",
+              "title": "Codes and Inspections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "111",
+              "title": "Construction I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "112",
+              "title": "Construction II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Construction Management Technology - Building Performance Certificate",
+      "credential": "other",
+      "program_code": "C35190S",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35190S",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "150",
+              "title": "Building Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "238",
+              "title": "Weatherization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SST",
+              "number": "120",
+              "title": "Energy Use Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SST",
+              "number": "130",
+              "title": "Modeling Renewable Energy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SST",
+              "number": "140",
+              "title": "Green Bldg & Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Plumbing Certificate",
+      "credential": "other",
+      "program_code": "C35300",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35300",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLU",
+              "number": "110",
+              "title": "Modern Plumbing",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLU",
+              "number": "140",
+              "title": "Intro to Plumbing Codes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLU",
+              "number": "150",
+              "title": "Plumbing Diagrams",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Pathway",
+      "credential": "other",
+      "program_code": "C35300CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C35300CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLU",
+              "number": "110",
+              "title": "Modern Plumbing",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLU",
+              "number": "140",
+              "title": "Intro to Plumbing Codes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLU",
+              "number": "150",
+              "title": "Plumbing Diagrams",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology Certificate",
+      "credential": "other",
+      "program_code": "C40100",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40100",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "111",
+              "title": "Intro to Arch Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "112",
+              "title": "Constr Matls & Methods",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "114",
+              "title": "Architectural CAD",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "114A",
+              "title": "Architectural CAD Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "220",
+              "title": "Adv Architect CAD",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "225A",
+              "title": "Architectural BIM I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "225",
+              "title": "Architectural BIM I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology - Advanced BIM Option Certificate",
+      "credential": "other",
+      "program_code": "C40100A",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40100A",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "111",
+              "title": "Intro to Arch Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "112",
+              "title": "Constr Matls & Methods",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "114",
+              "title": "Architectural CAD",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "114A",
+              "title": "Architectural CAD Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "225",
+              "title": "Architectural BIM I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "225A",
+              "title": "Architectural BIM I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "226",
+              "title": "Architectural BIM II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "226A",
+              "title": "Architectural BIM II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology Pathway",
+      "credential": "other",
+      "program_code": "C40100CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40100CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "111",
+              "title": "Intro to Arch Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "112",
+              "title": "Constr Matls & Methods",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "114",
+              "title": "Architectural CAD",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "114A",
+              "title": "Architectural CAD Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "220",
+              "title": "Adv Architect CAD",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "225A",
+              "title": "Architectural BIM I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "225",
+              "title": "Architectural BIM I",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Engineering Technology Certificate",
+      "credential": "other",
+      "program_code": "C40200",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40200",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Algebra/Trigonometry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "131",
+              "title": "Circuit Analysis I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "131",
+              "title": "Analog Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "133",
+              "title": "Digital Electronics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "152",
+              "title": "Fabrication Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electronics Engineering - Industrial Controls Certificate",
+      "credential": "other",
+      "program_code": "C40200C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40200C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATR",
+              "number": "112",
+              "title": "Intro to Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "111",
+              "title": "Intro to Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "128",
+              "title": "Intro to PLC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "152",
+              "title": "Fabrication Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "231",
+              "title": "Industrial Controls",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electronics Engineering Technology Pathway",
+      "credential": "other",
+      "program_code": "C40200CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40200CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Algebra/Trigonometry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "128",
+              "title": "Intro to PLC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "131",
+              "title": "Circuit Analysis I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "131",
+              "title": "Analog Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "133",
+              "title": "Digital Electronics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electronics Engineering Technology - Drone Systems Pathway",
+      "credential": "other",
+      "program_code": "C40200DP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40200DP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "131",
+              "title": "Circuit Analysis I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "152",
+              "title": "Fabrication Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "275",
+              "title": "Troubleshooting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "110",
+              "title": "Intro to UAS Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "111",
+              "title": "Unmanned Aircraft Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "115",
+              "title": "Small UAS Certification",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electronics Engineering Technology - Drone Systems Certificate",
+      "credential": "other",
+      "program_code": "C40200DS",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40200DS",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "131",
+              "title": "Circuit Analysis I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "152",
+              "title": "Fabrication Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "275",
+              "title": "Troubleshooting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "110",
+              "title": "Intro to UAS Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "111",
+              "title": "Unmanned Aircraft Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UAS",
+              "number": "115",
+              "title": "Small UAS Certification",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electronics Engineering - LAN Cabling Certificate",
+      "credential": "other",
+      "program_code": "C40200L",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40200L",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "125",
+              "title": "Voice and Data Cabling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "131",
+              "title": "Circuit Analysis I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "152",
+              "title": "Fabrication Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "236",
+              "title": "Fiber Optics and Lasers",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechanical Engineering Technology  Certificate",
+      "credential": "other",
+      "program_code": "C40320C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40320C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DFT",
+              "number": "151",
+              "title": "CAD I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "154",
+              "title": "Intro Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "110",
+              "title": "Intro to Engineering Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "111",
+              "title": "Intro to Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "145",
+              "title": "Mfg Materials I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechanical Engineering Technology Pathway",
+      "credential": "other",
+      "program_code": "C40320CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40320CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DFT",
+              "number": "151",
+              "title": "CAD I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "154",
+              "title": "Intro Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "110",
+              "title": "Intro to Engineering Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "111",
+              "title": "Intro to Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "145",
+              "title": "Mfg Materials I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechanical Engineering Technology - CAD Drafting Certificate",
+      "credential": "other",
+      "program_code": "C40320D",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40320D",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DFT",
+              "number": "111",
+              "title": "Technical Drafting I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "111A",
+              "title": "Technical Drafting I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "112",
+              "title": "Technical Drafting II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "112A",
+              "title": "Technical Drafting II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "151",
+              "title": "CAD I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "154",
+              "title": "Intro Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechanical Engineering Technology - CAD Drafting Pathway",
+      "credential": "other",
+      "program_code": "C40320DP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40320DP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DFT",
+              "number": "111",
+              "title": "Technical Drafting I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "111A",
+              "title": "Technical Drafting I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "112",
+              "title": "Technical Drafting II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "112A",
+              "title": "Technical Drafting II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "151",
+              "title": "CAD I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "154",
+              "title": "Intro Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechanical Engineering Technology - 3D Printing Certificate",
+      "credential": "other",
+      "program_code": "C40320P",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40320P",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DFT",
+              "number": "154",
+              "title": "Intro Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "254",
+              "title": "Intermed Solid Model/Render",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDP",
+              "number": "110",
+              "title": "Introduction to 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDP",
+              "number": "140",
+              "title": "Precision 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechanical Engineering Technology - 3D Printing Pathway",
+      "credential": "other",
+      "program_code": "C40320PP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40320PP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DFT",
+              "number": "154",
+              "title": "Intro Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "254",
+              "title": "Intermed Solid Model/Render",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDP",
+              "number": "110",
+              "title": "Introduction to 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDP",
+              "number": "140",
+              "title": "Precision 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechatronics Engineering Technology - Automation Certificate",
+      "credential": "other",
+      "program_code": "C40350",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40350",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATR",
+              "number": "112",
+              "title": "Intro to Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATR",
+              "number": "280",
+              "title": "Robotic Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "131",
+              "title": "Circuit Analysis I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HYD",
+              "number": "110",
+              "title": "Hydraulics/Pneumatics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechatronics Engineering Technology - Advanced Manufacturing Certificate",
+      "credential": "other",
+      "program_code": "C40350A",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40350A",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATR",
+              "number": "112",
+              "title": "Intro to Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATR",
+              "number": "280",
+              "title": "Robotic Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "131",
+              "title": "Circuit Analysis I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "130",
+              "title": "Mechanisms",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HYD",
+              "number": "110",
+              "title": "Hydraulics/Pneumatics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechatronics Engineering Technology Pathway",
+      "credential": "other",
+      "program_code": "C40350CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40350CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATR",
+              "number": "112",
+              "title": "Intro to Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATR",
+              "number": "280",
+              "title": "Robotic Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "131",
+              "title": "Circuit Analysis I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "130",
+              "title": "Mechanisms",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HYD",
+              "number": "110",
+              "title": "Hydraulics/Pneumatics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechatronics Engineering Technology - Automation Pathway",
+      "credential": "other",
+      "program_code": "C40350MP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40350MP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATR",
+              "number": "112",
+              "title": "Intro to Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "131",
+              "title": "Circuit Analysis I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HYD",
+              "number": "110",
+              "title": "Hydraulics/Pneumatics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ATR",
+              "number": "280",
+              "title": "Robotic Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Sustainability Technologies Certificate",
+      "credential": "other",
+      "program_code": "C40370",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40370",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALT",
+              "number": "120",
+              "title": "Renewable Energy Tech",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "110",
+              "title": "Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SST",
+              "number": "110",
+              "title": "Intro to Sustainability",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SST",
+              "number": "120",
+              "title": "Energy Use Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SST",
+              "number": "140",
+              "title": "Green Bldg & Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sustainability Technologies Pathway",
+      "credential": "other",
+      "program_code": "C40370CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40370CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALT",
+              "number": "120",
+              "title": "Renewable Energy Tech",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "110",
+              "title": "Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SST",
+              "number": "110",
+              "title": "Intro to Sustainability",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SST",
+              "number": "120",
+              "title": "Energy Use Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SST",
+              "number": "140",
+              "title": "Green Bldg & Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sustainability Technologies - Renewable Energy Technology Certificate",
+      "credential": "other",
+      "program_code": "C40370R",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40370R",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ALT",
+              "number": "120",
+              "title": "Renewable Energy Tech",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ALT",
+              "number": "250",
+              "title": "Thermal Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "111",
+              "title": "Intro to Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "220",
+              "title": "Photovoltaic Sys Tech",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "230",
+              "title": "Wind & Hydro Power Sys",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sustainability Technologies - Building Performance Certificate",
+      "credential": "other",
+      "program_code": "C40370S",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40370S",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SST",
+              "number": "120",
+              "title": "Energy Use Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SST",
+              "number": "130",
+              "title": "Modeling Renewable Energy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SST",
+              "number": "140",
+              "title": "Green Bldg & Design Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "150",
+              "title": "Building Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "238",
+              "title": "Weatherization",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geomatics Technology - Survey Technician Certificate",
+      "credential": "other",
+      "program_code": "C40420",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40420",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CEG",
+              "number": "111",
+              "title": "Intro to Gis and Gnss",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRV",
+              "number": "110",
+              "title": "Surveying",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRV",
+              "number": "111",
+              "title": "Surveying II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRV",
+              "number": "260",
+              "title": "Field & Office Practices",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geomatics Technology - Survey Technician Pathway",
+      "credential": "other",
+      "program_code": "C40420CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C40420CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CEG",
+              "number": "111",
+              "title": "Intro to Gis and Gnss",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRV",
+              "number": "110",
+              "title": "Surveying",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRV",
+              "number": "111",
+              "title": "Surveying II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SRV",
+              "number": "260",
+              "title": "Field & Office Practices",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computed Tomography Certificate",
+      "credential": "other",
+      "program_code": "C45200CT",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C45200CT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAT",
+              "number": "210",
+              "title": "CT Physics & Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "211",
+              "title": "CT Procedures",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAT",
+              "number": "231",
+              "title": "CT Clinical Practicum",
+              "credits": 11,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Magnetic Resonance Imaging Certificate",
+      "credential": "other",
+      "program_code": "C45200MR",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C45200MR",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MRI",
+              "number": "210",
+              "title": "MRI Physics and Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRI",
+              "number": "211",
+              "title": "MRI Procedures",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRI",
+              "number": "231",
+              "title": "MRI Clinical Practicum",
+              "credits": 11,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social and Human Services - Child Advocacy Certificate",
+      "credential": "other",
+      "program_code": "C45380A",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C45380A",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAS",
+              "number": "110",
+              "title": "Persp Child Maltreatment & Adv",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAS",
+              "number": "120",
+              "title": "Cultural Aware Child Malt/Adv",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAS",
+              "number": "220",
+              "title": "Resp Survivor of Child Abuse",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAS",
+              "number": "210",
+              "title": "Prof & Sys Resp to Child Malt",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social and Human Services - Mental Health Certificate",
+      "credential": "other",
+      "program_code": "C45380C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C45380C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSE",
+              "number": "135",
+              "title": "Orientation Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHA",
+              "number": "140",
+              "title": "Intro to Mental Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHA",
+              "number": "150",
+              "title": "Mental Health Interventions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHA",
+              "number": "155",
+              "title": "Psychological Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHA",
+              "number": "238",
+              "title": "Psychopathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MHA",
+              "number": "240",
+              "title": "Advocacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "111",
+              "title": "Work-Based Learning I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "115",
+              "title": "Work-Based Learning Seminar I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social and Human Services Pathway",
+      "credential": "other",
+      "program_code": "C45380CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C45380CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSE",
+              "number": "110",
+              "title": "Intro to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSE",
+              "number": "123",
+              "title": "Interview Tech Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSE",
+              "number": "210",
+              "title": "Diversity Ethics and Trends",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSE",
+              "number": "212",
+              "title": "Group Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSE",
+              "number": "225",
+              "title": "Crisis and Intervention Prin",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social and Human Services - Addiction & Recovery Certificate",
+      "credential": "other",
+      "program_code": "C45380E",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C45380E",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSE",
+              "number": "212",
+              "title": "– Group Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAB",
+              "number": "110",
+              "title": "– Intro to Addiction and Recovery Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAB",
+              "number": "120",
+              "title": "Intake and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAB",
+              "number": "210",
+              "title": "Addiction and Recovery Counsel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAB",
+              "number": "240",
+              "title": "Diversity, Ethics, and Trends",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "111",
+              "title": "Work-Based Learning I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "115",
+              "title": "– Work-Based Learning Seminar I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "121",
+              "title": "Work-Based Learning II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting Pathway",
+      "credential": "other",
+      "program_code": "C45400CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C45400CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MED",
+              "number": "110",
+              "title": "Orientation to Med Assist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "118",
+              "title": "Medical Law and Ethics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "121",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "122",
+              "title": "Medical Terminology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "130",
+              "title": "Admin Office Proc I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "131",
+              "title": "Admin Office Proc II",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health and Fitness Science Pathway",
+      "credential": "other",
+      "program_code": "C45630CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C45630CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HFS",
+              "number": "110",
+              "title": "Exercise Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFS",
+              "number": "111",
+              "title": "Fitness & Exer Testing I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFS",
+              "number": "120",
+              "title": "Group Exer Instruction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HFS",
+              "number": "212",
+              "title": "Exercise Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PED",
+              "number": "110",
+              "title": "Fit and Well for Life",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "119",
+              "title": "Circuit Training",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer-Integrated Machining Certificate",
+      "credential": "other",
+      "program_code": "C50210",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C50210",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "111",
+              "title": "Machining Technology I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "112",
+              "title": "Machining Technology II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "121",
+              "title": "Intro to CNC",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "122",
+              "title": "CNC Turning",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "124",
+              "title": "CNC Milling",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer-Integrated Machining Pathway",
+      "credential": "other",
+      "program_code": "C50210CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C50210CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "111",
+              "title": "Machining Technology I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "112",
+              "title": "Machining Technology II",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Technology - SMAW/GTAW Certificate",
+      "credential": "other",
+      "program_code": "C50420",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C50420",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "115",
+              "title": "SMAW (Stick) Plate",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "116",
+              "title": "SMAW (stick) Plate/Pipe",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "GTAW (TIG) Plate",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology Certificate",
+      "credential": "other",
+      "program_code": "C50420C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C50420C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "115",
+              "title": "SMAW (Stick) Plate",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "116",
+              "title": "SMAW (stick) Plate/Pipe",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "GMAW (MIG) FCAW/Plate",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology Pathway",
+      "credential": "other",
+      "program_code": "C50420CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C50420CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "115",
+              "title": "SMAW (Stick) Plate",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "GMAW (MIG) FCAW/Plate",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "116",
+              "title": "SMAW (stick) Plate/Pipe",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Technology - GTAW/GMAW Certificate",
+      "credential": "other",
+      "program_code": "C50420F",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C50420F",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "GMAW (MIG) FCAW/Plate",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "GTAW (TIG) Plate",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "132",
+              "title": "GTAW (TIG) Plate/Pipe",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Nuclear Technology Certificate",
+      "credential": "other",
+      "program_code": "C50460",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C50460",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HYD",
+              "number": "110",
+              "title": "Hydraulics/Pneumatics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUC",
+              "number": "110",
+              "title": "Nuclear Reactor Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "112",
+              "title": "Basic Welding Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Welding Metallurgy",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Technology Pathway",
+      "credential": "other",
+      "program_code": "C50460CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C50460CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HYD",
+              "number": "110",
+              "title": "Hydraulics/Pneumatics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUC",
+              "number": "110",
+              "title": "Nuclear Reactor Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "112",
+              "title": "Basic Welding Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "143",
+              "title": "Welding Metallurgy",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Basic Law Enforcement Training Certificate",
+      "credential": "other",
+      "program_code": "C55120",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55120",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LET",
+              "number": "110",
+              "title": "Basic Law Enforcement BLET",
+              "credits": 37,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Baking and Pastry Arts Certificate",
+      "credential": "other",
+      "program_code": "C55130",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55130",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPA",
+              "number": "150",
+              "title": "Artisan & Specialty Bread",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BPA",
+              "number": "165",
+              "title": "Hot and Cold Desserts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BPA",
+              "number": "210",
+              "title": "Cake Design & Decorating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "110",
+              "title": "Sanitation & Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "160",
+              "title": "Baking I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Baking and Pastry Arts Pathway",
+      "credential": "other",
+      "program_code": "C55130CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55130CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPA",
+              "number": "150",
+              "title": "Artisan & Specialty Bread",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BPA",
+              "number": "165",
+              "title": "Hot and Cold Desserts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BPA",
+              "number": "210",
+              "title": "Cake Design & Decorating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "110",
+              "title": "Sanitation & Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "160",
+              "title": "Baking I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cosmetology Certificate",
+      "credential": "other",
+      "program_code": "C55140",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55140",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Cosmetology Concepts I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Salon I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "Cosmetology Concepts II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Salon II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Cosmetology Concepts III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Salon III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "223",
+              "title": "Contemp Hair Coloring",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "224",
+              "title": "Trichology & Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "240",
+              "title": "Contemporary Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "260",
+              "title": "Design Applications",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cosmetology Pathway",
+      "credential": "other",
+      "program_code": "C55140CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55140CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Cosmetology Concepts I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Salon I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "Cosmetology Concepts II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Salon II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Cosmetology Concepts III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Salon III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "260",
+              "title": "Design Applications",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts Certificate",
+      "credential": "other",
+      "program_code": "C55150",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55150",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "110",
+              "title": "Sanitation & Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "130",
+              "title": "Menu Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "140",
+              "title": "Culinary Skills I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "160",
+              "title": "Baking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Culinary Skills II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts Pathway",
+      "credential": "other",
+      "program_code": "C55150CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55150CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "110",
+              "title": "Sanitation & Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "130",
+              "title": "Menu Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "140",
+              "title": "Culinary Skills I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "160",
+              "title": "Baking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "240",
+              "title": "Culinary Skills II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cosmetology Instructor Certificate",
+      "credential": "other",
+      "program_code": "C55160",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55160",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "271",
+              "title": "Instructor Concepts I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "272",
+              "title": "Instructor Practicum I",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "273",
+              "title": "Instructor Concepts II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "274",
+              "title": "Instructor Practicum II",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice Technology Certificate",
+      "credential": "other",
+      "program_code": "C55180",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55180",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "111",
+              "title": "Intro to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "121",
+              "title": "Law Enforcement Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "141",
+              "title": "Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "221",
+              "title": "Investigative Principles",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice Technology Pathway",
+      "credential": "other",
+      "program_code": "C55180CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55180CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "111",
+              "title": "Intro to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "112",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "113",
+              "title": "Juvenile Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "221",
+              "title": "Investigative Principles",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice Technology - Leadership Certificate",
+      "credential": "other",
+      "program_code": "C55180L",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55180L",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Communications",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts Elective",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "253",
+              "title": "Leadership and Mgt Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "212",
+              "title": "Ethics & Comm Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "225",
+              "title": "Crisis Intervention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "240",
+              "title": "Law Enfor Mgt. & Supervis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice Technology - Industrial Security Certificate",
+      "credential": "other",
+      "program_code": "C55180S",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55180S",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "111",
+              "title": "Intro to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "214",
+              "title": "Victimology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "221",
+              "title": "Investigative Principles",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJC",
+              "number": "225",
+              "title": "Crisis Intervention",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "High School Adjunct Instructor Certificate",
+      "credential": "other",
+      "program_code": "C55190",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55190",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "163",
+              "title": "Classroom Mgmt and Instruction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "177",
+              "title": "Instructional Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "243",
+              "title": "Learning Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "270",
+              "title": "Effective Instructional Enviro",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "271",
+              "title": "Educational Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "272",
+              "title": "Technology, Data, and Assess",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Crime Technology Certificate",
+      "credential": "other",
+      "program_code": "C55210",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55210",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCT",
+              "number": "110",
+              "title": "Intro to Cyber Crime",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCT",
+              "number": "112",
+              "title": "Ethics & High Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCT",
+              "number": "121",
+              "title": "Computer Crime Invest.",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCT",
+              "number": "231",
+              "title": "Technology Crimes & Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Crime Technology - Ethical Hacker Certificate",
+      "credential": "other",
+      "program_code": "C55210A",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55210A",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCT",
+              "number": "112",
+              "title": "Ethics & High Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCT",
+              "number": "250",
+              "title": "Network Vulnerabilities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCT",
+              "number": "251",
+              "title": "Network Vulnerabilities II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "130",
+              "title": "Operating System Prin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "110",
+              "title": "Networking Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEC",
+              "number": "110",
+              "title": "Security Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Crime Technology Pathway",
+      "credential": "other",
+      "program_code": "C55210CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55210CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCT",
+              "number": "110",
+              "title": "Intro to Cyber Crime",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCT",
+              "number": "112",
+              "title": "Ethics & High Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCT",
+              "number": "121",
+              "title": "Computer Crime Invest.",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CCT",
+              "number": "231",
+              "title": "Technology Crimes & Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Crime Technology - Cyber Security and Networking Certificate",
+      "credential": "other",
+      "program_code": "C55210N",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55210N",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCT",
+              "number": "250",
+              "title": "Network Vulnerabilities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "130",
+              "title": "Operating System Prin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "125",
+              "title": "Introduction to Networks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "126",
+              "title": "Switching and Routing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEC",
+              "number": "110",
+              "title": "Security Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEC",
+              "number": "160",
+              "title": "Security Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education - Administration Certificate",
+      "credential": "other",
+      "program_code": "C55220",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55220",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "119",
+              "title": "Intro to Early Child Education",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Child, Family, and Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "153",
+              "title": "Health, Safety and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "261",
+              "title": "Early Childhood Admin I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "262",
+              "title": "Early Childhood Admin II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education - Infant/Toddler Care Pathway",
+      "credential": "other",
+      "program_code": "C55220IP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55220IP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "119",
+              "title": "Intro to Early Child Education",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Child, Family, and Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "144",
+              "title": "Child Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "153",
+              "title": "Health, Safety and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "234",
+              "title": "Infants, Toddlers, and Twos",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "234A",
+              "title": "Infants, Toddlers, and Twos Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education - Infant/Toddler Care Certificate",
+      "credential": "other",
+      "program_code": "C55220IT",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55220IT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "119",
+              "title": "Intro to Early Child Education",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Child, Family, and Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "144",
+              "title": "Child Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "153",
+              "title": "Health, Safety and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "234",
+              "title": "Infants, Toddlers, and Twos",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "234A",
+              "title": "Infants, Toddlers, and Twos Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education - Preschool Certificate",
+      "credential": "other",
+      "program_code": "C55220PE",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55220PE",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "119",
+              "title": "Intro to Early Child Education",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Child, Family, and Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "145",
+              "title": "Child Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "146",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "153",
+              "title": "Health, Safety and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education - Preschool Pathway",
+      "credential": "other",
+      "program_code": "C55220PP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55220PP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "119",
+              "title": "Intro to Early Child Education",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Child, Family, and Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "145",
+              "title": "Child Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "146",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "153",
+              "title": "Health, Safety and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Esthetics Technology Certificate",
+      "credential": "other",
+      "program_code": "C55230",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55230",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "119",
+              "title": "Esthetics Concepts I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "120",
+              "title": "Esthetics Salon I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "125",
+              "title": "Esthetics Concepts II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "126",
+              "title": "Esthetics Salon II",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Protection Technology Pathway",
+      "credential": "other",
+      "program_code": "C55240CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55240CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIP",
+              "number": "120",
+              "title": "Intro to Fire Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "124",
+              "title": "Fire Prevention & Public Ed",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "132",
+              "title": "Building Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "162",
+              "title": "Firefighter Safety & Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "220",
+              "title": "Fire Fighting Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Community Spanish Interpreter Certificate",
+      "credential": "other",
+      "program_code": "C55370",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55370",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Elementary Spanish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Elementary Spanish II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "120",
+              "title": "Spanish for the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "181",
+              "title": "Spanish Lab 1",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "182",
+              "title": "Spanish Lab 2",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPI",
+              "number": "113",
+              "title": "Intro. to Spanish Inter.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPI",
+              "number": "243",
+              "title": "Medical Interpreting I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Community Spanish Interpreter Pathway",
+      "credential": "other",
+      "program_code": "C55370CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55370CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPA",
+              "number": "111",
+              "title": "Elementary Spanish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "112",
+              "title": "Elementary Spanish II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "120",
+              "title": "Spanish for the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "181",
+              "title": "Spanish Lab 1",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "182",
+              "title": "Spanish Lab 2",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPI",
+              "number": "113",
+              "title": "Intro. to Spanish Inter.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPI",
+              "number": "243",
+              "title": "Medical Interpreting I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Management Certificate",
+      "credential": "other",
+      "program_code": "C55460",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55460",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EPT",
+              "number": "130",
+              "title": "Mitigation & Preparedness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPT",
+              "number": "140",
+              "title": "Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPT",
+              "number": "150",
+              "title": "Incident Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPT",
+              "number": "210",
+              "title": "Response & Recovery",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Emergency Management - Administration Certificate",
+      "credential": "other",
+      "program_code": "C55460A",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55460A",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EPT",
+              "number": "120",
+              "title": "Sociology of Disaster",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPT",
+              "number": "124",
+              "title": "EM Services Law & Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPT",
+              "number": "220",
+              "title": "Terrorism and Emer. Mgt.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPT",
+              "number": "275",
+              "title": "Emergency Ops Center Mgt",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Emergency Management Pathway",
+      "credential": "other",
+      "program_code": "C55460CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55460CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EPT",
+              "number": "130",
+              "title": "Mitigation & Preparedness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPT",
+              "number": "140",
+              "title": "Emergency Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPT",
+              "number": "150",
+              "title": "Incident Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPT",
+              "number": "210",
+              "title": "Response & Recovery",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Public Safety Administration Certificate",
+      "credential": "other",
+      "program_code": "C55480",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55480",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EPT",
+              "number": "150",
+              "title": "Incident Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "151",
+              "title": "Intro to Public Admin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "252",
+              "title": "Public Policy Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "254",
+              "title": "Grant Writing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group I",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIP",
+              "number": "228",
+              "title": "Local Govt Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "251",
+              "title": "Public Finance & Budgeting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group II",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EPT",
+              "number": "124",
+              "title": "EM Services Law & Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIP",
+              "number": "152",
+              "title": "Fire Protection Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "152",
+              "title": "Ethics in Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Public Safety Administration Pathway",
+      "credential": "other",
+      "program_code": "C55480CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55480CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EPT",
+              "number": "150",
+              "title": "Incident Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "151",
+              "title": "Intro to Public Admin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "152",
+              "title": "Ethics in Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "251",
+              "title": "Public Finance & Budgeting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "252",
+              "title": "Public Policy Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAD",
+              "number": "254",
+              "title": "Grant Writing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Elementary Education Residency Licensure Certificate",
+      "credential": "other",
+      "program_code": "C55490",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C55490",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "270",
+              "title": "Effective Instructional Enviro",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "272",
+              "title": "Technology, Data, and Assess",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "277",
+              "title": "Integr CU Inst: Math/Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "278",
+              "title": "Integr CU Inst: Soc Stu/ELA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "279",
+              "title": "Literacy Develop and Instruct",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "283",
+              "title": "Educator Preparation Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Collision Repair and Refinishing Technology Certificate",
+      "credential": "other",
+      "program_code": "C60130",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C60130",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUB",
+              "number": "111",
+              "title": "Painting & Refinishing I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "121",
+              "title": "Non-Structural Damage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "110",
+              "title": "Intro to Transport Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "180",
+              "title": "Basic Welding for Transp",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Collision Repair and Refinishing Technology Pathway",
+      "credential": "other",
+      "program_code": "C60130CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C60130CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUB",
+              "number": "111",
+              "title": "Painting & Refinishing I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "121",
+              "title": "Non-Structural Damage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "110",
+              "title": "Intro to Transport Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "180",
+              "title": "Basic Welding for Transp",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Systems Technology Certificate",
+      "credential": "other",
+      "program_code": "C60160A",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C60160A",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "141",
+              "title": "Suspension & Steering Sys",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "141A",
+              "title": "Suspension & Steering Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "151",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "151A",
+              "title": "Brakes Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "181",
+              "title": "Engine Performance 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "181A",
+              "title": "Engine Performance 1 Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "130",
+              "title": "Intro to Sustainable Transp",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Systems Technology Pathway",
+      "credential": "other",
+      "program_code": "C60160CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C60160CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "141",
+              "title": "Suspension & Steering Sys",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "141A",
+              "title": "Suspension & Steering Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "151",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "151A",
+              "title": "Brakes Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "181",
+              "title": "Engine Performance 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "181A",
+              "title": "Engine Performance 1 Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "130",
+              "title": "Intro to Sustainable Transp",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Customizing Technology Certificate",
+      "credential": "other",
+      "program_code": "C60190",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C60190",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "110",
+              "title": "Intro to Transport Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUC",
+              "number": "114",
+              "title": "Custom Fiberglass Skills",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUC",
+              "number": "115",
+              "title": "Glass Customizing Methods",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUC",
+              "number": "117",
+              "title": "Custom Airbrushing",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Customizing Technology Pathway",
+      "credential": "other",
+      "program_code": "C60190CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C60190CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "110",
+              "title": "Intro to Transport Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUC",
+              "number": "114",
+              "title": "Custom Fiberglass Skills",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUC",
+              "number": "115",
+              "title": "Glass Customizing Methods",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUC",
+              "number": "117",
+              "title": "Custom Airbrushing",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Diesel and Heavy Equipment Technology Certificate",
+      "credential": "other",
+      "program_code": "C60460",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C60460",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HET",
+              "number": "110",
+              "title": "Diesel Engines",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "110",
+              "title": "Intro to Transport Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "120",
+              "title": "Basic Transp Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "121",
+              "title": "Marine Engines",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel and Heavy Equipment Technology Pathway",
+      "credential": "other",
+      "program_code": "C60460CP",
+      "catalog_url": "https://catalog.cfcc.edu/programs/C60460CP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HET",
+              "number": "110",
+              "title": "Diesel Engines",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "121",
+              "title": "Marine Engines",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "110",
+              "title": "Intro to Transport Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "120",
+              "title": "Basic Transp Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Chemical Technology Diploma",
+      "credential": "other",
+      "program_code": "D20120",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D20120",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Prof Research & Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts Elective",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "110",
+              "title": "World Religions",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTC",
+              "number": "110",
+              "title": "Chemical Safety & Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTC",
+              "number": "114",
+              "title": "Wet Laboratory Techniques",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTC",
+              "number": "115",
+              "title": "Quality Control Laboratory",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTC",
+              "number": "145",
+              "title": "Advanced Laboratory Methods",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTC",
+              "number": "150",
+              "title": "Standards & Solutions",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTC",
+              "number": "210",
+              "title": "Forensic Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTC",
+              "number": "235",
+              "title": "Food Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTC",
+              "number": "240",
+              "title": "Instru I: Spectroscopy",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTC",
+              "number": "250",
+              "title": "Instru II: Chromatography",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTC",
+              "number": "260",
+              "title": "Chemical Technology Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality Management - Lodging Professional Diploma",
+      "credential": "other",
+      "program_code": "D25110",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D25110",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Communications",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Science/Math",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "110",
+              "title": "Sanitation & Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "110",
+              "title": "Intro to Hosp & Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "140",
+              "title": "Legal Issues-Hospitality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "220",
+              "title": "Cost Control-Food & Bev",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "240",
+              "title": "Marketing for Hospitality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "245",
+              "title": "Human Resource Mgmt-Hosp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "280",
+              "title": "Mgmt Problems-Hospitality",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "120",
+              "title": "Front Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "130",
+              "title": "Bed and Breakfast Mgt.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "135",
+              "title": "Facilities Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "160",
+              "title": "Info Systems for Hosp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "120",
+              "title": "Spanish for the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hospitality Management - Food Service Entrepreneur Diploma",
+      "credential": "other",
+      "program_code": "D25110A",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D25110A",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Communications",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Science/Math (",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "110",
+              "title": "Sanitation & Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "110",
+              "title": "Intro to Hosp & Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "140",
+              "title": "Legal Issues-Hospitality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "220",
+              "title": "Cost Control-Food & Bev",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "240",
+              "title": "Marketing for Hospitality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "245",
+              "title": "Human Resource Mgmt-Hosp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "280",
+              "title": "Mgmt Problems-Hospitality",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "124",
+              "title": "Guest Service Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "160",
+              "title": "Info Systems for Hosp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "215",
+              "title": "Restaurant Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "225",
+              "title": "Beverage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "120",
+              "title": "Spanish for the Workplace",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration - Insurance Diploma",
+      "credential": "other",
+      "program_code": "D25120B",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D25120B",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "151",
+              "title": "Survey of Economics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Prin of Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "137",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "147",
+              "title": "Business Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Professional Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Basic PC Literacy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INS",
+              "number": "121",
+              "title": "Life Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INS",
+              "number": "122",
+              "title": "Accident and Health Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INS",
+              "number": "129",
+              "title": "Property & Casualty Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "223",
+              "title": "Customer Experience",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration - Entrepreneurship Diploma",
+      "credential": "other",
+      "program_code": "D25120C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D25120C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Introduction to Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Prof Research & Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Prin of Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "137",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Accounting Software Appl",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "139",
+              "title": "Entrepreneurship I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "230",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "232",
+              "title": "Social Media Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OMT",
+              "number": "156",
+              "title": "Problem-Solving Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PMT",
+              "number": "110",
+              "title": "Intro to Project Mgmt",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Entrepreneurship Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MKT",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "223",
+              "title": "Customer Experience",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Analytics Diploma",
+      "credential": "other",
+      "program_code": "D25350",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D25350",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required English",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications Elective",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Intro to Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Prof Research & Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Science Elective",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "151",
+              "title": "Survey of Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Prin of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Prin of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAS",
+              "number": "120",
+              "title": "Intro to Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "121",
+              "title": "Data Visualization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "150",
+              "title": "Intro to Analytical Program.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAS",
+              "number": "220",
+              "title": "Appl. Analytical Program.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "130",
+              "title": "Spreadsheet",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DBA",
+              "number": "110",
+              "title": "Database Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Paralegal Technology Diploma",
+      "credential": "other",
+      "program_code": "D25380",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D25380",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Communications",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Science/Math Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Math Measurement & Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Algebra/Trigonometry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LEX",
+              "number": "110",
+              "title": "Intro to Paralegal Study",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "120",
+              "title": "Legal Research/Writing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "130",
+              "title": "Civil Injuries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "140",
+              "title": "Civil Litigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "150",
+              "title": "Commercial Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "210",
+              "title": "Real Property I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "240",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "250",
+              "title": "Wills, Estates, & Trusts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJC",
+              "number": "231",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "160",
+              "title": "Criminal Law & Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEX",
+              "number": "260",
+              "title": "Bankruptcy and Collections",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology Diploma",
+      "credential": "other",
+      "program_code": "D25590",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D25590",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications Elective",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Introduction to Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Prof Research & Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTI",
+              "number": "110",
+              "title": "Web, Pgm, & Db Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTI",
+              "number": "120",
+              "title": "Network & Sec Foundation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "115",
+              "title": "Info Sys Business Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "120",
+              "title": "Hardware/Software Support",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Systems Security",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DBA",
+              "number": "120",
+              "title": "Database Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "125",
+              "title": "Introduction to Networks",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group I",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "130",
+              "title": "Operating System Prin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "115",
+              "title": "Intro to Prog & Logic",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group II",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTI",
+              "number": "240",
+              "title": "Virtualization Admin I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "240",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEC",
+              "number": "110",
+              "title": "Security Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group III",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "174",
+              "title": "Server-Side Javascript",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DBA",
+              "number": "210",
+              "title": "Database Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "126",
+              "title": "Switching and Routing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group IV",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CCT",
+              "number": "250",
+              "title": "Network Vulnerabilities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CET",
+              "number": "125",
+              "title": "Voice and Data Cabling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "120",
+              "title": "Computing Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "220",
+              "title": "Adv Hard/Software Support",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group V",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "256",
+              "title": "Software Quality Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group VI",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTI",
+              "number": "241",
+              "title": "Virtualization Admin II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NET",
+              "number": "225",
+              "title": "Enterprise Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OMT",
+              "number": "156",
+              "title": "Problem-Solving Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEB",
+              "number": "210",
+              "title": "Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group VII",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CET",
+              "number": "172",
+              "title": "Internet Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTS",
+              "number": "130",
+              "title": "Spreadsheet",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OMT",
+              "number": "156",
+              "title": "Problem-Solving Skills",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Accounting and Finance Diploma",
+      "credential": "other",
+      "program_code": "D25800",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D25800",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications Elective",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Introduction to Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Comm",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Prof Research & Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "120",
+              "title": "Prin of Financial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "121",
+              "title": "Prin of Managerial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Computer Applications",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spreadsheet Applications",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTS",
+              "number": "130",
+              "title": "Spreadsheet",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "129",
+              "title": "Individual Income Taxes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "140",
+              "title": "Payroll Accounting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Accounting Software Appl",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Prin of Financial Acct II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "121",
+              "title": "Business Math",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Film and Video Production Technology Diploma",
+      "credential": "other",
+      "program_code": "D30140",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D30140",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Intro to Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Prof Research & Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FVP",
+              "number": "111",
+              "title": "Intro. to Film and Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "112",
+              "title": "Art Dept Operations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "113",
+              "title": "Grip & Electrical I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "114",
+              "title": "Camera & Lighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "115",
+              "title": "Camera & Lighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "116",
+              "title": "Sound Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "120",
+              "title": "Art Dept. Operations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "212",
+              "title": "Production Techniques I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "110",
+              "title": "Introduction to Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "220",
+              "title": "Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FVP",
+              "number": "250",
+              "title": "Production Specialties I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Interior Design - Kitchen and Bath Design Diploma",
+      "credential": "other",
+      "program_code": "D30220",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D30220",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Math Measurement & Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DES",
+              "number": "110",
+              "title": "Architectural Graphics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "125",
+              "title": "Visual Presentation I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "135",
+              "title": "Prin & Elem of Design I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "210",
+              "title": "Professional Practices/Int Des",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "220",
+              "title": "Interior Design Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "235",
+              "title": "Products",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DES",
+              "number": "112",
+              "title": "Bldg/Construc Sys",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "136",
+              "title": "Prin & Elem of Design II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "242",
+              "title": "Kitchen/Bath Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DES",
+              "number": "265",
+              "title": "Lighting/Interior Design",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Interior Design Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DES",
+              "number": "243",
+              "title": "Advanced Kitchen/Bath Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WBL",
+              "number": "111",
+              "title": "Work Based Learning I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Boat Building Diploma",
+      "credential": "other",
+      "program_code": "D35120",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D35120",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Applied Communications I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Math Measurement & Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTB",
+              "number": "101",
+              "title": "Boat Building I",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTB",
+              "number": "102",
+              "title": "Boat Building II",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTB",
+              "number": "103",
+              "title": "Yacht Joiner Practices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTB",
+              "number": "104",
+              "title": "Yacht Joiner Practices II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTB",
+              "number": "105",
+              "title": "Yacht Repair/Renovation",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTB",
+              "number": "109",
+              "title": "Yacht Rigging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "100",
+              "title": "Marine Drafting",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Basic PC Literacy",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Systems Technology Diploma",
+      "credential": "other",
+      "program_code": "D35130",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D35130",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Algebra/Trigonometry I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "113",
+              "title": "Residential Wiring",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Motor Controls",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "117",
+              "title": "Motors and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "DC/AC",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "112",
+              "title": "DC/AC Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Concentration Requirements",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "115",
+              "title": "Industrial Wiring",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "118",
+              "title": "National Electrical Code",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Basic PC Literacy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "114",
+              "title": "Commercial Wiring",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "119",
+              "title": "NEC Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "125",
+              "title": "Diagrams and Schematics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ISC",
+              "number": "112",
+              "title": "Industrial Safety",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Diploma",
+      "credential": "other",
+      "program_code": "D35300",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D35300",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Applied Communications I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Math Measurement & Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PLU",
+              "number": "110",
+              "title": "Modern Plumbing",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BPR",
+              "number": "130",
+              "title": "Print Reading-Construction",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Basic PC Literacy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLU",
+              "number": "120",
+              "title": "Plumbing Applications",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLU",
+              "number": "124",
+              "title": "Plumbing Business Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLU",
+              "number": "130",
+              "title": "Plumbing Systems",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLU",
+              "number": "140",
+              "title": "Intro to Plumbing Codes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLU",
+              "number": "150",
+              "title": "Plumbing Diagrams",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLU",
+              "number": "160",
+              "title": "Plumbing Estimates",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronics Engineering Technology Diploma",
+      "credential": "other",
+      "program_code": "D40200",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D40200",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Algebra/Trigonometry I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Core",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "131",
+              "title": "Circuit Analysis I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "131",
+              "title": "Analog Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "133",
+              "title": "Digital Electronics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electronics Engineering Technology",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "133",
+              "title": "Circuit Analysis II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "132",
+              "title": "Analog Electronics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELN",
+              "number": "152",
+              "title": "Fabrication Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "275",
+              "title": "Troubleshooting",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electives",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ATR",
+              "number": "112",
+              "title": "Intro to Automation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "117",
+              "title": "Motors and Controls",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechanical Engineering Technology Diploma",
+      "credential": "other",
+      "program_code": "D40320",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D40320",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Prof Research & Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Algebra/Trigonometry I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Two-Dimensional Drawing",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DFT",
+              "number": "151",
+              "title": "CAD I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Three-Dimensional Drawing",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DFT",
+              "number": "154",
+              "title": "Intro Solid Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Manufacturing",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "145",
+              "title": "Mfg Materials I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Physics",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "131",
+              "title": "Physics-Mechanics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DFT",
+              "number": "254",
+              "title": "Intermed Solid Model/Render",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "110",
+              "title": "Intro to Engineering Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "111",
+              "title": "Intro to Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "111",
+              "title": "Machine Processes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "130",
+              "title": "Mechanisms",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TDP",
+              "number": "110",
+              "title": "Introduction to 3D Printing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Cardiovascular Sonography Diploma",
+      "credential": "other",
+      "program_code": "D45160",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D45160",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Communications Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Introduction to Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Science Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CVS",
+              "number": "160",
+              "title": "CVS Clinical Ed I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CVS",
+              "number": "161",
+              "title": "CVS Clinical Ed II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CVS",
+              "number": "162",
+              "title": "CVS Clinical Ed III",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CVS",
+              "number": "163",
+              "title": "Echo I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CVS",
+              "number": "164",
+              "title": "Echo II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CVS",
+              "number": "277",
+              "title": "Cardiovascular Topics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SON",
+              "number": "111",
+              "title": "Sonographic Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SON",
+              "number": "250",
+              "title": "Vascular Sonography",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting Diploma",
+      "credential": "other",
+      "program_code": "D45240",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D45240",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Communications",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Science Elective",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "118",
+              "title": "Interpersonal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "240",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group 1:",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "163",
+              "title": "Basic Anat & Physiology",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group 2:",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "168",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "169",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEN",
+              "number": "100",
+              "title": "Basic Orofacial Anatomy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "101",
+              "title": "Preclinical Procedures",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "102",
+              "title": "Dental Materials",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "103",
+              "title": "Dental Sciences",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "104",
+              "title": "Dental Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "105",
+              "title": "Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "106",
+              "title": "Clinical Practice I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "107",
+              "title": "Clinical Practice II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "111",
+              "title": "Infection/Hazard Control",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "112",
+              "title": "Dental Radiography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting Diploma",
+      "credential": "other",
+      "program_code": "D45400",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D45400",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Communications",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences/Math Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Math Measurement & Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Algebra/Trigonometry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "Precalculus",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MED",
+              "number": "110",
+              "title": "Orientation to Med Assist",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "116",
+              "title": "Introduction to A & P",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "118",
+              "title": "Medical Law and Ethics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "121",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "122",
+              "title": "Medical Terminology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "130",
+              "title": "Admin Office Proc I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "131",
+              "title": "Admin Office Proc II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "140",
+              "title": "Exam Room Procedures I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "150",
+              "title": "Laboratory Procedures I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "260",
+              "title": "MED Clinical Practicum",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "264",
+              "title": "Med Assisting Overview",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "272",
+              "title": "Drug Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "274",
+              "title": "Diet Therapy/Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pharmacy Technology Diploma",
+      "credential": "other",
+      "program_code": "D45580",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D45580",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "163",
+              "title": "Basic Anat & Physiology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Psychology Elective",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "118",
+              "title": "Interpersonal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHM",
+              "number": "110",
+              "title": "Introduction to Pharmacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "111",
+              "title": "Pharmacy Practice I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "115",
+              "title": "Pharmacy Calculations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "115A",
+              "title": "Pharmacy Calculations Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "118",
+              "title": "Sterile Products",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "120",
+              "title": "Pharmacology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "125",
+              "title": "Pharmacology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "133",
+              "title": "Pharmacy Clinical",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "136",
+              "title": "Pharmacy Clinical",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "140",
+              "title": "Trends in Pharmacy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "165",
+              "title": "Pharmacy Prof Practice",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing Diploma",
+      "credential": "other",
+      "program_code": "D45660",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D45660",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Communications",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Science",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psych",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "163",
+              "title": "Basic Anat & Physiology",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group II",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "168",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "169",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "101",
+              "title": "Practical Nursing I",
+              "credits": 11,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "102",
+              "title": "Practical Nursing II",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "103",
+              "title": "Practical Nursing III",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Welding Technology Diploma",
+      "credential": "other",
+      "program_code": "D50420",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D50420",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Communications Elective",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Applied Communications I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Prof Research & Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Science/Math",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Math Measurement & Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WLD",
+              "number": "110",
+              "title": "Cutting Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "115",
+              "title": "SMAW (Stick) Plate",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "121",
+              "title": "GMAW (MIG) FCAW/Plate",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "131",
+              "title": "GTAW (TIG) Plate",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "141",
+              "title": "Symbols & Specifications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Basic PC Literacy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "116",
+              "title": "SMAW (stick) Plate/Pipe",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "132",
+              "title": "GTAW (TIG) Plate/Pipe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "215",
+              "title": "SMAW (stick) Pipe",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "231",
+              "title": "GTAW (TIG) Pipe",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Cosmetology Diploma",
+      "credential": "other",
+      "program_code": "D55140",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D55140",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Introduction to Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Prof Research & Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "111",
+              "title": "Cosmetology Concepts I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "112",
+              "title": "Salon I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "113",
+              "title": "Cosmetology Concepts II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "114",
+              "title": "Salon II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "115",
+              "title": "Cosmetology Concepts III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "116",
+              "title": "Salon III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COS",
+              "number": "117",
+              "title": "Cosmetology Concepts IV",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COS",
+              "number": "118",
+              "title": "Salon IV",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts Diploma",
+      "credential": "other",
+      "program_code": "D55150",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D55150",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Communications",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Science Elective",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Prin of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Prin of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "110",
+              "title": "Sanitation & Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "112",
+              "title": "Nutrition for Foodservice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "140",
+              "title": "Culinary Skills I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "130",
+              "title": "Menu Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "160",
+              "title": "Baking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "170",
+              "title": "Garde Manger I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "230",
+              "title": "Global Cuisines",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "245",
+              "title": "Human Resource Mgmt-Hosp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "260",
+              "title": "Procurement for Hosp",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WBL",
+              "number": "110",
+              "title": "World of Work",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education Diploma",
+      "credential": "other",
+      "program_code": "D55220",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D55220",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "119",
+              "title": "Intro to Early Child Education",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Child, Family, and Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "144",
+              "title": "Child Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "145",
+              "title": "Child Development II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "146",
+              "title": "Child Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "151",
+              "title": "Creative Activities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "153",
+              "title": "Health, Safety and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "162",
+              "title": "Observ & Assess in ECE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "221",
+              "title": "Children With Exceptionalities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "251",
+              "title": "Exploration Activities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "259",
+              "title": "Curriculum Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "280",
+              "title": "Language/Literacy Experiences",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Collision Repair and Refinishing Technology Diploma",
+      "credential": "other",
+      "program_code": "D60130",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D60130",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Applied Communications I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Math Measurement & Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fundamental Trans Skills",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "110",
+              "title": "Intro to Transport Tech",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Intermediate Trans Skills",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "180",
+              "title": "Basic Welding for Transp",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Specialized Trans Skills",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "140",
+              "title": "Transp Climate Control",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUB",
+              "number": "111",
+              "title": "Painting & Refinishing I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "121",
+              "title": "Non-Structural Damage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "131",
+              "title": "Structural Damage I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "136",
+              "title": "Plastics & Adhesives",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUB",
+              "number": "112",
+              "title": "Painting & Refinishing II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "114",
+              "title": "Special Finishes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "122",
+              "title": "Non-Structural Damage II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "141",
+              "title": "Mech & Elec Components I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "162",
+              "title": "Autobody Estimating",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "140A",
+              "title": "Transp Climate Cont Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Systems Technology Diploma",
+      "credential": "other",
+      "program_code": "D60160",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D60160",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Math Measurement & Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fundamental Transport Skills",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "110",
+              "title": "Intro to Transport Tech",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Intermediate Transport Skills",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "120",
+              "title": "Basic Transp Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Specialized Transport Skills",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "140",
+              "title": "Transp Climate Control",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Automotive Systems Technology",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "141",
+              "title": "Suspension & Steering Sys",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "151",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "181",
+              "title": "Engine Performance 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "141A",
+              "title": "Suspension & Steering Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "151A",
+              "title": "Brakes Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "163",
+              "title": "Adv Auto Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "163A",
+              "title": "Adv Auto Electricity Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "181A",
+              "title": "Engine Performance 1 Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "212",
+              "title": "Auto Shop Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "213",
+              "title": "Automotive Servicing 2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "140A",
+              "title": "Transp Climate Cont Lab",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Customizing Technology Diploma",
+      "credential": "other",
+      "program_code": "D60190",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D60190",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Communication",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "115",
+              "title": "Critical Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences/Math",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Math Measurement & Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fundamental Transp Skills",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "110",
+              "title": "Intro to Transport Tech",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Intermediate Transp Skills",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "180",
+              "title": "Basic Welding for Transp",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Automotive Custom Technology",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUB",
+              "number": "111",
+              "title": "Painting & Refinishing I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "121",
+              "title": "Non-Structural Damage I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUC",
+              "number": "111",
+              "title": "Auto Customizing Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUC",
+              "number": "112",
+              "title": "Auto Custom Fabrication",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AUC",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUC",
+              "number": "114",
+              "title": "Custom Fiberglass Skills",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUC",
+              "number": "115",
+              "title": "Glass Customizing Methods",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUC",
+              "number": "117",
+              "title": "Custom Airbrushing",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "AUT",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "212",
+              "title": "Auto Shop Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Boat Manufacture and Service Diploma",
+      "credential": "other",
+      "program_code": "D60330",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D60330",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Applied Communications I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Math Measurement & Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTB",
+              "number": "110",
+              "title": "Fiberglass Boat Bldg I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTB",
+              "number": "111",
+              "title": "Fiberglass Boat Bldg II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTB",
+              "number": "112",
+              "title": "Fiberglass Boat Repairs",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Marine Services",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTB",
+              "number": "106",
+              "title": "Engine Install/Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTB",
+              "number": "107",
+              "title": "Boat Electrical Systems",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTB",
+              "number": "108",
+              "title": "Boat Plumbing Systems",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BMS",
+              "number": "117",
+              "title": "Marine Spray Finishing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMS",
+              "number": "118",
+              "title": "Basic Boat Operation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Basic PC Literacy",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel and Heavy Equipment Technology Diploma",
+      "credential": "other",
+      "program_code": "D60460",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D60460",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Math Measurement & Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fundamental Trans Skills",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "110",
+              "title": "Intro to Transport Tech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HET",
+              "number": "134",
+              "title": "Diesel Fuel & Power Sys",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Intermediate Trans Skills",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "120",
+              "title": "Basic Transp Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Diesel and Heavy Equipment",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HET",
+              "number": "110",
+              "title": "Diesel Engines",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "121",
+              "title": "Marine Engines",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "147",
+              "title": "Marine Power Trains",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Basic PC Literacy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HET",
+              "number": "115",
+              "title": "Electronic Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "112",
+              "title": "Basic Welding Processes",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Onsite Diesel Power Generation Technology Diploma",
+      "credential": "other",
+      "program_code": "D60460PG",
+      "catalog_url": "https://catalog.cfcc.edu/programs/D60460PG",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "110",
+              "title": "Math Measurement & Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fundamental Trans Skills",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HET",
+              "number": "134",
+              "title": "Diesel Fuel & Power Sys",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRN",
+              "number": "110",
+              "title": "Intro to Transport Tech",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Intermediate Trans Skills",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRN",
+              "number": "120",
+              "title": "Basic Transp Electricity",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Diesel & Heavy Equipment",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HET",
+              "number": "110",
+              "title": "Diesel Engines",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "121",
+              "title": "Marine Engines",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MRN",
+              "number": "150",
+              "title": "Adv Marine Electrical Sys",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "111",
+              "title": "Basic PC Literacy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HET",
+              "number": "115",
+              "title": "Electronic Engines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WLD",
+              "number": "112",
+              "title": "Basic Welding Processes",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "College Transfer - Associate in Arts Pathway",
+      "credential": "other",
+      "program_code": "P1012C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/P1012C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications/Humanities/Fine Arts Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "215",
+              "title": "Philosophical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Prin of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Prin of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group I",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "111",
+              "title": "Descriptive Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "111A",
+              "title": "Descriptive Astronomy Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group II",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group III",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group IV",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group V",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEL",
+              "number": "111",
+              "title": "Geology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group VI",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110A",
+              "title": "Conceptual Physics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group VII",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "151",
+              "title": "General Astronomy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "151A",
+              "title": "General Astronomy I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "College Transfer Success",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "College Transfer - Associate in Arts in Teacher Preparation Pathway",
+      "credential": "other",
+      "program_code": "P1012T",
+      "catalog_url": "https://catalog.cfcc.edu/programs/P1012T",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "215",
+              "title": "Philosophical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Prin of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Prin of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group I",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "111",
+              "title": "Descriptive Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "111A",
+              "title": "Descriptive Astronomy Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group II",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "151",
+              "title": "General Astronomy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "151A",
+              "title": "General Astronomy I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group III",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110A",
+              "title": "Conceptual Physics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Required General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "225",
+              "title": "Social Diversity",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Education",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "187",
+              "title": "Teaching and Learning for All",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Academic Transition",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "College Transfer Success",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "College Transfer - Associate in General Education Pathway",
+      "credential": "other",
+      "program_code": "P1032C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/P1032C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Group I",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group II",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "Prof Research & Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "215",
+              "title": "Philosophical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "168",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "169",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "241",
+              "title": "Developmental Psych",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Required Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "College Transfer Success",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "College Transfer - Associate in Science Pathway",
+      "credential": "other",
+      "program_code": "P1042C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/P1042C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications/Humanities/Fine Arts Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "215",
+              "title": "Philosophical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Prin of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Prin of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math Electives",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Precalculus Trigonometry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "263",
+              "title": "Brief Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "272",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group I",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "151",
+              "title": "General Astronomy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "151A",
+              "title": "General Astronomy I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "152",
+              "title": "General Astronomy II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "152A",
+              "title": "General Astronomy II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group II",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "151",
+              "title": "General Astronomy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "151A",
+              "title": "General Astronomy I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group III",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "151",
+              "title": "General Astronomy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "151A",
+              "title": "General Astronomy I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEL",
+              "number": "111",
+              "title": "Geology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110A",
+              "title": "Conceptual Physics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "152",
+              "title": "General Astronomy II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "152A",
+              "title": "General Astronomy II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group VI",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "152",
+              "title": "General Astronomy II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "152A",
+              "title": "General Astronomy II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEL",
+              "number": "111",
+              "title": "Geology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110A",
+              "title": "Conceptual Physics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group XI",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group XII",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "General Astronomy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110A",
+              "title": "General Astronomy I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEL",
+              "number": "111",
+              "title": "Geology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group XIII",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group VII",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "252",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Required Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "College Transfer Success",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "College Transfer - Associate in Science in Teacher Preparation Pathway",
+      "credential": "other",
+      "program_code": "P1042T",
+      "catalog_url": "https://catalog.cfcc.edu/programs/P1042T",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications/Humanities/Fine Arts Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "215",
+              "title": "Philosophical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Prin of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Prin of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math Electives",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "172",
+              "title": "Precalculus Trigonometry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "272",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group I",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "151",
+              "title": "General Astronomy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "151A",
+              "title": "General Astronomy I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group II",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "112",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group III",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group IV",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEL",
+              "number": "111",
+              "title": "Geology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110A",
+              "title": "Conceptual Physics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group V",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "152",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group VI",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "252",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Required General Education",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "225",
+              "title": "Social Diversity",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Education",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "187",
+              "title": "Teaching and Learning for All",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Academic Transition",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "College Transfer Success",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "College Transfer - Associate in Engineering Pathway",
+      "credential": "other",
+      "program_code": "P1052C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/P1052C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "215",
+              "title": "Philosophical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Prin of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics Electives",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "272",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences Electives",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "251",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "252",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Other Required Hours",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "College Transfer Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFT",
+              "number": "170",
+              "title": "Engineering Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "150",
+              "title": "Intro to Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "College Transfer - Associate in Fine Arts in Visual Arts Pathway",
+      "credential": "other",
+      "program_code": "P1062C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/P1062C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications/Humanities/Fine Arts Elective",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "215",
+              "title": "Philosophical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Sciences Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Prin of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Prin of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Math Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group I",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "111",
+              "title": "Descriptive Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "111A",
+              "title": "Descriptive Astronomy Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group II",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "151",
+              "title": "General Astronomy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "151A",
+              "title": "General Astronomy I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group III",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group IV",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group V",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group VI",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEL",
+              "number": "111",
+              "title": "Geology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group VII",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110A",
+              "title": "Conceptual Physics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "College Transfer Success",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Art",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Two-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "College Transfer - Associate in Fine Arts in Music Pathway",
+      "credential": "other",
+      "program_code": "P1072C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/P1072C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities/Fine Arts Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "215",
+              "title": "Philosophical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social/Behavioral Science Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Prin of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Prin of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group I",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "111",
+              "title": "Descriptive Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "111A",
+              "title": "Descriptive Astronomy Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group II",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "151",
+              "title": "General Astronomy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "151A",
+              "title": "General Astronomy I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group III",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group IV",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group VI",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEL",
+              "number": "111",
+              "title": "Geology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group VII",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110A",
+              "title": "Conceptual Physics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Music",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "111",
+              "title": "Fundamentals of Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "Class Music I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Ensemble",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "Chorus I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Chorus II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "133",
+              "title": "Band I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "134",
+              "title": "Band II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "135",
+              "title": "Jazz Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "136",
+              "title": "Jazz Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "137",
+              "title": "Orchestra I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "138",
+              "title": "Orchestra II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "141",
+              "title": "Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "142",
+              "title": "Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Academic Transition",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "College Transfer Success",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
+    },
+    {
+      "title": "College Transfer - Associate in Fine Arts in Theatre Pathway",
+      "credential": "other",
+      "program_code": "P1082C",
+      "catalog_url": "https://catalog.cfcc.edu/programs/P1082C",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "English",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Writing and Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "Writing/Research in the Disc",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Select two courses from two different disciplines",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "111",
+              "title": "Art Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "114",
+              "title": "Art History Survey I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Art History Survey II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Intro Interpersonal Com",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "111",
+              "title": "Theatre Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "231",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "232",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "110",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Introduction to Jazz",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "215",
+              "title": "Philosophical Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "240",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Select two courses from two different disciplines",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "251",
+              "title": "Prin of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "252",
+              "title": "Prin of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "131",
+              "title": "American History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "132",
+              "title": "American History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "150",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "143",
+              "title": "Quantitative Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "152",
+              "title": "Statistical Methods I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "171",
+              "title": "Precalculus Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "271",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group 1:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "111",
+              "title": "Descriptive Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "111A",
+              "title": "Descriptive Astronomy Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group 2:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "151",
+              "title": "General Astronomy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "151A",
+              "title": "General Astronomy I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group 3:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group 4:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group 5:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group 6:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEL",
+              "number": "111",
+              "title": "Geology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Group 7:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Conceptual Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110A",
+              "title": "Conceptual Physics Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Acting Track",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRA",
+              "number": "130",
+              "title": "Acting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "170",
+              "title": "Play Production I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Track",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRA",
+              "number": "140",
+              "title": "Stagecraft I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRA",
+              "number": "170",
+              "title": "Play Production I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Academic Transition",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACA",
+              "number": "122",
+              "title": "College Transfer Success",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "art"
     }
   ]
 }

--- a/scripts/lib/scrape-coursedog-programs.ts
+++ b/scripts/lib/scrape-coursedog-programs.ts
@@ -263,33 +263,49 @@ export function isActiveProgramStatus(status?: string): boolean {
   return s === "" || s === "active";
 }
 
+/** Safety bound on pagination — 30 × 200 = 6,000 programs is far above any
+ *  real catalog and prevents an unbounded loop if the API misbehaves. */
+const MAX_PROGRAM_PAGES = 30;
+
 async function listAllPrograms(
   page: Page,
   tenantId: string,
   catalogId: string,
 ): Promise<ProgramListItem[]> {
-  const url =
+  const pageUrl = (skip: number) =>
     `https://app.coursedog.com/api/v1/cm/${tenantId}/programs/search/%24filters` +
     `?catalogId=${encodeURIComponent(catalogId)}` +
-    `&skip=0&limit=${PROGRAMS_PAGE_SIZE}` +
+    `&skip=${skip}&limit=${PROGRAMS_PAGE_SIZE}` +
     `&orderBy=code&formatDependents=false`;
-  const resp = await apiPost<{ data: ProgramListItem[]; listLength: number }>(
-    page,
-    url,
-    PROGRAMS_FILTER_BODY,
-  );
-  let data = resp?.data ?? [];
+
+  // Page through results: the search endpoint caps each response at
+  // PROGRAMS_PAGE_SIZE, so a single fetch silently truncated large catalogs
+  // (cape-fear 473, central-carolina 654, del-mar 304). Keep fetching until a
+  // short page signals the end.
+  const fetchAll = async (filterBody: unknown): Promise<ProgramListItem[]> => {
+    const out: ProgramListItem[] = [];
+    for (let p = 0; p < MAX_PROGRAM_PAGES; p++) {
+      const resp = await apiPost<{ data: ProgramListItem[]; listLength: number }>(
+        page,
+        pageUrl(p * PROGRAMS_PAGE_SIZE),
+        filterBody,
+      );
+      const batch = resp?.data ?? [];
+      out.push(...batch);
+      if (batch.length < PROGRAMS_PAGE_SIZE) break;
+    }
+    return out;
+  };
+
+  let data = await fetchAll(PROGRAMS_FILTER_BODY);
   // Casing fallback: when the "Active"-filtered search returns nothing, the
   // tenant likely stores its status lowercase. Re-fetch unfiltered and keep
   // only active/unspecified programs (drop Inactive/Archived) so the catalog
   // isn't silently empty. Tenants that already return rows are untouched.
   if (data.length === 0) {
-    const respAll = await apiPost<{ data: ProgramListItem[]; listLength: number }>(
-      page,
-      url,
-      EMPTY_FILTER_BODY,
+    data = (await fetchAll(EMPTY_FILTER_BODY)).filter((p) =>
+      isActiveProgramStatus(p.status),
     );
-    data = (respAll?.data ?? []).filter((p) => isActiveProgramStatus(p.status));
   }
   return data;
 }


### PR DESCRIPTION
## What changes for someone using the site

**Cape Fear CC (NC)** jumps from **100 to 228** plannable degree programs in the planner. Last PR's freeform parser unlocked cape-fear but only saw the first 200 of its 473 programs; this fetches the rest, so 128 more programs become plannable.

## What changed technically

`listAllPrograms` in `scripts/lib/scrape-coursedog-programs.ts` fetched a **single** `skip=0&limit=200` page, silently truncating any CourseDog catalog with more than 200 programs. It now **pages through** `skip += PROGRAMS_PAGE_SIZE` until a short page signals the end (safety bound: 30 pages), for both the normal fetch and the lowercase-status fallback.

```diff
- const resp = await apiPost(page, url /* skip=0 */, PROGRAMS_FILTER_BODY);
- let data = resp?.data ?? [];
+ const fetchAll = async (filterBody) => {
+   const out = [];
+   for (let p = 0; p < MAX_PROGRAM_PAGES; p++) {
+     const resp = await apiPost(page, pageUrl(p * PROGRAMS_PAGE_SIZE), filterBody);
+     const batch = resp?.data ?? [];
+     out.push(...batch);
+     if (batch.length < PROGRAMS_PAGE_SIZE) break;
+   }
+   return out;
+ };
+ let data = await fetchAll(PROGRAMS_FILTER_BODY);
```

## Honest scope — the other two large catalogs don't pan out

I re-scraped the two other catalogs the cap was truncating, and verified each live:

- **cape-fear (NC): 100 → 228 plannable.** ✅ 469 fetched, 275 parsed.
- **central-carolina (NC, 644 programs)** and **del-mar (TX, 282)** now fetch fully, **but their CourseDog program details return empty `requisites: {}`** — no structured requirements and no freeform HTML (probed directly). The catalog just doesn't publish machine-readable requirements there; a parser can't help. **Not committed** — documented as needing a different source (HTML/PDF).

So pagination's concrete win is cape-fear; the other two confirm the fix works (they fetch fully now) but have no data to parse.

## Files
- `scripts/lib/scrape-coursedog-programs.ts` — paginated `listAllPrograms`
- `data/nc/programs/cape-fear.json` — re-scraped (275 programs, 228 plannable)
- `data/nc/DEFERRED-programs.md` — cape-fear / central-carolina / del-mar updated

## Verification
- **tsc** clean; **eslint** 0 errors; **vitest 16/16** (the freeform + status tests still pass — no regression).
- **File check** (the committed artifact): `countRealCourses` → **228 plannable** of 275, real courses across the newly-fetched pages.
- Note on verifying: prod reads the `programs` Supabase table (synced by `import-on-merge.yml`), so a `--env-file` planner query reads *current prod* (100), not the worktree file — the file's 228 is what this PR ships, and import-on-merge syncs it on merge.

**Post-merge check:** after the import workflow runs, `communitycollegepath.com/nc/college/cape-fear/programs` should list ~228 plannable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)