### PR TITLE
perf(transfer): cache getUniversitiesWithCounts — drop full-table scan on /[state]/transfer

### DIFF
--- a/data/ak/transfer-universities.json
+++ b/data/ak/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "university-of-alaska-anchorage",
     "name": "University of Alaska Anchorage",
-    "mappingCount": 148
+    "mappingCount": 148,
+    "directCount": 26,
+    "electiveCount": 122,
+    "totalCount": 148
   }
 ]

--- a/data/al/transfer-universities.json
+++ b/data/al/transfer-universities.json
@@ -2,71 +2,113 @@
   {
     "slug": "aamu",
     "name": "Alabama A&M University",
-    "mappingCount": 5819
+    "mappingCount": 5819,
+    "directCount": 1173,
+    "electiveCount": 4646,
+    "totalCount": 5819
   },
   {
     "slug": "asu",
     "name": "Alabama State University",
-    "mappingCount": 6371
+    "mappingCount": 6371,
+    "directCount": 943,
+    "electiveCount": 5428,
+    "totalCount": 6371
   },
   {
     "slug": "athens",
     "name": "Athens State University",
-    "mappingCount": 6348
+    "mappingCount": 6348,
+    "directCount": 0,
+    "electiveCount": 6348,
+    "totalCount": 6348
   },
   {
     "slug": "au",
     "name": "Auburn University",
-    "mappingCount": 6371
+    "mappingCount": 6371,
+    "directCount": 1173,
+    "electiveCount": 5198,
+    "totalCount": 6371
   },
   {
     "slug": "aum",
     "name": "Auburn University at Montgomery",
-    "mappingCount": 6348
+    "mappingCount": 6348,
+    "directCount": 1449,
+    "electiveCount": 4899,
+    "totalCount": 6348
   },
   {
     "slug": "jsu",
     "name": "Jacksonville State University",
-    "mappingCount": 6302
+    "mappingCount": 6302,
+    "directCount": 1541,
+    "electiveCount": 4761,
+    "totalCount": 6302
   },
   {
     "slug": "ua",
     "name": "The University of Alabama",
-    "mappingCount": 6348
+    "mappingCount": 6348,
+    "directCount": 1794,
+    "electiveCount": 4554,
+    "totalCount": 6348
   },
   {
     "slug": "troy",
     "name": "Troy University",
-    "mappingCount": 6348
+    "mappingCount": 6348,
+    "directCount": 1265,
+    "electiveCount": 5083,
+    "totalCount": 6348
   },
   {
     "slug": "uab",
     "name": "University of Alabama at Birmingham",
-    "mappingCount": 5474
+    "mappingCount": 5474,
+    "directCount": 1702,
+    "electiveCount": 3772,
+    "totalCount": 5474
   },
   {
     "slug": "uah",
     "name": "University of Alabama in Huntsville",
-    "mappingCount": 5773
+    "mappingCount": 5773,
+    "directCount": 1173,
+    "electiveCount": 4600,
+    "totalCount": 5773
   },
   {
     "slug": "um",
     "name": "University of Montevallo",
-    "mappingCount": 6371
+    "mappingCount": 6371,
+    "directCount": 1219,
+    "electiveCount": 5152,
+    "totalCount": 6371
   },
   {
     "slug": "una",
     "name": "University of North Alabama",
-    "mappingCount": 6371
+    "mappingCount": 6371,
+    "directCount": 1725,
+    "electiveCount": 4646,
+    "totalCount": 6371
   },
   {
     "slug": "usa",
     "name": "University of South Alabama",
-    "mappingCount": 6348
+    "mappingCount": 6348,
+    "directCount": 1863,
+    "electiveCount": 4485,
+    "totalCount": 6348
   },
   {
     "slug": "uwa",
     "name": "University of West Alabama",
-    "mappingCount": 6348
+    "mappingCount": 6348,
+    "directCount": 1380,
+    "electiveCount": 4968,
+    "totalCount": 6348
   }
 ]

--- a/data/ar/transfer-universities.json
+++ b/data/ar/transfer-universities.json
@@ -2,36 +2,57 @@
   {
     "slug": "asuj",
     "name": "Arkansas State University",
-    "mappingCount": 12990
+    "mappingCount": 12992,
+    "directCount": 9940,
+    "electiveCount": 22,
+    "totalCount": 9962
   },
   {
     "slug": "atu",
     "name": "Arkansas Tech University",
-    "mappingCount": 101
+    "mappingCount": 101,
+    "directCount": 77,
+    "electiveCount": 0,
+    "totalCount": 77
   },
   {
     "slug": "sau",
     "name": "Southern Arkansas University",
-    "mappingCount": 59
+    "mappingCount": 59,
+    "directCount": 59,
+    "electiveCount": 0,
+    "totalCount": 59
   },
   {
     "slug": "uaf",
     "name": "University of Arkansas",
-    "mappingCount": 76
+    "mappingCount": 76,
+    "directCount": 75,
+    "electiveCount": 1,
+    "totalCount": 76
   },
   {
     "slug": "uafs",
     "name": "University of Arkansas — Fort Smith",
-    "mappingCount": 66
+    "mappingCount": 66,
+    "directCount": 66,
+    "electiveCount": 0,
+    "totalCount": 66
   },
   {
     "slug": "ualr",
     "name": "University of Arkansas at Little Rock",
-    "mappingCount": 61
+    "mappingCount": 61,
+    "directCount": 61,
+    "electiveCount": 0,
+    "totalCount": 61
   },
   {
     "slug": "uca",
     "name": "University of Central Arkansas",
-    "mappingCount": 87
+    "mappingCount": 87,
+    "directCount": 87,
+    "electiveCount": 0,
+    "totalCount": 87
   }
 ]

--- a/data/az/transfer-universities.json
+++ b/data/az/transfer-universities.json
@@ -2,16 +2,25 @@
   {
     "slug": "asu",
     "name": "Arizona State University",
-    "mappingCount": 11993
+    "mappingCount": 10575,
+    "directCount": 9152,
+    "electiveCount": 1423,
+    "totalCount": 10575
   },
   {
     "slug": "nau",
     "name": "Northern Arizona University",
-    "mappingCount": 8957
+    "mappingCount": 8079,
+    "directCount": 0,
+    "electiveCount": 0,
+    "totalCount": 0
   },
   {
     "slug": "ua",
     "name": "University of Arizona",
-    "mappingCount": 10514
+    "mappingCount": 9327,
+    "directCount": 1531,
+    "electiveCount": 5407,
+    "totalCount": 6938
   }
 ]

--- a/data/ca/transfer-universities.json
+++ b/data/ca/transfer-universities.json
@@ -2,36 +2,57 @@
   {
     "slug": "csu-system",
     "name": "California State University (system-wide)",
-    "mappingCount": 99843
+    "mappingCount": 99843,
+    "directCount": 0,
+    "electiveCount": 99843,
+    "totalCount": 99843
   },
   {
     "slug": "university-of-california-berkeley",
     "name": "UC Berkeley",
-    "mappingCount": 1905
+    "mappingCount": 1905,
+    "directCount": 1905,
+    "electiveCount": 0,
+    "totalCount": 1905
   },
   {
     "slug": "university-of-california-davis",
     "name": "UC Davis",
-    "mappingCount": 642
+    "mappingCount": 642,
+    "directCount": 642,
+    "electiveCount": 0,
+    "totalCount": 642
   },
   {
     "slug": "university-of-california-irvine",
     "name": "UC Irvine",
-    "mappingCount": 1039
+    "mappingCount": 1039,
+    "directCount": 1039,
+    "electiveCount": 0,
+    "totalCount": 1039
   },
   {
     "slug": "university-of-california-san-diego",
     "name": "UC San Diego",
-    "mappingCount": 1004
+    "mappingCount": 1004,
+    "directCount": 1004,
+    "electiveCount": 0,
+    "totalCount": 1004
   },
   {
     "slug": "university-of-california-los-angeles",
     "name": "UCLA",
-    "mappingCount": 960
+    "mappingCount": 960,
+    "directCount": 960,
+    "electiveCount": 0,
+    "totalCount": 960
   },
   {
     "slug": "uc-system",
     "name": "University of California (system-wide)",
-    "mappingCount": 56287
+    "mappingCount": 56287,
+    "directCount": 0,
+    "electiveCount": 56287,
+    "totalCount": 56287
   }
 ]

--- a/data/co/transfer-universities.json
+++ b/data/co/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "du",
     "name": "University of Denver",
-    "mappingCount": 336
+    "mappingCount": 336,
+    "directCount": 201,
+    "electiveCount": 135,
+    "totalCount": 336
   }
 ]

--- a/data/ct/transfer-universities.json
+++ b/data/ct/transfer-universities.json
@@ -2,21 +2,33 @@
   {
     "slug": "ccsu",
     "name": "Central Connecticut State University",
-    "mappingCount": 509
+    "mappingCount": 509,
+    "directCount": 501,
+    "electiveCount": 0,
+    "totalCount": 501
   },
   {
     "slug": "scsu",
     "name": "Southern Connecticut State University",
-    "mappingCount": 9402
+    "mappingCount": 9402,
+    "directCount": 2740,
+    "electiveCount": 6296,
+    "totalCount": 9036
   },
   {
     "slug": "uconn",
     "name": "University of Connecticut",
-    "mappingCount": 747
+    "mappingCount": 747,
+    "directCount": 747,
+    "electiveCount": 0,
+    "totalCount": 747
   },
   {
     "slug": "wcsu",
     "name": "Western Connecticut State University",
-    "mappingCount": 859
+    "mappingCount": 860,
+    "directCount": 361,
+    "electiveCount": 499,
+    "totalCount": 860
   }
 ]

--- a/data/de/transfer-universities.json
+++ b/data/de/transfer-universities.json
@@ -2,16 +2,25 @@
   {
     "slug": "desu",
     "name": "Delaware State University",
-    "mappingCount": 694
+    "mappingCount": 694,
+    "directCount": 504,
+    "electiveCount": 189,
+    "totalCount": 693
   },
   {
     "slug": "udel",
     "name": "University of Delaware",
-    "mappingCount": 291
+    "mappingCount": 291,
+    "directCount": 178,
+    "electiveCount": 113,
+    "totalCount": 291
   },
   {
     "slug": "wilmington",
     "name": "Wilmington University",
-    "mappingCount": 563
+    "mappingCount": 563,
+    "directCount": 102,
+    "electiveCount": 461,
+    "totalCount": 563
   }
 ]

--- a/data/fl/transfer-universities.json
+++ b/data/fl/transfer-universities.json
@@ -2,61 +2,97 @@
   {
     "slug": "famu",
     "name": "Florida A&M University",
-    "mappingCount": 543
+    "mappingCount": 543,
+    "directCount": 543,
+    "electiveCount": 0,
+    "totalCount": 543
   },
   {
     "slug": "fau",
     "name": "Florida Atlantic University",
-    "mappingCount": 503
+    "mappingCount": 503,
+    "directCount": 503,
+    "electiveCount": 0,
+    "totalCount": 503
   },
   {
     "slug": "fgcu",
     "name": "Florida Gulf Coast University",
-    "mappingCount": 381
+    "mappingCount": 381,
+    "directCount": 381,
+    "electiveCount": 0,
+    "totalCount": 381
   },
   {
     "slug": "fiu",
     "name": "Florida International University",
-    "mappingCount": 645
+    "mappingCount": 645,
+    "directCount": 645,
+    "electiveCount": 0,
+    "totalCount": 645
   },
   {
     "slug": "flpoly",
     "name": "Florida Polytechnic University",
-    "mappingCount": 90
+    "mappingCount": 90,
+    "directCount": 90,
+    "electiveCount": 0,
+    "totalCount": 90
   },
   {
     "slug": "fsu",
     "name": "Florida State University",
-    "mappingCount": 675
+    "mappingCount": 675,
+    "directCount": 675,
+    "electiveCount": 0,
+    "totalCount": 675
   },
   {
     "slug": "ncf",
     "name": "New College of Florida",
-    "mappingCount": 29
+    "mappingCount": 29,
+    "directCount": 29,
+    "electiveCount": 0,
+    "totalCount": 29
   },
   {
     "slug": "ucf",
     "name": "University of Central Florida",
-    "mappingCount": 514
+    "mappingCount": 514,
+    "directCount": 514,
+    "electiveCount": 0,
+    "totalCount": 514
   },
   {
     "slug": "uf",
     "name": "University of Florida",
-    "mappingCount": 526
+    "mappingCount": 526,
+    "directCount": 526,
+    "electiveCount": 0,
+    "totalCount": 526
   },
   {
     "slug": "unf",
     "name": "University of North Florida",
-    "mappingCount": 412
+    "mappingCount": 412,
+    "directCount": 412,
+    "electiveCount": 0,
+    "totalCount": 412
   },
   {
     "slug": "usf",
     "name": "University of South Florida",
-    "mappingCount": 539
+    "mappingCount": 539,
+    "directCount": 539,
+    "electiveCount": 0,
+    "totalCount": 539
   },
   {
     "slug": "uwf",
     "name": "University of West Florida",
-    "mappingCount": 383
+    "mappingCount": 383,
+    "directCount": 383,
+    "electiveCount": 0,
+    "totalCount": 383
   }
 ]

--- a/data/ga/transfer-universities.json
+++ b/data/ga/transfer-universities.json
@@ -2,26 +2,41 @@
   {
     "slug": "gsu",
     "name": "Georgia State University",
-    "mappingCount": 4784
+    "mappingCount": 4784,
+    "directCount": 442,
+    "electiveCount": 456,
+    "totalCount": 898
   },
   {
     "slug": "gatech",
     "name": "Georgia Tech",
-    "mappingCount": 164
+    "mappingCount": 164,
+    "directCount": 89,
+    "electiveCount": 75,
+    "totalCount": 164
   },
   {
     "slug": "ksu",
     "name": "Kennesaw State University",
-    "mappingCount": 358
+    "mappingCount": 358,
+    "directCount": 323,
+    "electiveCount": 30,
+    "totalCount": 353
   },
   {
     "slug": "uga",
     "name": "University of Georgia",
-    "mappingCount": 1269
+    "mappingCount": 1269,
+    "directCount": 121,
+    "electiveCount": 151,
+    "totalCount": 272
   },
   {
     "slug": "uwg",
     "name": "University of West Georgia",
-    "mappingCount": 3201
+    "mappingCount": 3183,
+    "directCount": 221,
+    "electiveCount": 1834,
+    "totalCount": 2055
   }
 ]

--- a/data/hi/transfer-universities.json
+++ b/data/hi/transfer-universities.json
@@ -2,16 +2,25 @@
   {
     "slug": "uh-hilo",
     "name": "University of Hawaiʻi at Hilo",
-    "mappingCount": 4641
+    "mappingCount": 4641,
+    "directCount": 4641,
+    "electiveCount": 0,
+    "totalCount": 4641
   },
   {
     "slug": "uh-manoa",
     "name": "University of Hawaiʻi at Mānoa",
-    "mappingCount": 5041
+    "mappingCount": 5041,
+    "directCount": 1874,
+    "electiveCount": 3167,
+    "totalCount": 5041
   },
   {
     "slug": "uh-west-oahu",
     "name": "University of Hawaiʻi—West Oʻahu",
-    "mappingCount": 5967
+    "mappingCount": 5967,
+    "directCount": 2562,
+    "electiveCount": 3398,
+    "totalCount": 5960
   }
 ]

--- a/data/ia/transfer-universities.json
+++ b/data/ia/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "iowa-state",
     "name": "Iowa State University",
-    "mappingCount": 3512
+    "mappingCount": 3513,
+    "directCount": 3513,
+    "electiveCount": 0,
+    "totalCount": 3513
   }
 ]

--- a/data/id/transfer-universities.json
+++ b/data/id/transfer-universities.json
@@ -2,41 +2,65 @@
   {
     "slug": "boise-state-university",
     "name": "Boise State University",
-    "mappingCount": 646
+    "mappingCount": 646,
+    "directCount": 449,
+    "electiveCount": 196,
+    "totalCount": 645
   },
   {
     "slug": "college-of-eastern-idaho",
     "name": "College of Eastern Idaho",
-    "mappingCount": 347
+    "mappingCount": 347,
+    "directCount": 247,
+    "electiveCount": 100,
+    "totalCount": 347
   },
   {
     "slug": "college-of-southern-idaho",
     "name": "College of Southern Idaho",
-    "mappingCount": 236
+    "mappingCount": 236,
+    "directCount": 236,
+    "electiveCount": 0,
+    "totalCount": 236
   },
   {
     "slug": "college-of-western-idaho",
     "name": "College of Western Idaho",
-    "mappingCount": 405
+    "mappingCount": 405,
+    "directCount": 271,
+    "electiveCount": 134,
+    "totalCount": 405
   },
   {
     "slug": "idaho-state-university",
     "name": "Idaho State University",
-    "mappingCount": 740
+    "mappingCount": 740,
+    "directCount": 431,
+    "electiveCount": 309,
+    "totalCount": 740
   },
   {
     "slug": "lewis-clark-state-college",
     "name": "Lewis-Clark State College",
-    "mappingCount": 644
+    "mappingCount": 644,
+    "directCount": 465,
+    "electiveCount": 179,
+    "totalCount": 644
   },
   {
     "slug": "north-idaho-college",
     "name": "North Idaho College",
-    "mappingCount": 220
+    "mappingCount": 220,
+    "directCount": 213,
+    "electiveCount": 7,
+    "totalCount": 220
   },
   {
     "slug": "university-of-idaho",
     "name": "University of Idaho",
-    "mappingCount": 615
+    "mappingCount": 615,
+    "directCount": 615,
+    "electiveCount": 0,
+    "totalCount": 615
   }
 ]

--- a/data/il/transfer-universities.json
+++ b/data/il/transfer-universities.json
@@ -2,11 +2,17 @@
   {
     "slug": "niu",
     "name": "Northern Illinois University",
-    "mappingCount": 17773
+    "mappingCount": 17773,
+    "directCount": 9059,
+    "electiveCount": 8714,
+    "totalCount": 17773
   },
   {
     "slug": "siu",
     "name": "Southern Illinois University Carbondale",
-    "mappingCount": 36196
+    "mappingCount": 36204,
+    "directCount": 8740,
+    "electiveCount": 27464,
+    "totalCount": 36204
   }
 ]

--- a/data/in/transfer-universities.json
+++ b/data/in/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "university-of-southern-indiana",
     "name": "University of Southern Indiana",
-    "mappingCount": 311
+    "mappingCount": 311,
+    "directCount": 311,
+    "electiveCount": 0,
+    "totalCount": 311
   }
 ]

--- a/data/ks/transfer-universities.json
+++ b/data/ks/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "wichita-state-university",
     "name": "Wichita State University",
-    "mappingCount": 4009
+    "mappingCount": 4010,
+    "directCount": 3734,
+    "electiveCount": 271,
+    "totalCount": 4005
   }
 ]

--- a/data/ky/transfer-universities.json
+++ b/data/ky/transfer-universities.json
@@ -2,31 +2,49 @@
   {
     "slug": "eku",
     "name": "Eastern Kentucky University",
-    "mappingCount": 5
+    "mappingCount": 5,
+    "directCount": 1,
+    "electiveCount": 4,
+    "totalCount": 5
   },
   {
     "slug": "morehead",
     "name": "Morehead State University",
-    "mappingCount": 619
+    "mappingCount": 619,
+    "directCount": 457,
+    "electiveCount": 162,
+    "totalCount": 619
   },
   {
     "slug": "nku",
     "name": "Northern Kentucky University",
-    "mappingCount": 4539
+    "mappingCount": 4539,
+    "directCount": 2411,
+    "electiveCount": 2128,
+    "totalCount": 4539
   },
   {
     "slug": "uky",
     "name": "University of Kentucky",
-    "mappingCount": 1872
+    "mappingCount": 1874,
+    "directCount": 504,
+    "electiveCount": 1370,
+    "totalCount": 1874
   },
   {
     "slug": "uofl",
     "name": "University of Louisville",
-    "mappingCount": 1534
+    "mappingCount": 1536,
+    "directCount": 1371,
+    "electiveCount": 0,
+    "totalCount": 1371
   },
   {
     "slug": "wku",
     "name": "Western Kentucky University",
-    "mappingCount": 2072
+    "mappingCount": 2072,
+    "directCount": 1991,
+    "electiveCount": 81,
+    "totalCount": 2072
   }
 ]

--- a/data/la/transfer-universities.json
+++ b/data/la/transfer-universities.json
@@ -2,81 +2,129 @@
   {
     "slug": "grambling-state",
     "name": "Grambling State University",
-    "mappingCount": 884
+    "mappingCount": 884,
+    "directCount": 884,
+    "electiveCount": 0,
+    "totalCount": 884
   },
   {
     "slug": "louisiana-tech",
     "name": "Louisiana Tech University",
-    "mappingCount": 982
+    "mappingCount": 982,
+    "directCount": 982,
+    "electiveCount": 0,
+    "totalCount": 982
   },
   {
     "slug": "lsu-baton-rouge",
     "name": "LSU (Baton Rouge)",
-    "mappingCount": 976
+    "mappingCount": 976,
+    "directCount": 976,
+    "electiveCount": 0,
+    "totalCount": 976
   },
   {
     "slug": "lsu-alexandria",
     "name": "LSU Alexandria",
-    "mappingCount": 958
+    "mappingCount": 958,
+    "directCount": 958,
+    "electiveCount": 0,
+    "totalCount": 958
   },
   {
     "slug": "lsu-eunice",
     "name": "LSU Eunice",
-    "mappingCount": 972
+    "mappingCount": 972,
+    "directCount": 972,
+    "electiveCount": 0,
+    "totalCount": 972
   },
   {
     "slug": "lsu-shreveport",
     "name": "LSU Shreveport",
-    "mappingCount": 986
+    "mappingCount": 986,
+    "directCount": 986,
+    "electiveCount": 0,
+    "totalCount": 986
   },
   {
     "slug": "mcneese-state",
     "name": "McNeese State University",
-    "mappingCount": 877
+    "mappingCount": 877,
+    "directCount": 877,
+    "electiveCount": 0,
+    "totalCount": 877
   },
   {
     "slug": "nicholls-state",
     "name": "Nicholls State University",
-    "mappingCount": 926
+    "mappingCount": 926,
+    "directCount": 926,
+    "electiveCount": 0,
+    "totalCount": 926
   },
   {
     "slug": "northwestern-state",
     "name": "Northwestern State University",
-    "mappingCount": 952
+    "mappingCount": 952,
+    "directCount": 952,
+    "electiveCount": 0,
+    "totalCount": 952
   },
   {
     "slug": "southeastern-louisiana",
     "name": "Southeastern Louisiana University",
-    "mappingCount": 1121
+    "mappingCount": 1121,
+    "directCount": 1121,
+    "electiveCount": 0,
+    "totalCount": 1121
   },
   {
     "slug": "southern-baton-rouge",
     "name": "Southern University (Baton Rouge)",
-    "mappingCount": 440
+    "mappingCount": 440,
+    "directCount": 440,
+    "electiveCount": 0,
+    "totalCount": 440
   },
   {
     "slug": "southern-new-orleans",
     "name": "Southern University at New Orleans",
-    "mappingCount": 837
+    "mappingCount": 837,
+    "directCount": 837,
+    "electiveCount": 0,
+    "totalCount": 837
   },
   {
     "slug": "southern-shreveport",
     "name": "Southern University at Shreveport",
-    "mappingCount": 1019
+    "mappingCount": 1019,
+    "directCount": 1019,
+    "electiveCount": 0,
+    "totalCount": 1019
   },
   {
     "slug": "ul-lafayette",
     "name": "University of Louisiana at Lafayette",
-    "mappingCount": 988
+    "mappingCount": 988,
+    "directCount": 988,
+    "electiveCount": 0,
+    "totalCount": 988
   },
   {
     "slug": "ul-monroe",
     "name": "University of Louisiana at Monroe",
-    "mappingCount": 930
+    "mappingCount": 930,
+    "directCount": 930,
+    "electiveCount": 0,
+    "totalCount": 930
   },
   {
     "slug": "new-orleans",
     "name": "University of New Orleans",
-    "mappingCount": 1055
+    "mappingCount": 1055,
+    "directCount": 1055,
+    "electiveCount": 0,
+    "totalCount": 1055
   }
 ]

--- a/data/ma/transfer-universities.json
+++ b/data/ma/transfer-universities.json
@@ -2,66 +2,105 @@
   {
     "slug": "bridgewater-state-university",
     "name": "Bridgewater State University",
-    "mappingCount": 4497
+    "mappingCount": 4497,
+    "directCount": 1706,
+    "electiveCount": 2772,
+    "totalCount": 4478
   },
   {
     "slug": "fitchburg-state-university",
     "name": "Fitchburg State University",
-    "mappingCount": 6076
+    "mappingCount": 6076,
+    "directCount": 2902,
+    "electiveCount": 3167,
+    "totalCount": 6069
   },
   {
     "slug": "framingham-state-university",
     "name": "Framingham State University",
-    "mappingCount": 3447
+    "mappingCount": 3447,
+    "directCount": 1064,
+    "electiveCount": 2341,
+    "totalCount": 3405
   },
   {
     "slug": "massachusetts-college-of-art-and-design",
     "name": "Massachusetts College of Art and Design",
-    "mappingCount": 130
+    "mappingCount": 130,
+    "directCount": 115,
+    "electiveCount": 15,
+    "totalCount": 130
   },
   {
     "slug": "massachusetts-college-of-liberal-arts",
     "name": "Massachusetts College of Liberal Arts",
-    "mappingCount": 4135
+    "mappingCount": 4135,
+    "directCount": 2144,
+    "electiveCount": 1924,
+    "totalCount": 4068
   },
   {
     "slug": "massachusetts-maritime-academy",
     "name": "Massachusetts Maritime Academy",
-    "mappingCount": 476
+    "mappingCount": 476,
+    "directCount": 474,
+    "electiveCount": 2,
+    "totalCount": 476
   },
   {
     "slug": "salem-state-university",
     "name": "Salem State University",
-    "mappingCount": 3987
+    "mappingCount": 3987,
+    "directCount": 2265,
+    "electiveCount": 1175,
+    "totalCount": 3440
   },
   {
     "slug": "university-of-massachusetts-at-amherst",
     "name": "University of Massachusetts at Amherst",
-    "mappingCount": 5296
+    "mappingCount": 5296,
+    "directCount": 1659,
+    "electiveCount": 2853,
+    "totalCount": 4512
   },
   {
     "slug": "university-of-massachusetts-at-boston",
     "name": "University of Massachusetts at Boston",
-    "mappingCount": 2476
+    "mappingCount": 2476,
+    "directCount": 1130,
+    "electiveCount": 1185,
+    "totalCount": 2315
   },
   {
     "slug": "university-of-massachusetts-at-dartmouth",
     "name": "University of Massachusetts at Dartmouth",
-    "mappingCount": 3052
+    "mappingCount": 3052,
+    "directCount": 1557,
+    "electiveCount": 1465,
+    "totalCount": 3022
   },
   {
     "slug": "university-of-massachusetts-at-lowell",
     "name": "University of Massachusetts at Lowell",
-    "mappingCount": 1820
+    "mappingCount": 1820,
+    "directCount": 1421,
+    "electiveCount": 379,
+    "totalCount": 1800
   },
   {
     "slug": "westfield-state-university",
     "name": "Westfield State University",
-    "mappingCount": 4498
+    "mappingCount": 4498,
+    "directCount": 2798,
+    "electiveCount": 1438,
+    "totalCount": 4236
   },
   {
     "slug": "worcester-state-university",
     "name": "Worcester State University",
-    "mappingCount": 5833
+    "mappingCount": 5833,
+    "directCount": 2400,
+    "electiveCount": 3073,
+    "totalCount": 5473
   }
 ]

--- a/data/md/transfer-universities.json
+++ b/data/md/transfer-universities.json
@@ -2,41 +2,65 @@
   {
     "slug": "bowie-state",
     "name": "Bowie State University",
-    "mappingCount": 1387
+    "mappingCount": 1387,
+    "directCount": 1372,
+    "electiveCount": 15,
+    "totalCount": 1387
   },
   {
     "slug": "frostburg",
     "name": "Frostburg State University",
-    "mappingCount": 22682
+    "mappingCount": 22683,
+    "directCount": 10748,
+    "electiveCount": 11935,
+    "totalCount": 22683
   },
   {
     "slug": "morgan-state",
     "name": "Morgan State University",
-    "mappingCount": 14231
+    "mappingCount": 14231,
+    "directCount": 6926,
+    "electiveCount": 7305,
+    "totalCount": 14231
   },
   {
     "slug": "salisbury",
     "name": "Salisbury University",
-    "mappingCount": 9174
+    "mappingCount": 9174,
+    "directCount": 6264,
+    "electiveCount": 2910,
+    "totalCount": 9174
   },
   {
     "slug": "towson",
     "name": "Towson University",
-    "mappingCount": 7094
+    "mappingCount": 7094,
+    "directCount": 5224,
+    "electiveCount": 1870,
+    "totalCount": 7094
   },
   {
     "slug": "umgc",
     "name": "University of Maryland Global Campus",
-    "mappingCount": 39150
+    "mappingCount": 39146,
+    "directCount": 11737,
+    "electiveCount": 27409,
+    "totalCount": 39146
   },
   {
     "slug": "umbc",
     "name": "University of Maryland, Baltimore County",
-    "mappingCount": 17411
+    "mappingCount": 17411,
+    "directCount": 9348,
+    "electiveCount": 8063,
+    "totalCount": 17411
   },
   {
     "slug": "umcp",
     "name": "University of Maryland, College Park",
-    "mappingCount": 12352
+    "mappingCount": 12350,
+    "directCount": 8124,
+    "electiveCount": 4226,
+    "totalCount": 12350
   }
 ]

--- a/data/me/transfer-universities.json
+++ b/data/me/transfer-universities.json
@@ -2,31 +2,49 @@
   {
     "slug": "umaine",
     "name": "University of Maine & University of Maine at Machias",
-    "mappingCount": 3617
+    "mappingCount": 4329,
+    "directCount": 4303,
+    "electiveCount": 26,
+    "totalCount": 4329
   },
   {
     "slug": "uma",
     "name": "University of Maine at Augusta",
-    "mappingCount": 9982
+    "mappingCount": 9983,
+    "directCount": 2387,
+    "electiveCount": 7596,
+    "totalCount": 9983
   },
   {
     "slug": "umf",
     "name": "University of Maine at Farmington",
-    "mappingCount": 3704
+    "mappingCount": 3704,
+    "directCount": 2197,
+    "electiveCount": 1507,
+    "totalCount": 3704
   },
   {
     "slug": "umfk",
     "name": "University of Maine at Fort Kent",
-    "mappingCount": 8389
+    "mappingCount": 8389,
+    "directCount": 6251,
+    "electiveCount": 2138,
+    "totalCount": 8389
   },
   {
     "slug": "umpi",
     "name": "University of Maine at Presque Isle",
-    "mappingCount": 9496
+    "mappingCount": 9496,
+    "directCount": 2127,
+    "electiveCount": 7369,
+    "totalCount": 9496
   },
   {
     "slug": "usm",
     "name": "University of Southern Maine",
-    "mappingCount": 6304
+    "mappingCount": 6315,
+    "directCount": 734,
+    "electiveCount": 5581,
+    "totalCount": 6315
   }
 ]

--- a/data/mi/transfer-universities.json
+++ b/data/mi/transfer-universities.json
@@ -2,26 +2,41 @@
   {
     "slug": "emich",
     "name": "Eastern Michigan University",
-    "mappingCount": 19765
+    "mappingCount": 19765,
+    "directCount": 19765,
+    "electiveCount": 0,
+    "totalCount": 19765
   },
   {
     "slug": "msu",
     "name": "Michigan State University",
-    "mappingCount": 20793
+    "mappingCount": 20793,
+    "directCount": 3061,
+    "electiveCount": 4104,
+    "totalCount": 7165
   },
   {
     "slug": "umich",
     "name": "University of Michigan-Ann Arbor",
-    "mappingCount": 12981
+    "mappingCount": 12981,
+    "directCount": 12981,
+    "electiveCount": 0,
+    "totalCount": 12981
   },
   {
     "slug": "wayne-state",
     "name": "Wayne State University",
-    "mappingCount": 41343
+    "mappingCount": 41343,
+    "directCount": 41343,
+    "electiveCount": 0,
+    "totalCount": 41343
   },
   {
     "slug": "wmich",
     "name": "Western Michigan University",
-    "mappingCount": 57943
+    "mappingCount": 57943,
+    "directCount": 57943,
+    "electiveCount": 0,
+    "totalCount": 57943
   }
 ]

--- a/data/mn/transfer-universities.json
+++ b/data/mn/transfer-universities.json
@@ -2,36 +2,57 @@
   {
     "slug": "bemidji-state-university",
     "name": "Bemidji State University",
-    "mappingCount": 663
+    "mappingCount": 663,
+    "directCount": 663,
+    "electiveCount": 0,
+    "totalCount": 663
   },
   {
     "slug": "metro-state-university",
     "name": "Metropolitan State University",
-    "mappingCount": 872
+    "mappingCount": 872,
+    "directCount": 872,
+    "electiveCount": 0,
+    "totalCount": 872
   },
   {
     "slug": "minnesota-state-university-moorhead",
     "name": "Minnesota State University Moorhead",
-    "mappingCount": 669
+    "mappingCount": 669,
+    "directCount": 669,
+    "electiveCount": 0,
+    "totalCount": 669
   },
   {
     "slug": "minnesota-state-university-mankato",
     "name": "Minnesota State University, Mankato",
-    "mappingCount": 1191
+    "mappingCount": 1192,
+    "directCount": 1192,
+    "electiveCount": 0,
+    "totalCount": 1192
   },
   {
     "slug": "southwest-minnesota-state-university",
     "name": "Southwest Minnesota State University",
-    "mappingCount": 861
+    "mappingCount": 861,
+    "directCount": 861,
+    "electiveCount": 0,
+    "totalCount": 861
   },
   {
     "slug": "st-cloud-state-university",
     "name": "St. Cloud State University",
-    "mappingCount": 986
+    "mappingCount": 986,
+    "directCount": 986,
+    "electiveCount": 0,
+    "totalCount": 986
   },
   {
     "slug": "winona-state-university",
     "name": "Winona State University",
-    "mappingCount": 930
+    "mappingCount": 928,
+    "directCount": 928,
+    "electiveCount": 0,
+    "totalCount": 928
   }
 ]

--- a/data/mo/transfer-universities.json
+++ b/data/mo/transfer-universities.json
@@ -2,66 +2,105 @@
   {
     "slug": "harris-stowe",
     "name": "Harris-Stowe State University",
-    "mappingCount": 450
+    "mappingCount": 450,
+    "directCount": 450,
+    "electiveCount": 0,
+    "totalCount": 450
   },
   {
     "slug": "lincoln",
     "name": "Lincoln University",
-    "mappingCount": 681
+    "mappingCount": 681,
+    "directCount": 681,
+    "electiveCount": 0,
+    "totalCount": 681
   },
   {
     "slug": "missouri-southern",
     "name": "Missouri Southern State University",
-    "mappingCount": 794
+    "mappingCount": 794,
+    "directCount": 794,
+    "electiveCount": 0,
+    "totalCount": 794
   },
   {
     "slug": "missouri-state",
     "name": "Missouri State University",
-    "mappingCount": 1273
+    "mappingCount": 1273,
+    "directCount": 1273,
+    "electiveCount": 0,
+    "totalCount": 1273
   },
   {
     "slug": "missouri-st",
     "name": "Missouri University of Science & Technology",
-    "mappingCount": 349
+    "mappingCount": 349,
+    "directCount": 349,
+    "electiveCount": 0,
+    "totalCount": 349
   },
   {
     "slug": "missouri-western",
     "name": "Missouri Western State University",
-    "mappingCount": 900
+    "mappingCount": 900,
+    "directCount": 900,
+    "electiveCount": 0,
+    "totalCount": 900
   },
   {
     "slug": "northwest-missouri",
     "name": "Northwest Missouri State University",
-    "mappingCount": 641
+    "mappingCount": 641,
+    "directCount": 641,
+    "electiveCount": 0,
+    "totalCount": 641
   },
   {
     "slug": "semo",
     "name": "Southeast Missouri State University",
-    "mappingCount": 782
+    "mappingCount": 782,
+    "directCount": 782,
+    "electiveCount": 0,
+    "totalCount": 782
   },
   {
     "slug": "truman",
     "name": "Truman State University",
-    "mappingCount": 579
+    "mappingCount": 579,
+    "directCount": 579,
+    "electiveCount": 0,
+    "totalCount": 579
   },
   {
     "slug": "ucm",
     "name": "University of Central Missouri",
-    "mappingCount": 860
+    "mappingCount": 860,
+    "directCount": 860,
+    "electiveCount": 0,
+    "totalCount": 860
   },
   {
     "slug": "mizzou",
     "name": "University of Missouri",
-    "mappingCount": 592
+    "mappingCount": 592,
+    "directCount": 592,
+    "electiveCount": 0,
+    "totalCount": 592
   },
   {
     "slug": "umkc",
     "name": "University of Missouri–Kansas City",
-    "mappingCount": 510
+    "mappingCount": 510,
+    "directCount": 510,
+    "electiveCount": 0,
+    "totalCount": 510
   },
   {
     "slug": "umsl",
     "name": "University of Missouri–St. Louis",
-    "mappingCount": 463
+    "mappingCount": 463,
+    "directCount": 463,
+    "electiveCount": 0,
+    "totalCount": 463
   }
 ]

--- a/data/ms/transfer-universities.json
+++ b/data/ms/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "ole-miss",
     "name": "University of Mississippi",
-    "mappingCount": 2109
+    "mappingCount": 2109,
+    "directCount": 833,
+    "electiveCount": 1276,
+    "totalCount": 2109
   }
 ]

--- a/data/mt/transfer-universities.json
+++ b/data/mt/transfer-universities.json
@@ -2,31 +2,49 @@
   {
     "slug": "msu-bozeman",
     "name": "Montana State University",
-    "mappingCount": 271
+    "mappingCount": 271,
+    "directCount": 271,
+    "electiveCount": 0,
+    "totalCount": 271
   },
   {
     "slug": "msu-billings",
     "name": "Montana State University Billings",
-    "mappingCount": 186
+    "mappingCount": 186,
+    "directCount": 186,
+    "electiveCount": 0,
+    "totalCount": 186
   },
   {
     "slug": "msu-northern",
     "name": "Montana State University Northern",
-    "mappingCount": 249
+    "mappingCount": 249,
+    "directCount": 249,
+    "electiveCount": 0,
+    "totalCount": 249
   },
   {
     "slug": "montana-tech",
     "name": "Montana Technological University",
-    "mappingCount": 160
+    "mappingCount": 160,
+    "directCount": 160,
+    "electiveCount": 0,
+    "totalCount": 160
   },
   {
     "slug": "um-missoula",
     "name": "University of Montana",
-    "mappingCount": 272
+    "mappingCount": 272,
+    "directCount": 272,
+    "electiveCount": 0,
+    "totalCount": 272
   },
   {
     "slug": "um-western",
     "name": "University of Montana Western",
-    "mappingCount": 171
+    "mappingCount": 171,
+    "directCount": 171,
+    "electiveCount": 0,
+    "totalCount": 171
   }
 ]

--- a/data/nc/transfer-universities.json
+++ b/data/nc/transfer-universities.json
@@ -2,101 +2,161 @@
   {
     "slug": "appstate",
     "name": "Appalachian State University",
-    "mappingCount": 1000
+    "mappingCount": 1000,
+    "directCount": 508,
+    "electiveCount": 492,
+    "totalCount": 1000
   },
   {
     "slug": "catawba",
     "name": "Catawba College",
-    "mappingCount": 677
+    "mappingCount": 677,
+    "directCount": 433,
+    "electiveCount": 244,
+    "totalCount": 677
   },
   {
     "slug": "ecu",
     "name": "East Carolina University",
-    "mappingCount": 1956
+    "mappingCount": 1956,
+    "directCount": 398,
+    "electiveCount": 1558,
+    "totalCount": 1956
   },
   {
     "slug": "ecsu",
     "name": "Elizabeth City State University",
-    "mappingCount": 648
+    "mappingCount": 648,
+    "directCount": 482,
+    "electiveCount": 166,
+    "totalCount": 648
   },
   {
     "slug": "elon",
     "name": "Elon University",
-    "mappingCount": 2035
+    "mappingCount": 2035,
+    "directCount": 0,
+    "electiveCount": 0,
+    "totalCount": 0
   },
   {
     "slug": "fsu",
     "name": "Fayetteville State University",
-    "mappingCount": 2013
+    "mappingCount": 2013,
+    "directCount": 638,
+    "electiveCount": 1375,
+    "totalCount": 2013
   },
   {
     "slug": "high-point",
     "name": "High Point University",
-    "mappingCount": 219
+    "mappingCount": 219,
+    "directCount": 168,
+    "electiveCount": 51,
+    "totalCount": 219
   },
   {
     "slug": "ncat",
     "name": "NC A&T State University",
-    "mappingCount": 1240
+    "mappingCount": 1240,
+    "directCount": 1240,
+    "electiveCount": 0,
+    "totalCount": 1240
   },
   {
     "slug": "ncstate",
     "name": "NC State University",
-    "mappingCount": 676
+    "mappingCount": 676,
+    "directCount": 279,
+    "electiveCount": 87,
+    "totalCount": 366
   },
   {
     "slug": "unca",
     "name": "UNC Asheville",
-    "mappingCount": 804
+    "mappingCount": 804,
+    "directCount": 757,
+    "electiveCount": 47,
+    "totalCount": 804
   },
   {
     "slug": "unc-ch",
     "name": "UNC Chapel Hill",
-    "mappingCount": 856
+    "mappingCount": 856,
+    "directCount": 454,
+    "electiveCount": 402,
+    "totalCount": 856
   },
   {
     "slug": "uncc",
     "name": "UNC Charlotte",
-    "mappingCount": 1737
+    "mappingCount": 1737,
+    "directCount": 544,
+    "electiveCount": 1193,
+    "totalCount": 1737
   },
   {
     "slug": "uncg",
     "name": "UNC Greensboro",
-    "mappingCount": 927
+    "mappingCount": 927,
+    "directCount": 408,
+    "electiveCount": 519,
+    "totalCount": 927
   },
   {
     "slug": "uncp",
     "name": "UNC Pembroke",
-    "mappingCount": 736
+    "mappingCount": 736,
+    "directCount": 472,
+    "electiveCount": 264,
+    "totalCount": 736
   },
   {
     "slug": "uncsa",
     "name": "UNC School of the Arts",
-    "mappingCount": 520
+    "mappingCount": 520,
+    "directCount": 283,
+    "electiveCount": 237,
+    "totalCount": 520
   },
   {
     "slug": "unc-system",
     "name": "UNC System (CAA)",
-    "mappingCount": 361
+    "mappingCount": 361,
+    "directCount": 160,
+    "electiveCount": 201,
+    "totalCount": 361
   },
   {
     "slug": "uncw",
     "name": "UNC Wilmington",
-    "mappingCount": 4687
+    "mappingCount": 4687,
+    "directCount": 3811,
+    "electiveCount": 876,
+    "totalCount": 4687
   },
   {
     "slug": "wcu",
     "name": "Western Carolina University",
-    "mappingCount": 2745
+    "mappingCount": 2745,
+    "directCount": 704,
+    "electiveCount": 2041,
+    "totalCount": 2745
   },
   {
     "slug": "wingate",
     "name": "Wingate University",
-    "mappingCount": 817
+    "mappingCount": 817,
+    "directCount": 262,
+    "electiveCount": 555,
+    "totalCount": 817
   },
   {
     "slug": "wssu",
     "name": "Winston-Salem State University",
-    "mappingCount": 1033
+    "mappingCount": 1033,
+    "directCount": 1033,
+    "electiveCount": 0,
+    "totalCount": 1033
   }
 ]

--- a/data/nd/transfer-universities.json
+++ b/data/nd/transfer-universities.json
@@ -2,31 +2,49 @@
   {
     "slug": "dickinson-state-university",
     "name": "Dickinson State University",
-    "mappingCount": 949
+    "mappingCount": 949,
+    "directCount": 949,
+    "electiveCount": 0,
+    "totalCount": 949
   },
   {
     "slug": "mayville-state-university",
     "name": "Mayville State University",
-    "mappingCount": 949
+    "mappingCount": 949,
+    "directCount": 949,
+    "electiveCount": 0,
+    "totalCount": 949
   },
   {
     "slug": "minot-state-university",
     "name": "Minot State University",
-    "mappingCount": 949
+    "mappingCount": 949,
+    "directCount": 949,
+    "electiveCount": 0,
+    "totalCount": 949
   },
   {
     "slug": "north-dakota-state-university",
     "name": "North Dakota State University",
-    "mappingCount": 949
+    "mappingCount": 949,
+    "directCount": 949,
+    "electiveCount": 0,
+    "totalCount": 949
   },
   {
     "slug": "university-of-north-dakota",
     "name": "University of North Dakota",
-    "mappingCount": 949
+    "mappingCount": 949,
+    "directCount": 949,
+    "electiveCount": 0,
+    "totalCount": 949
   },
   {
     "slug": "valley-city-state-university",
     "name": "Valley City State University",
-    "mappingCount": 949
+    "mappingCount": 949,
+    "directCount": 949,
+    "electiveCount": 0,
+    "totalCount": 949
   }
 ]

--- a/data/ne/transfer-universities.json
+++ b/data/ne/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "university-of-nebraska-lincoln",
     "name": "University of Nebraska-Lincoln",
-    "mappingCount": 1996
+    "mappingCount": 1996,
+    "directCount": 901,
+    "electiveCount": 1095,
+    "totalCount": 1996
   }
 ]

--- a/data/nh/transfer-universities.json
+++ b/data/nh/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "keene",
     "name": "Keene State College",
-    "mappingCount": 2680
+    "mappingCount": 2680,
+    "directCount": 834,
+    "electiveCount": 1846,
+    "totalCount": 2680
   }
 ]

--- a/data/nj/transfer-universities.json
+++ b/data/nj/transfer-universities.json
@@ -2,201 +2,321 @@
   {
     "slug": "berkeley-college",
     "name": "Berkeley College",
-    "mappingCount": 3449
+    "mappingCount": 3449,
+    "directCount": 963,
+    "electiveCount": 0,
+    "totalCount": 963
   },
   {
     "slug": "montclair",
     "name": "Bloomfield College of Montclair State University",
-    "mappingCount": 2423
+    "mappingCount": 2423,
+    "directCount": 1759,
+    "electiveCount": 0,
+    "totalCount": 1759
   },
   {
     "slug": "caldwell-university",
     "name": "Caldwell University",
-    "mappingCount": 3431
+    "mappingCount": 3431,
+    "directCount": 3226,
+    "electiveCount": 0,
+    "totalCount": 3226
   },
   {
     "slug": "centenary-university",
     "name": "Centenary University",
-    "mappingCount": 3490
+    "mappingCount": 3490,
+    "directCount": 3167,
+    "electiveCount": 0,
+    "totalCount": 3167
   },
   {
     "slug": "devry-university",
     "name": "DeVry University",
-    "mappingCount": 3266
+    "mappingCount": 3266,
+    "directCount": 1079,
+    "electiveCount": 0,
+    "totalCount": 1079
   },
   {
     "slug": "drew-university",
     "name": "Drew University",
-    "mappingCount": 2272
+    "mappingCount": 2272,
+    "directCount": 1246,
+    "electiveCount": 0,
+    "totalCount": 1246
   },
   {
     "slug": "fairleigh-dickinson-florham",
     "name": "Fairleigh Dickinson-Florham",
-    "mappingCount": 3358
+    "mappingCount": 3358,
+    "directCount": 2325,
+    "electiveCount": 0,
+    "totalCount": 2325
   },
   {
     "slug": "fairleigh-dickinson-metropolitan",
     "name": "Fairleigh Dickinson-Metropolitan",
-    "mappingCount": 3333
+    "mappingCount": 3333,
+    "directCount": 2301,
+    "electiveCount": 0,
+    "totalCount": 2301
   },
   {
     "slug": "felician-university",
     "name": "Felician University",
-    "mappingCount": 3485
+    "mappingCount": 3485,
+    "directCount": 2912,
+    "electiveCount": 0,
+    "totalCount": 2912
   },
   {
     "slug": "georgian-court-university",
     "name": "Georgian Court University",
-    "mappingCount": 3095
+    "mappingCount": 3095,
+    "directCount": 2780,
+    "electiveCount": 0,
+    "totalCount": 2780
   },
   {
     "slug": "kean",
     "name": "Kean University",
-    "mappingCount": 1470
+    "mappingCount": 1470,
+    "directCount": 1190,
+    "electiveCount": 0,
+    "totalCount": 1190
   },
   {
     "slug": "monmouth",
     "name": "Monmouth University",
-    "mappingCount": 1395
+    "mappingCount": 1395,
+    "directCount": 869,
+    "electiveCount": 0,
+    "totalCount": 869
   },
   {
     "slug": "njcu",
     "name": "New Jersey City University",
-    "mappingCount": 1576
+    "mappingCount": 1576,
+    "directCount": 1038,
+    "electiveCount": 0,
+    "totalCount": 1038
   },
   {
     "slug": "njit",
     "name": "New Jersey Institute of Technology",
-    "mappingCount": 1576
+    "mappingCount": 1576,
+    "directCount": 324,
+    "electiveCount": 0,
+    "totalCount": 324
   },
   {
     "slug": "ramapo",
     "name": "Ramapo College",
-    "mappingCount": 1570
+    "mappingCount": 1570,
+    "directCount": 909,
+    "electiveCount": 0,
+    "totalCount": 909
   },
   {
     "slug": "rider",
     "name": "Rider University",
-    "mappingCount": 1445
+    "mappingCount": 1445,
+    "directCount": 729,
+    "electiveCount": 0,
+    "totalCount": 729
   },
   {
     "slug": "rowan",
     "name": "Rowan University",
-    "mappingCount": 1531
+    "mappingCount": 1531,
+    "directCount": 1463,
+    "electiveCount": 0,
+    "totalCount": 1463
   },
   {
     "slug": "rutgers-bus",
     "name": "Rutgers Business School - New Brunswick",
-    "mappingCount": 1582
+    "mappingCount": 1582,
+    "directCount": 609,
+    "electiveCount": 0,
+    "totalCount": 609
   },
   {
     "slug": "rutgers-camden",
     "name": "Rutgers-Camden - CCAS and Nursing",
-    "mappingCount": 1583
+    "mappingCount": 1583,
+    "directCount": 1138,
+    "electiveCount": 0,
+    "totalCount": 1138
   },
   {
     "slug": "rutgers-camden-school-of-business",
     "name": "Rutgers-Camden-School of Business",
-    "mappingCount": 3492
+    "mappingCount": 3492,
+    "directCount": 2402,
+    "electiveCount": 0,
+    "totalCount": 2402
   },
   {
     "slug": "rutgers-edward-bloustein-sch-of-planning-amp-policy",
     "name": "Rutgers-Edward Bloustein Sch of Planning &amp; Policy",
-    "mappingCount": 3608
+    "mappingCount": 3608,
+    "directCount": 3351,
+    "electiveCount": 0,
+    "totalCount": 3351
   },
   {
     "slug": "rutgers-ernest-mario-school-of-pharmacy",
     "name": "Rutgers-Ernest Mario School of Pharmacy",
-    "mappingCount": 3391
+    "mappingCount": 3391,
+    "directCount": 591,
+    "electiveCount": 0,
+    "totalCount": 591
   },
   {
     "slug": "rutgers-mason-gross-school-of-arts",
     "name": "Rutgers-Mason Gross School of Arts",
-    "mappingCount": 3399
+    "mappingCount": 3399,
+    "directCount": 1334,
+    "electiveCount": 0,
+    "totalCount": 1334
   },
   {
     "slug": "rutgers-newark",
     "name": "Rutgers-Newark College of Arts and Sciences",
-    "mappingCount": 1597
+    "mappingCount": 1597,
+    "directCount": 1120,
+    "electiveCount": 0,
+    "totalCount": 1120
   },
   {
     "slug": "rutgers-newark-rutgers-business-school",
     "name": "Rutgers-Newark-Rutgers Business School",
-    "mappingCount": 3490
+    "mappingCount": 3490,
+    "directCount": 2478,
+    "electiveCount": 0,
+    "totalCount": 2478
   },
   {
     "slug": "rutgers-newark-school-of-criminal-justice",
     "name": "Rutgers-Newark-School of Criminal Justice",
-    "mappingCount": 3488
+    "mappingCount": 3488,
+    "directCount": 2476,
+    "electiveCount": 0,
+    "totalCount": 2476
   },
   {
     "slug": "rutgers-newark-school-of-public-affairs-and-admin",
     "name": "Rutgers-Newark-School of Public Affairs and Admin",
-    "mappingCount": 3488
+    "mappingCount": 3488,
+    "directCount": 2476,
+    "electiveCount": 0,
+    "totalCount": 2476
   },
   {
     "slug": "rutgers-newark-university-college",
     "name": "Rutgers-Newark-University College",
-    "mappingCount": 3488
+    "mappingCount": 3488,
+    "directCount": 2476,
+    "electiveCount": 0,
+    "totalCount": 2476
   },
   {
     "slug": "rutgers-sas",
     "name": "Rutgers-School of Arts and Sciences",
-    "mappingCount": 1620
+    "mappingCount": 1620,
+    "directCount": 582,
+    "electiveCount": 0,
+    "totalCount": 582
   },
   {
     "slug": "rutgers-eng",
     "name": "Rutgers-School of Engineering",
-    "mappingCount": 1531
+    "mappingCount": 1531,
+    "directCount": 200,
+    "electiveCount": 0,
+    "totalCount": 200
   },
   {
     "slug": "rutgers-school-of-env-biological-sciences",
     "name": "Rutgers-School of Env Biological Sciences",
-    "mappingCount": 3402
+    "mappingCount": 3402,
+    "directCount": 2492,
+    "electiveCount": 0,
+    "totalCount": 2492
   },
   {
     "slug": "rutgers-school-of-management-and-labor-relations",
     "name": "Rutgers-School of Management and Labor Relations",
-    "mappingCount": 3602
+    "mappingCount": 3602,
+    "directCount": 3408,
+    "electiveCount": 0,
+    "totalCount": 3408
   },
   {
     "slug": "rutgers-school-of-nursing",
     "name": "Rutgers-School of Nursing",
-    "mappingCount": 3255
+    "mappingCount": 3255,
+    "directCount": 1628,
+    "electiveCount": 0,
+    "totalCount": 1628
   },
   {
     "slug": "saint-elizabeth-university",
     "name": "Saint Elizabeth University",
-    "mappingCount": 3216
+    "mappingCount": 3216,
+    "directCount": 2025,
+    "electiveCount": 0,
+    "totalCount": 2025
   },
   {
     "slug": "saint-peter-s-university",
     "name": "Saint Peter's University",
-    "mappingCount": 3161
+    "mappingCount": 3161,
+    "directCount": 1686,
+    "electiveCount": 0,
+    "totalCount": 1686
   },
   {
     "slug": "seton-hall",
     "name": "Seton Hall University",
-    "mappingCount": 1499
+    "mappingCount": 1499,
+    "directCount": 753,
+    "electiveCount": 0,
+    "totalCount": 753
   },
   {
     "slug": "stockton",
     "name": "Stockton University",
-    "mappingCount": 1446
+    "mappingCount": 1446,
+    "directCount": 766,
+    "electiveCount": 0,
+    "totalCount": 766
   },
   {
     "slug": "tcnj",
     "name": "The College of New Jersey",
-    "mappingCount": 1431
+    "mappingCount": 1431,
+    "directCount": 907,
+    "electiveCount": 0,
+    "totalCount": 907
   },
   {
     "slug": "tesu",
     "name": "Thomas Edison State University",
-    "mappingCount": 1678
+    "mappingCount": 1678,
+    "directCount": 1568,
+    "electiveCount": 0,
+    "totalCount": 1568
   },
   {
     "slug": "william-paterson",
     "name": "William Paterson University",
-    "mappingCount": 1493
+    "mappingCount": 1493,
+    "directCount": 1420,
+    "electiveCount": 0,
+    "totalCount": 1420
   }
 ]

--- a/data/nm/transfer-universities.json
+++ b/data/nm/transfer-universities.json
@@ -2,31 +2,49 @@
   {
     "slug": "enmu",
     "name": "Eastern New Mexico University",
-    "mappingCount": 1483
+    "mappingCount": 1483,
+    "directCount": 1483,
+    "electiveCount": 0,
+    "totalCount": 1483
   },
   {
     "slug": "nmhu",
     "name": "New Mexico Highlands University",
-    "mappingCount": 1049
+    "mappingCount": 1049,
+    "directCount": 1049,
+    "electiveCount": 0,
+    "totalCount": 1049
   },
   {
     "slug": "nmt",
     "name": "New Mexico Institute of Mining and Technology",
-    "mappingCount": 587
+    "mappingCount": 587,
+    "directCount": 587,
+    "electiveCount": 0,
+    "totalCount": 587
   },
   {
     "slug": "nmsu",
     "name": "New Mexico State University",
-    "mappingCount": 1846
+    "mappingCount": 1846,
+    "directCount": 1846,
+    "electiveCount": 0,
+    "totalCount": 1846
   },
   {
     "slug": "unm",
     "name": "University of New Mexico",
-    "mappingCount": 2166
+    "mappingCount": 2166,
+    "directCount": 2166,
+    "electiveCount": 0,
+    "totalCount": 2166
   },
   {
     "slug": "wnmu",
     "name": "Western New Mexico University",
-    "mappingCount": 1706
+    "mappingCount": 1706,
+    "directCount": 1706,
+    "electiveCount": 0,
+    "totalCount": 1706
   }
 ]

--- a/data/nv/transfer-universities.json
+++ b/data/nv/transfer-universities.json
@@ -2,26 +2,41 @@
   {
     "slug": "college-of-southern-nevada",
     "name": "College of Southern Nevada",
-    "mappingCount": 468
+    "mappingCount": 468,
+    "directCount": 468,
+    "electiveCount": 0,
+    "totalCount": 468
   },
   {
     "slug": "great-basin-college",
     "name": "Great Basin College",
-    "mappingCount": 322
+    "mappingCount": 322,
+    "directCount": 322,
+    "electiveCount": 0,
+    "totalCount": 322
   },
   {
     "slug": "nsu",
     "name": "Nevada State University",
-    "mappingCount": 6114
+    "mappingCount": 6112,
+    "directCount": 1510,
+    "electiveCount": 3012,
+    "totalCount": 4522
   },
   {
     "slug": "truckee-meadows-community-college",
     "name": "Truckee Meadows Community College",
-    "mappingCount": 497
+    "mappingCount": 497,
+    "directCount": 497,
+    "electiveCount": 0,
+    "totalCount": 497
   },
   {
     "slug": "western-nevada-college",
     "name": "Western Nevada College",
-    "mappingCount": 379
+    "mappingCount": 379,
+    "directCount": 379,
+    "electiveCount": 0,
+    "totalCount": 379
   }
 ]

--- a/data/ny/transfer-universities.json
+++ b/data/ny/transfer-universities.json
@@ -2,181 +2,289 @@
   {
     "slug": "suny-alfred-state",
     "name": "Alfred State",
-    "mappingCount": 9203
+    "mappingCount": 9203,
+    "directCount": 6464,
+    "electiveCount": 2739,
+    "totalCount": 9203
   },
   {
     "slug": "baruch",
     "name": "Baruch College",
-    "mappingCount": 3200
+    "mappingCount": 3200,
+    "directCount": 1465,
+    "electiveCount": 1028,
+    "totalCount": 2493
   },
   {
     "slug": "suny-binghamton",
     "name": "Binghamton University",
-    "mappingCount": 4452
+    "mappingCount": 4452,
+    "directCount": 2691,
+    "electiveCount": 1761,
+    "totalCount": 4452
   },
   {
     "slug": "brooklyn",
     "name": "Brooklyn College",
-    "mappingCount": 3364
+    "mappingCount": 3364,
+    "directCount": 2315,
+    "electiveCount": 1048,
+    "totalCount": 3363
   },
   {
     "slug": "suny-buffalo-state",
     "name": "Buffalo State University",
-    "mappingCount": 12920
+    "mappingCount": 12920,
+    "directCount": 5466,
+    "electiveCount": 7454,
+    "totalCount": 12920
   },
   {
     "slug": "ccny",
     "name": "City College of New York",
-    "mappingCount": 3296
+    "mappingCount": 3296,
+    "directCount": 1369,
+    "electiveCount": 1418,
+    "totalCount": 2787
   },
   {
     "slug": "csi",
     "name": "College of Staten Island",
-    "mappingCount": 3296
+    "mappingCount": 3296,
+    "directCount": 1515,
+    "electiveCount": 1703,
+    "totalCount": 3218
   },
   {
     "slug": "grad-center",
     "name": "CUNY Graduate Center",
-    "mappingCount": 2855
+    "mappingCount": 2855,
+    "directCount": 1281,
+    "electiveCount": 0,
+    "totalCount": 1281
   },
   {
     "slug": "cuny-slu",
     "name": "CUNY School of Labor & Urban Studies",
-    "mappingCount": 3305
+    "mappingCount": 3305,
+    "directCount": 444,
+    "electiveCount": 2861,
+    "totalCount": 3305
   },
   {
     "slug": "cuny-sps",
     "name": "CUNY School of Professional Studies",
-    "mappingCount": 3312
+    "mappingCount": 3312,
+    "directCount": 1118,
+    "electiveCount": 2194,
+    "totalCount": 3312
   },
   {
     "slug": "suny-farmingdale",
     "name": "Farmingdale State College",
-    "mappingCount": 4694
+    "mappingCount": 4694,
+    "directCount": 2442,
+    "electiveCount": 2252,
+    "totalCount": 4694
   },
   {
     "slug": "hunter",
     "name": "Hunter College",
-    "mappingCount": 3396
+    "mappingCount": 3396,
+    "directCount": 1608,
+    "electiveCount": 1674,
+    "totalCount": 3282
   },
   {
     "slug": "john-jay",
     "name": "John Jay College of Criminal Justice",
-    "mappingCount": 3292
+    "mappingCount": 3292,
+    "directCount": 1114,
+    "electiveCount": 2178,
+    "totalCount": 3292
   },
   {
     "slug": "lehman",
     "name": "Lehman College",
-    "mappingCount": 3277
+    "mappingCount": 3277,
+    "directCount": 1947,
+    "electiveCount": 1330,
+    "totalCount": 3277
   },
   {
     "slug": "medgar-evers",
     "name": "Medgar Evers College",
-    "mappingCount": 3302
+    "mappingCount": 3302,
+    "directCount": 947,
+    "electiveCount": 470,
+    "totalCount": 1417
   },
   {
     "slug": "city-tech",
     "name": "NYC College of Technology",
-    "mappingCount": 3255
+    "mappingCount": 3255,
+    "directCount": 1241,
+    "electiveCount": 1887,
+    "totalCount": 3128
   },
   {
     "slug": "suny-purchase",
     "name": "Purchase College",
-    "mappingCount": 7460
+    "mappingCount": 7460,
+    "directCount": 2007,
+    "electiveCount": 5453,
+    "totalCount": 7460
   },
   {
     "slug": "queens",
     "name": "Queens College",
-    "mappingCount": 3461
+    "mappingCount": 3461,
+    "directCount": 1297,
+    "electiveCount": 2164,
+    "totalCount": 3461
   },
   {
     "slug": "suny-brockport",
     "name": "SUNY Brockport",
-    "mappingCount": 14026
+    "mappingCount": 14026,
+    "directCount": 14022,
+    "electiveCount": 4,
+    "totalCount": 14026
   },
   {
     "slug": "suny-canton",
     "name": "SUNY Canton",
-    "mappingCount": 5208
+    "mappingCount": 5208,
+    "directCount": 3195,
+    "electiveCount": 2013,
+    "totalCount": 5208
   },
   {
     "slug": "suny-cobleskill",
     "name": "SUNY Cobleskill",
-    "mappingCount": 10617
+    "mappingCount": 10617,
+    "directCount": 3639,
+    "electiveCount": 6978,
+    "totalCount": 10617
   },
   {
     "slug": "suny-cortland",
     "name": "SUNY Cortland",
-    "mappingCount": 16038
+    "mappingCount": 16038,
+    "directCount": 6449,
+    "electiveCount": 9561,
+    "totalCount": 16010
   },
   {
     "slug": "suny-delhi",
     "name": "SUNY Delhi",
-    "mappingCount": 1020
+    "mappingCount": 1020,
+    "directCount": 1020,
+    "electiveCount": 0,
+    "totalCount": 1020
   },
   {
     "slug": "suny-empire-state",
     "name": "SUNY Empire State",
-    "mappingCount": 19312
+    "mappingCount": 19312,
+    "directCount": 2927,
+    "electiveCount": 16383,
+    "totalCount": 19310
   },
   {
     "slug": "suny-fredonia",
     "name": "SUNY Fredonia",
-    "mappingCount": 11404
+    "mappingCount": 11404,
+    "directCount": 9720,
+    "electiveCount": 1555,
+    "totalCount": 11275
   },
   {
     "slug": "suny-geneseo",
     "name": "SUNY Geneseo",
-    "mappingCount": 8921
+    "mappingCount": 8921,
+    "directCount": 8919,
+    "electiveCount": 2,
+    "totalCount": 8921
   },
   {
     "slug": "suny-morrisville",
     "name": "SUNY Morrisville",
-    "mappingCount": 7836
+    "mappingCount": 7836,
+    "directCount": 2654,
+    "electiveCount": 5182,
+    "totalCount": 7836
   },
   {
     "slug": "suny-new-paltz",
     "name": "SUNY New Paltz",
-    "mappingCount": 11233
+    "mappingCount": 11233,
+    "directCount": 11211,
+    "electiveCount": 22,
+    "totalCount": 11233
   },
   {
     "slug": "suny-old-westbury",
     "name": "SUNY Old Westbury",
-    "mappingCount": 4958
+    "mappingCount": 4958,
+    "directCount": 4388,
+    "electiveCount": 570,
+    "totalCount": 4958
   },
   {
     "slug": "suny-oneonta",
     "name": "SUNY Oneonta",
-    "mappingCount": 14400
+    "mappingCount": 14400,
+    "directCount": 5375,
+    "electiveCount": 9025,
+    "totalCount": 14400
   },
   {
     "slug": "suny-oswego",
     "name": "SUNY Oswego",
-    "mappingCount": 10121
+    "mappingCount": 10121,
+    "directCount": 5416,
+    "electiveCount": 4705,
+    "totalCount": 10121
   },
   {
     "slug": "suny-plattsburgh",
     "name": "SUNY Plattsburgh",
-    "mappingCount": 11737
+    "mappingCount": 11737,
+    "directCount": 4151,
+    "electiveCount": 7586,
+    "totalCount": 11737
   },
   {
     "slug": "suny-polytechnic",
     "name": "SUNY Polytechnic Institute",
-    "mappingCount": 6640
+    "mappingCount": 6640,
+    "directCount": 3793,
+    "electiveCount": 2847,
+    "totalCount": 6640
   },
   {
     "slug": "suny-potsdam",
     "name": "SUNY Potsdam",
-    "mappingCount": 15186
+    "mappingCount": 15186,
+    "directCount": 10285,
+    "electiveCount": 4833,
+    "totalCount": 15118
   },
   {
     "slug": "suny-buffalo",
     "name": "University at Buffalo",
-    "mappingCount": 1348
+    "mappingCount": 1348,
+    "directCount": 1024,
+    "electiveCount": 324,
+    "totalCount": 1348
   },
   {
     "slug": "york",
     "name": "York College",
-    "mappingCount": 3103
+    "mappingCount": 3103,
+    "directCount": 1211,
+    "electiveCount": 1143,
+    "totalCount": 2354
   }
 ]

--- a/data/oh/transfer-universities.json
+++ b/data/oh/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "osu",
     "name": "The Ohio State University",
-    "mappingCount": 5348
+    "mappingCount": 5348,
+    "directCount": 2820,
+    "electiveCount": 2528,
+    "totalCount": 5348
   }
 ]

--- a/data/ok/transfer-universities.json
+++ b/data/ok/transfer-universities.json
@@ -2,186 +2,297 @@
   {
     "slug": "bacone-college",
     "name": "Bacone College",
-    "mappingCount": 363
+    "mappingCount": 363,
+    "directCount": 363,
+    "electiveCount": 0,
+    "totalCount": 363
   },
   {
     "slug": "cameron-university",
     "name": "Cameron University",
-    "mappingCount": 1643
+    "mappingCount": 1643,
+    "directCount": 1643,
+    "electiveCount": 0,
+    "totalCount": 1643
   },
   {
     "slug": "carl-albert-state-college",
     "name": "Carl Albert State College",
-    "mappingCount": 1712
+    "mappingCount": 1712,
+    "directCount": 1712,
+    "electiveCount": 0,
+    "totalCount": 1712
   },
   {
     "slug": "connors-state-college",
     "name": "Connors State College",
-    "mappingCount": 1410
+    "mappingCount": 1410,
+    "directCount": 1410,
+    "electiveCount": 0,
+    "totalCount": 1410
   },
   {
     "slug": "east-central-university",
     "name": "East Central University",
-    "mappingCount": 1425
+    "mappingCount": 1425,
+    "directCount": 1425,
+    "electiveCount": 0,
+    "totalCount": 1425
   },
   {
     "slug": "eastern-oklahoma-state-college",
     "name": "Eastern Oklahoma State College",
-    "mappingCount": 1512
+    "mappingCount": 1512,
+    "directCount": 1512,
+    "electiveCount": 0,
+    "totalCount": 1512
   },
   {
     "slug": "langston-university",
     "name": "Langston University",
-    "mappingCount": 1115
+    "mappingCount": 1115,
+    "directCount": 1115,
+    "electiveCount": 0,
+    "totalCount": 1115
   },
   {
     "slug": "mid-america-christian-university",
     "name": "Mid-America Christian University",
-    "mappingCount": 987
+    "mappingCount": 987,
+    "directCount": 987,
+    "electiveCount": 0,
+    "totalCount": 987
   },
   {
     "slug": "murray-state-college",
     "name": "Murray State College",
-    "mappingCount": 1402
+    "mappingCount": 1402,
+    "directCount": 1402,
+    "electiveCount": 0,
+    "totalCount": 1402
   },
   {
     "slug": "northeastern-oklahoma-aandm-college",
     "name": "Northeastern Oklahoma A&M College",
-    "mappingCount": 1591
+    "mappingCount": 1591,
+    "directCount": 1591,
+    "electiveCount": 0,
+    "totalCount": 1591
   },
   {
     "slug": "northeastern-state-university",
     "name": "Northeastern State University",
-    "mappingCount": 2442
+    "mappingCount": 2442,
+    "directCount": 2442,
+    "electiveCount": 0,
+    "totalCount": 2442
   },
   {
     "slug": "northern-oklahoma-college",
     "name": "Northern Oklahoma College",
-    "mappingCount": 1799
+    "mappingCount": 1799,
+    "directCount": 1799,
+    "electiveCount": 0,
+    "totalCount": 1799
   },
   {
     "slug": "northwestern-oklahoma-state-university",
     "name": "Northwestern Oklahoma State University",
-    "mappingCount": 2680
+    "mappingCount": 2680,
+    "directCount": 2680,
+    "electiveCount": 0,
+    "totalCount": 2680
   },
   {
     "slug": "oklahoma-baptist-university",
     "name": "Oklahoma Baptist University",
-    "mappingCount": 1051
+    "mappingCount": 1051,
+    "directCount": 1051,
+    "electiveCount": 0,
+    "totalCount": 1051
   },
   {
     "slug": "oklahoma-christian-university",
     "name": "Oklahoma Christian University",
-    "mappingCount": 956
+    "mappingCount": 956,
+    "directCount": 956,
+    "electiveCount": 0,
+    "totalCount": 956
   },
   {
     "slug": "oklahoma-city-community-college",
     "name": "Oklahoma City Community College",
-    "mappingCount": 1539
+    "mappingCount": 1539,
+    "directCount": 1539,
+    "electiveCount": 0,
+    "totalCount": 1539
   },
   {
     "slug": "oklahoma-city-university",
     "name": "Oklahoma City University",
-    "mappingCount": 1107
+    "mappingCount": 1107,
+    "directCount": 1107,
+    "electiveCount": 0,
+    "totalCount": 1107
   },
   {
     "slug": "oklahoma-panhandle-state-university",
     "name": "Oklahoma Panhandle State University",
-    "mappingCount": 1684
+    "mappingCount": 1684,
+    "directCount": 1684,
+    "electiveCount": 0,
+    "totalCount": 1684
   },
   {
     "slug": "oklahoma-state-university",
     "name": "Oklahoma State University",
-    "mappingCount": 1447
+    "mappingCount": 1447,
+    "directCount": 1447,
+    "electiveCount": 0,
+    "totalCount": 1447
   },
   {
     "slug": "oklahoma-state-university-institute-technology-okmulgee",
     "name": "Oklahoma State University Institute Technology-Okmulgee",
-    "mappingCount": 881
+    "mappingCount": 881,
+    "directCount": 881,
+    "electiveCount": 0,
+    "totalCount": 881
   },
   {
     "slug": "oklahoma-state-university-oklahoma-city",
     "name": "Oklahoma State University-Oklahoma City",
-    "mappingCount": 1160
+    "mappingCount": 1160,
+    "directCount": 1160,
+    "electiveCount": 0,
+    "totalCount": 1160
   },
   {
     "slug": "oklahoma-wesleyan-university",
     "name": "Oklahoma Wesleyan University",
-    "mappingCount": 10
+    "mappingCount": 10,
+    "directCount": 10,
+    "electiveCount": 0,
+    "totalCount": 10
   },
   {
     "slug": "oral-roberts-university",
     "name": "Oral Roberts University",
-    "mappingCount": 1360
+    "mappingCount": 1360,
+    "directCount": 1360,
+    "electiveCount": 0,
+    "totalCount": 1360
   },
   {
     "slug": "redlands-community-college",
     "name": "Redlands Community College",
-    "mappingCount": 1327
+    "mappingCount": 1327,
+    "directCount": 1327,
+    "electiveCount": 0,
+    "totalCount": 1327
   },
   {
     "slug": "rogers-state-university",
     "name": "Rogers State University",
-    "mappingCount": 1447
+    "mappingCount": 1447,
+    "directCount": 1447,
+    "electiveCount": 0,
+    "totalCount": 1447
   },
   {
     "slug": "rose-state-college",
     "name": "Rose State College",
-    "mappingCount": 1634
+    "mappingCount": 1634,
+    "directCount": 1634,
+    "electiveCount": 0,
+    "totalCount": 1634
   },
   {
     "slug": "seminole-state-college",
     "name": "Seminole State College",
-    "mappingCount": 1285
+    "mappingCount": 1285,
+    "directCount": 1285,
+    "electiveCount": 0,
+    "totalCount": 1285
   },
   {
     "slug": "southeastern-oklahoma-state-university",
     "name": "Southeastern Oklahoma State University",
-    "mappingCount": 1967
+    "mappingCount": 1967,
+    "directCount": 1967,
+    "electiveCount": 0,
+    "totalCount": 1967
   },
   {
     "slug": "southern-nazarene-university",
     "name": "Southern Nazarene University",
-    "mappingCount": 716
+    "mappingCount": 716,
+    "directCount": 716,
+    "electiveCount": 0,
+    "totalCount": 716
   },
   {
     "slug": "southwestern-christian-university",
     "name": "Southwestern Christian University",
-    "mappingCount": 303
+    "mappingCount": 303,
+    "directCount": 303,
+    "electiveCount": 0,
+    "totalCount": 303
   },
   {
     "slug": "southwestern-oklahoma-state-university",
     "name": "Southwestern Oklahoma State University",
-    "mappingCount": 2078
+    "mappingCount": 2078,
+    "directCount": 2078,
+    "electiveCount": 0,
+    "totalCount": 2078
   },
   {
     "slug": "the-university-of-tulsa",
     "name": "The University of Tulsa",
-    "mappingCount": 436
+    "mappingCount": 436,
+    "directCount": 436,
+    "electiveCount": 0,
+    "totalCount": 436
   },
   {
     "slug": "tulsa-community-college",
     "name": "Tulsa Community College",
-    "mappingCount": 2237
+    "mappingCount": 2237,
+    "directCount": 2237,
+    "electiveCount": 0,
+    "totalCount": 2237
   },
   {
     "slug": "university-of-central-oklahoma",
     "name": "University of Central Oklahoma",
-    "mappingCount": 1751
+    "mappingCount": 1751,
+    "directCount": 1751,
+    "electiveCount": 0,
+    "totalCount": 1751
   },
   {
     "slug": "university-of-oklahoma",
     "name": "University of Oklahoma",
-    "mappingCount": 1124
+    "mappingCount": 1124,
+    "directCount": 1124,
+    "electiveCount": 0,
+    "totalCount": 1124
   },
   {
     "slug": "university-of-science-and-arts-of-oklahoma",
     "name": "University of Science & Arts of Oklahoma",
-    "mappingCount": 1718
+    "mappingCount": 1718,
+    "directCount": 1718,
+    "electiveCount": 0,
+    "totalCount": 1718
   },
   {
     "slug": "western-oklahoma-state-college",
     "name": "Western Oklahoma State College",
-    "mappingCount": 998
+    "mappingCount": 998,
+    "directCount": 998,
+    "electiveCount": 0,
+    "totalCount": 998
   }
 ]

--- a/data/or/transfer-universities.json
+++ b/data/or/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "oregon-state",
     "name": "Oregon State University",
-    "mappingCount": 11479
+    "mappingCount": 11479,
+    "directCount": 1752,
+    "electiveCount": 9726,
+    "totalCount": 11478
   }
 ]

--- a/data/pa/transfer-universities.json
+++ b/data/pa/transfer-universities.json
@@ -2,36 +2,57 @@
   {
     "slug": "commonwealth",
     "name": "Commonwealth University of Pennsylvania",
-    "mappingCount": 5353
+    "mappingCount": 5353,
+    "directCount": 5263,
+    "electiveCount": 90,
+    "totalCount": 5353
   },
   {
     "slug": "kutztown",
     "name": "Kutztown University",
-    "mappingCount": 12631
+    "mappingCount": 12631,
+    "directCount": 7443,
+    "electiveCount": 5188,
+    "totalCount": 12631
   },
   {
     "slug": "millersville",
     "name": "Millersville University",
-    "mappingCount": 10534
+    "mappingCount": 10534,
+    "directCount": 7878,
+    "electiveCount": 2656,
+    "totalCount": 10534
   },
   {
     "slug": "penn-state",
     "name": "Penn State University",
-    "mappingCount": 1298
+    "mappingCount": 1298,
+    "directCount": 1298,
+    "electiveCount": 0,
+    "totalCount": 1298
   },
   {
     "slug": "slippery-rock",
     "name": "Slippery Rock University",
-    "mappingCount": 14760
+    "mappingCount": 14760,
+    "directCount": 4338,
+    "electiveCount": 10422,
+    "totalCount": 14760
   },
   {
     "slug": "pitt",
     "name": "University of Pittsburgh",
-    "mappingCount": 3295
+    "mappingCount": 3942,
+    "directCount": 3942,
+    "electiveCount": 0,
+    "totalCount": 3942
   },
   {
     "slug": "west-chester",
     "name": "West Chester University",
-    "mappingCount": 6658
+    "mappingCount": 6658,
+    "directCount": 5616,
+    "electiveCount": 1042,
+    "totalCount": 6658
   }
 ]

--- a/data/ri/transfer-universities.json
+++ b/data/ri/transfer-universities.json
@@ -2,16 +2,25 @@
   {
     "slug": "jwu",
     "name": "Johnson & Wales University",
-    "mappingCount": 591
+    "mappingCount": 590,
+    "directCount": 294,
+    "electiveCount": 296,
+    "totalCount": 590
   },
   {
     "slug": "ric",
     "name": "Rhode Island College",
-    "mappingCount": 691
+    "mappingCount": 840,
+    "directCount": 287,
+    "electiveCount": 552,
+    "totalCount": 839
   },
   {
     "slug": "uri",
     "name": "University of Rhode Island",
-    "mappingCount": 795
+    "mappingCount": 795,
+    "directCount": 407,
+    "electiveCount": 367,
+    "totalCount": 774
   }
 ]

--- a/data/sc/transfer-universities.json
+++ b/data/sc/transfer-universities.json
@@ -2,21 +2,33 @@
   {
     "slug": "clemson",
     "name": "Clemson University",
-    "mappingCount": 855
+    "mappingCount": 858,
+    "directCount": 292,
+    "electiveCount": 566,
+    "totalCount": 858
   },
   {
     "slug": "cofc",
     "name": "College of Charleston",
-    "mappingCount": 2459
+    "mappingCount": 2482,
+    "directCount": 1485,
+    "electiveCount": 997,
+    "totalCount": 2482
   },
   {
     "slug": "usc",
     "name": "University of South Carolina",
-    "mappingCount": 2693
+    "mappingCount": 2695,
+    "directCount": 2694,
+    "electiveCount": 1,
+    "totalCount": 2695
   },
   {
     "slug": "usc-upstate",
     "name": "USC Upstate",
-    "mappingCount": 3456
+    "mappingCount": 3456,
+    "directCount": 3456,
+    "electiveCount": 0,
+    "totalCount": 3456
   }
 ]

--- a/data/sd/transfer-universities.json
+++ b/data/sd/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "usd",
     "name": "University of South Dakota",
-    "mappingCount": 255
+    "mappingCount": 255,
+    "directCount": 147,
+    "electiveCount": 108,
+    "totalCount": 255
   }
 ]

--- a/data/tn/transfer-universities.json
+++ b/data/tn/transfer-universities.json
@@ -2,26 +2,41 @@
   {
     "slug": "apsu",
     "name": "Austin Peay State University",
-    "mappingCount": 15934
+    "mappingCount": 15941,
+    "directCount": 3246,
+    "electiveCount": 12695,
+    "totalCount": 15941
   },
   {
     "slug": "mtsu",
     "name": "Middle Tennessee State University",
-    "mappingCount": 21578
+    "mappingCount": 21581,
+    "directCount": 17924,
+    "electiveCount": 3657,
+    "totalCount": 21581
   },
   {
     "slug": "ttu",
     "name": "Tennessee Technological University",
-    "mappingCount": 4602
+    "mappingCount": 4602,
+    "directCount": 2648,
+    "electiveCount": 446,
+    "totalCount": 3094
   },
   {
     "slug": "utm",
     "name": "University of Tennessee at Martin",
-    "mappingCount": 10059
+    "mappingCount": 10059,
+    "directCount": 3256,
+    "electiveCount": 5956,
+    "totalCount": 9212
   },
   {
     "slug": "utk",
     "name": "University of Tennessee Knoxville",
-    "mappingCount": 10786
+    "mappingCount": 10786,
+    "directCount": 7196,
+    "electiveCount": 3589,
+    "totalCount": 10785
   }
 ]

--- a/data/tx/transfer-universities.json
+++ b/data/tx/transfer-universities.json
@@ -2,216 +2,345 @@
   {
     "slug": "abilene-christian-university",
     "name": "Abilene Christian University",
-    "mappingCount": 3054
+    "mappingCount": 3162,
+    "directCount": 3162,
+    "electiveCount": 0,
+    "totalCount": 3162
   },
   {
     "slug": "angelo-state-university",
     "name": "Angelo State University",
-    "mappingCount": 3340
+    "mappingCount": 3464,
+    "directCount": 3464,
+    "electiveCount": 0,
+    "totalCount": 3464
   },
   {
     "slug": "baylor-university",
     "name": "Baylor University",
-    "mappingCount": 2007
+    "mappingCount": 2079,
+    "directCount": 2079,
+    "electiveCount": 0,
+    "totalCount": 2079
   },
   {
     "slug": "dallas-baptist-university",
     "name": "Dallas Baptist University",
-    "mappingCount": 1820
+    "mappingCount": 1881,
+    "directCount": 1881,
+    "electiveCount": 0,
+    "totalCount": 1881
   },
   {
     "slug": "east-texas-a-m-university-commerce",
     "name": "East Texas A&M University (Commerce)",
-    "mappingCount": 6537
+    "mappingCount": 6769,
+    "directCount": 6769,
+    "electiveCount": 0,
+    "totalCount": 6769
   },
   {
     "slug": "howard-payne-university",
     "name": "Howard Payne University",
-    "mappingCount": 2094
+    "mappingCount": 2156,
+    "directCount": 2156,
+    "electiveCount": 0,
+    "totalCount": 2156
   },
   {
     "slug": "lamar-university",
     "name": "Lamar University",
-    "mappingCount": 2328
+    "mappingCount": 2403,
+    "directCount": 2403,
+    "electiveCount": 0,
+    "totalCount": 2403
   },
   {
     "slug": "letourneau-university",
     "name": "LeTourneau University",
-    "mappingCount": 1834
+    "mappingCount": 1910,
+    "directCount": 1910,
+    "electiveCount": 0,
+    "totalCount": 1910
   },
   {
     "slug": "mcmurry-university",
     "name": "McMurry University",
-    "mappingCount": 3730
+    "mappingCount": 3878,
+    "directCount": 3878,
+    "electiveCount": 0,
+    "totalCount": 3878
   },
   {
     "slug": "midwestern-state-university",
     "name": "Midwestern State University",
-    "mappingCount": 2819
+    "mappingCount": 2914,
+    "directCount": 2914,
+    "electiveCount": 0,
+    "totalCount": 2914
   },
   {
     "slug": "nelson-university",
     "name": "Nelson University",
-    "mappingCount": 1137
+    "mappingCount": 1185,
+    "directCount": 1185,
+    "electiveCount": 0,
+    "totalCount": 1185
   },
   {
     "slug": "our-lady-of-the-lake-university",
     "name": "Our Lady of the Lake University",
-    "mappingCount": 3005
+    "mappingCount": 3100,
+    "directCount": 3100,
+    "electiveCount": 0,
+    "totalCount": 3100
   },
   {
     "slug": "prairie-view-a-m-university",
     "name": "Prairie View A&M University",
-    "mappingCount": 6552
+    "mappingCount": 6784,
+    "directCount": 6784,
+    "electiveCount": 0,
+    "totalCount": 6784
   },
   {
     "slug": "sam-houston-state-university",
     "name": "Sam Houston State University",
-    "mappingCount": 6447
+    "mappingCount": 6679,
+    "directCount": 6679,
+    "electiveCount": 0,
+    "totalCount": 6679
   },
   {
     "slug": "schreiner-university",
     "name": "Schreiner University",
-    "mappingCount": 1984
+    "mappingCount": 2056,
+    "directCount": 2056,
+    "electiveCount": 0,
+    "totalCount": 2056
   },
   {
     "slug": "southwestern-adventist-university",
     "name": "Southwestern Adventist University",
-    "mappingCount": 2255
+    "mappingCount": 2319,
+    "directCount": 2319,
+    "electiveCount": 0,
+    "totalCount": 2319
   },
   {
     "slug": "southwestern-university",
     "name": "Southwestern University",
-    "mappingCount": 4570
+    "mappingCount": 4739,
+    "directCount": 4739,
+    "electiveCount": 0,
+    "totalCount": 4739
   },
   {
     "slug": "st-mary-s-university",
     "name": "St. Mary's University",
-    "mappingCount": 5929
+    "mappingCount": 6156,
+    "directCount": 6156,
+    "electiveCount": 0,
+    "totalCount": 6156
   },
   {
     "slug": "stephen-f-austin-state-university",
     "name": "Stephen F. Austin State University",
-    "mappingCount": 2913
+    "mappingCount": 3038,
+    "directCount": 3038,
+    "electiveCount": 0,
+    "totalCount": 3038
   },
   {
     "slug": "tarleton-state-university",
     "name": "Tarleton State University",
-    "mappingCount": 6420
+    "mappingCount": 6652,
+    "directCount": 6652,
+    "electiveCount": 0,
+    "totalCount": 6652
   },
   {
     "slug": "texas-a-m-international-university",
     "name": "Texas A&M International University",
-    "mappingCount": 6443
+    "mappingCount": 6675,
+    "directCount": 6675,
+    "electiveCount": 0,
+    "totalCount": 6675
   },
   {
     "slug": "texas-a-m-university",
     "name": "Texas A&M University",
-    "mappingCount": 6343
+    "mappingCount": 6575,
+    "directCount": 3139,
+    "electiveCount": 3436,
+    "totalCount": 6575
   },
   {
     "slug": "texas-a-m-university-central-texas",
     "name": "Texas A&M University-Central Texas",
-    "mappingCount": 6552
+    "mappingCount": 6784,
+    "directCount": 6784,
+    "electiveCount": 0,
+    "totalCount": 6784
   },
   {
     "slug": "texas-a-m-university-corpus-christi",
     "name": "Texas A&M University-Corpus Christi",
-    "mappingCount": 6546
+    "mappingCount": 6778,
+    "directCount": 6714,
+    "electiveCount": 64,
+    "totalCount": 6778
   },
   {
     "slug": "texas-a-m-university-galveston",
     "name": "Texas A&M University-Galveston",
-    "mappingCount": 6343
+    "mappingCount": 6575,
+    "directCount": 3139,
+    "electiveCount": 3436,
+    "totalCount": 6575
   },
   {
     "slug": "texas-a-m-university-kingsville",
     "name": "Texas A&M University-Kingsville",
-    "mappingCount": 6547
+    "mappingCount": 6779,
+    "directCount": 6779,
+    "electiveCount": 0,
+    "totalCount": 6779
   },
   {
     "slug": "texas-a-m-university-san-antonio",
     "name": "Texas A&M University-San Antonio",
-    "mappingCount": 6549
+    "mappingCount": 6781,
+    "directCount": 6781,
+    "electiveCount": 0,
+    "totalCount": 6781
   },
   {
     "slug": "texas-a-m-university-texarkana",
     "name": "Texas A&M University-Texarkana",
-    "mappingCount": 6546
+    "mappingCount": 6778,
+    "directCount": 6778,
+    "electiveCount": 0,
+    "totalCount": 6778
   },
   {
     "slug": "texas-a-m-university-victoria-formerly-university-of-houston-victoria",
     "name": "Texas A&M University-Victoria (formerly University of Houston-Victoria)",
-    "mappingCount": 6381
+    "mappingCount": 6613,
+    "directCount": 2701,
+    "electiveCount": 3912,
+    "totalCount": 6613
   },
   {
     "slug": "texas-christian-university",
     "name": "Texas Christian University",
-    "mappingCount": 5832
+    "mappingCount": 6050,
+    "directCount": 6050,
+    "electiveCount": 0,
+    "totalCount": 6050
   },
   {
     "slug": "texas-southern-university",
     "name": "Texas Southern University",
-    "mappingCount": 4214
+    "mappingCount": 4381,
+    "directCount": 4381,
+    "electiveCount": 0,
+    "totalCount": 4381
   },
   {
     "slug": "texas-state-university",
     "name": "Texas State University",
-    "mappingCount": 6298
+    "mappingCount": 6687,
+    "directCount": 4070,
+    "electiveCount": 2617,
+    "totalCount": 6687
   },
   {
     "slug": "texas-tech-university",
     "name": "Texas Tech University",
-    "mappingCount": 6478
+    "mappingCount": 6710,
+    "directCount": 4343,
+    "electiveCount": 2367,
+    "totalCount": 6710
   },
   {
     "slug": "texas-woman-s-university",
     "name": "Texas Woman's University",
-    "mappingCount": 2829
+    "mappingCount": 2951,
+    "directCount": 2951,
+    "electiveCount": 0,
+    "totalCount": 2951
   },
   {
     "slug": "university-of-houston",
     "name": "University of Houston",
-    "mappingCount": 3242
+    "mappingCount": 3370,
+    "directCount": 3370,
+    "electiveCount": 0,
+    "totalCount": 3370
   },
   {
     "slug": "university-of-north-texas",
     "name": "University of North Texas",
-    "mappingCount": 3433
+    "mappingCount": 3554,
+    "directCount": 3554,
+    "electiveCount": 0,
+    "totalCount": 3554
   },
   {
     "slug": "university-of-north-texas-at-dallas",
     "name": "University of North Texas at Dallas",
-    "mappingCount": 1599
+    "mappingCount": 1665,
+    "directCount": 1665,
+    "electiveCount": 0,
+    "totalCount": 1665
   },
   {
     "slug": "university-of-st-thomas",
     "name": "University of St. Thomas",
-    "mappingCount": 3113
+    "mappingCount": 3225,
+    "directCount": 3225,
+    "electiveCount": 0,
+    "totalCount": 3225
   },
   {
     "slug": "university-of-texas-rio-grande-valley",
     "name": "University of Texas - Rio Grande Valley",
-    "mappingCount": 6422
+    "mappingCount": 6654,
+    "directCount": 6654,
+    "electiveCount": 0,
+    "totalCount": 6654
   },
   {
     "slug": "university-of-texas-at-arlington",
     "name": "University of Texas at Arlington",
-    "mappingCount": 3098
+    "mappingCount": 3193,
+    "directCount": 3193,
+    "electiveCount": 0,
+    "totalCount": 3193
   },
   {
     "slug": "university-of-texas-at-dallas",
     "name": "University of Texas at Dallas",
-    "mappingCount": 2139
+    "mappingCount": 2221,
+    "directCount": 2221,
+    "electiveCount": 0,
+    "totalCount": 2221
   },
   {
     "slug": "university-of-texas-at-san-antonio",
     "name": "University of Texas at San Antonio",
-    "mappingCount": 3251
+    "mappingCount": 3382,
+    "directCount": 3382,
+    "electiveCount": 0,
+    "totalCount": 3382
   },
   {
     "slug": "west-texas-a-m-university",
     "name": "West Texas A&M University",
-    "mappingCount": 6521
+    "mappingCount": 6753,
+    "directCount": 6753,
+    "electiveCount": 0,
+    "totalCount": 6753
   }
 ]

--- a/data/ut/transfer-universities.json
+++ b/data/ut/transfer-universities.json
@@ -2,31 +2,49 @@
   {
     "slug": "southern-utah-university",
     "name": "Southern Utah University",
-    "mappingCount": 2597
+    "mappingCount": 2597,
+    "directCount": 567,
+    "electiveCount": 2030,
+    "totalCount": 2597
   },
   {
     "slug": "university-of-utah",
     "name": "University of Utah",
-    "mappingCount": 1750
+    "mappingCount": 1750,
+    "directCount": 637,
+    "electiveCount": 1113,
+    "totalCount": 1750
   },
   {
     "slug": "utah-state-university",
     "name": "Utah State University",
-    "mappingCount": 3776
+    "mappingCount": 3776,
+    "directCount": 3776,
+    "electiveCount": 0,
+    "totalCount": 3776
   },
   {
     "slug": "utah-tech-university",
     "name": "Utah Tech University",
-    "mappingCount": 3245
+    "mappingCount": 3245,
+    "directCount": 3245,
+    "electiveCount": 0,
+    "totalCount": 3245
   },
   {
     "slug": "utah-valley-university",
     "name": "Utah Valley University",
-    "mappingCount": 6170
+    "mappingCount": 6170,
+    "directCount": 6170,
+    "electiveCount": 0,
+    "totalCount": 6170
   },
   {
     "slug": "weber-state-university",
     "name": "Weber State University",
-    "mappingCount": 5189
+    "mappingCount": 5189,
+    "directCount": 5189,
+    "electiveCount": 0,
+    "totalCount": 5189
   }
 ]

--- a/data/va/transfer-universities.json
+++ b/data/va/transfer-universities.json
@@ -2,41 +2,65 @@
   {
     "slug": "gmu",
     "name": "George Mason University",
-    "mappingCount": 2587
+    "mappingCount": 2587,
+    "directCount": 655,
+    "electiveCount": 1480,
+    "totalCount": 2135
   },
   {
     "slug": "odu",
     "name": "Old Dominion University",
-    "mappingCount": 5616
+    "mappingCount": 5617,
+    "directCount": 831,
+    "electiveCount": 4319,
+    "totalCount": 5150
   },
   {
     "slug": "umw",
     "name": "University of Mary Washington",
-    "mappingCount": 1183
+    "mappingCount": 1183,
+    "directCount": 244,
+    "electiveCount": 634,
+    "totalCount": 878
   },
   {
     "slug": "uva",
     "name": "University of Virginia",
-    "mappingCount": 1462
+    "mappingCount": 1464,
+    "directCount": 336,
+    "electiveCount": 712,
+    "totalCount": 1048
   },
   {
     "slug": "vcu",
     "name": "Virginia Commonwealth University",
-    "mappingCount": 2084
+    "mappingCount": 2103,
+    "directCount": 557,
+    "electiveCount": 1546,
+    "totalCount": 2103
   },
   {
     "slug": "vsu",
     "name": "Virginia State University",
-    "mappingCount": 745
+    "mappingCount": 745,
+    "directCount": 530,
+    "electiveCount": 215,
+    "totalCount": 745
   },
   {
     "slug": "vt",
     "name": "Virginia Tech",
-    "mappingCount": 1412
+    "mappingCount": 1412,
+    "directCount": 364,
+    "electiveCount": 999,
+    "totalCount": 1363
   },
   {
     "slug": "vwu",
     "name": "Virginia Wesleyan University",
-    "mappingCount": 394
+    "mappingCount": 394,
+    "directCount": 142,
+    "electiveCount": 252,
+    "totalCount": 394
   }
 ]

--- a/data/vt/transfer-universities.json
+++ b/data/vt/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "uvm",
     "name": "University of Vermont",
-    "mappingCount": 346
+    "mappingCount": 346,
+    "directCount": 134,
+    "electiveCount": 212,
+    "totalCount": 346
   }
 ]

--- a/data/wa/transfer-universities.json
+++ b/data/wa/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "university-of-washington",
     "name": "University of Washington",
-    "mappingCount": 37902
+    "mappingCount": 37906,
+    "directCount": 37475,
+    "electiveCount": 7,
+    "totalCount": 37482
   }
 ]

--- a/data/wi/transfer-universities.json
+++ b/data/wi/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "uw-milwaukee",
     "name": "University of Wisconsin-Milwaukee",
-    "mappingCount": 7555
+    "mappingCount": 7562,
+    "directCount": 2849,
+    "electiveCount": 3894,
+    "totalCount": 6743
   }
 ]

--- a/data/wv/transfer-universities.json
+++ b/data/wv/transfer-universities.json
@@ -2,6 +2,9 @@
   {
     "slug": "marshall",
     "name": "Marshall University",
-    "mappingCount": 1604
+    "mappingCount": 1604,
+    "directCount": 458,
+    "electiveCount": 1146,
+    "totalCount": 1604
   }
 ]

--- a/data/wy/transfer-universities.json
+++ b/data/wy/transfer-universities.json
@@ -2,41 +2,65 @@
   {
     "slug": "casper-college",
     "name": "Casper College",
-    "mappingCount": 967
+    "mappingCount": 967,
+    "directCount": 940,
+    "electiveCount": 27,
+    "totalCount": 967
   },
   {
     "slug": "central-wyoming-college",
     "name": "Central Wyoming College",
-    "mappingCount": 2388
+    "mappingCount": 2388,
+    "directCount": 2360,
+    "electiveCount": 28,
+    "totalCount": 2388
   },
   {
     "slug": "eastern-wyoming-college",
     "name": "Eastern Wyoming College",
-    "mappingCount": 1854
+    "mappingCount": 1854,
+    "directCount": 1854,
+    "electiveCount": 0,
+    "totalCount": 1854
   },
   {
     "slug": "laramie-county-community-college",
     "name": "Laramie County Community College",
-    "mappingCount": 67
+    "mappingCount": 67,
+    "directCount": 46,
+    "electiveCount": 21,
+    "totalCount": 67
   },
   {
     "slug": "northern-wyoming-community-college-district",
     "name": "Northern Wyoming Community College District",
-    "mappingCount": 1205
+    "mappingCount": 1205,
+    "directCount": 1164,
+    "electiveCount": 41,
+    "totalCount": 1205
   },
   {
     "slug": "northwest-college",
     "name": "Northwest College",
-    "mappingCount": 42
+    "mappingCount": 42,
+    "directCount": 42,
+    "electiveCount": 0,
+    "totalCount": 42
   },
   {
     "slug": "university-of-wyoming",
     "name": "University of Wyoming",
-    "mappingCount": 8854
+    "mappingCount": 8854,
+    "directCount": 5479,
+    "electiveCount": 3375,
+    "totalCount": 8854
   },
   {
     "slug": "western-wyoming-community-college",
     "name": "Western Wyoming Community College",
-    "mappingCount": 24
+    "mappingCount": 24,
+    "directCount": 24,
+    "electiveCount": 0,
+    "totalCount": 24
   }
 ]

--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -510,6 +510,48 @@ async function _getUniversitiesWithCounts(state: string): Promise<
     totalCount: number;
   }[]
 > {
+  // Fast path: pre-computed cache file from build-transfer-universities-cache.ts
+  // (wired into `npm run build`). getUniversities() got this #777 fix; this
+  // counts variant was missed and kept paginating the full transfers table —
+  // 162K rows for CA, ~10s to cold-render /[state]/transfer. The cache is
+  // ~1 KB and read in <5ms. The totalCount type-guard means an older cache
+  // file written before this field existed falls through to Supabase, so the
+  // change is safe before the cache is regenerated.
+  try {
+    const cachePath = path.join(
+      process.cwd(),
+      "data",
+      state,
+      "transfer-universities.json",
+    );
+    if (fs.existsSync(cachePath)) {
+      const cached = JSON.parse(fs.readFileSync(cachePath, "utf-8")) as {
+        slug: string;
+        name: string;
+        directCount?: number;
+        electiveCount?: number;
+        totalCount?: number;
+      }[];
+      if (
+        Array.isArray(cached) &&
+        cached.length > 0 &&
+        typeof cached[0].totalCount === "number"
+      ) {
+        return cached
+          .map((c) => ({
+            slug: c.slug,
+            name: c.name,
+            directCount: c.directCount ?? 0,
+            electiveCount: c.electiveCount ?? 0,
+            totalCount: c.totalCount ?? 0,
+          }))
+          .sort((a, b) => b.totalCount - a.totalCount);
+      }
+    }
+  } catch {
+    // Cache read/parse failed — fall through to Supabase.
+  }
+
   // Performance: column-projected Supabase query — same reason as
   // getUniversities. Only pulls the 5 fields we actually inspect, not the
   // full 13. See that function's comment.

--- a/scripts/build-transfer-universities-cache.ts
+++ b/scripts/build-transfer-universities-cache.ts
@@ -24,6 +24,9 @@ interface TransferMapping {
   state?: string;
   university: string;
   university_name: string;
+  univ_course?: string | null;
+  no_credit?: boolean;
+  is_elective?: boolean;
 }
 
 interface UniversityEntry {
@@ -36,6 +39,15 @@ interface UniversityEntry {
   // Heavy states (CA/TX/NY/MI, 150K+ rows) gate the full matrix behind an
   // explicit "Load all" button instead. See TransferClient. Issue #777 kin.
   mappingCount: number;
+  // Transferable-row counts that mirror getUniversitiesWithCounts() in
+  // lib/transfer.ts exactly: rows with no_credit or a wildcard ('*')
+  // univ_course are excluded; direct = not is_elective, elective =
+  // is_elective; totalCount = direct + elective. Lets that function read
+  // this cache instead of paginating the full transfers table (162K rows
+  // for CA) at request time — the same #777 fix getUniversities already got.
+  directCount: number;
+  electiveCount: number;
+  totalCount: number;
 }
 
 const DATA_DIR = path.join(process.cwd(), "data");
@@ -57,14 +69,37 @@ function buildOne(state: string): { written: boolean; count: number } {
 
   const seen = new Map<string, string>();
   const counts = new Map<string, number>();
+  const directCounts = new Map<string, number>();
+  const electiveCounts = new Map<string, number>();
   for (const m of data) {
     if (!m.university) continue;
     if (!seen.has(m.university)) seen.set(m.university, m.university_name || m.university);
     counts.set(m.university, (counts.get(m.university) ?? 0) + 1);
+    // Transferable split — mirror getUniversitiesWithCounts() filters exactly:
+    // drop no-credit rows and wildcard ('*') equivalencies, then count
+    // direct (not is_elective) vs elective (is_elective).
+    if (m.no_credit) continue;
+    if (m.univ_course && m.univ_course.includes("*")) continue;
+    if (m.is_elective) {
+      electiveCounts.set(m.university, (electiveCounts.get(m.university) ?? 0) + 1);
+    } else {
+      directCounts.set(m.university, (directCounts.get(m.university) ?? 0) + 1);
+    }
   }
 
   const out: UniversityEntry[] = Array.from(seen.entries())
-    .map(([slug, name]) => ({ slug, name, mappingCount: counts.get(slug) ?? 0 }))
+    .map(([slug, name]) => {
+      const directCount = directCounts.get(slug) ?? 0;
+      const electiveCount = electiveCounts.get(slug) ?? 0;
+      return {
+        slug,
+        name,
+        mappingCount: counts.get(slug) ?? 0,
+        directCount,
+        electiveCount,
+        totalCount: directCount + electiveCount,
+      };
+    })
     .sort((a, b) => a.name.localeCompare(b.name));
 
   const outPath = path.join(DATA_DIR, state, "transfer-universities.json");


### PR DESCRIPTION
## What changes for someone using the site

The California transfer page (`/ca/transfer`) — and every other large state's transfer page — now loads in well under a second instead of stalling **10–39 seconds** on the first visit after a quiet spell. Nothing changes visually: the same universities and counts appear, just without the long wait.

## What changed technically

The page renders a "Browse transfer pathways by university" list via `getUniversitiesWithCounts(state)`, which was **paginating the entire `transfers` table** on every cold render to tally per-university counts — 161,680 rows for CA, 254,448 for NY, 194k for TX. That full-table scan was the slow streamed Suspense boundary (fast TTFB, ~10s body).

`getUniversities()` already solved the identical problem in **issue #777** by reading a precomputed `data/{state}/transfer-universities.json` cache; **`getUniversitiesWithCounts()` was simply missed.** This finishes that fix:

- `scripts/build-transfer-universities-cache.ts` now also writes `directCount` / `electiveCount` / `totalCount` per university, filtered **identically** to the old query (drop `no_credit` and wildcard `*` rows; direct = not elective).
- `getUniversitiesWithCounts()` reads that ~1 KB cache (<1 ms) and **falls back** to the Supabase pagination if the cache predates the new fields — safe before and after regeneration.
- The cache build is already wired into `npm run build`, so it stays fresh on every deploy.

Secondary win: the build-time prerender of the ~100 `/[state]/transfer/to/[uni]` hub pages (which call this 3×/page) stops hitting the Supabase `statement_timeout` the function's own comment warned about.

### Before → after

| Metric | Before | After |
|---|---|---|
| `/ca/transfer` cold render | 10.7s (39s earlier) | ~0.12s (local prod build) |
| `getUniversitiesWithCounts('ca')` | ~10s (paginate 161,680 rows) | 0.17ms (read 1 KB cache) |
| Per-university counts | live query | identical (verified vs prod SQL) |

Generalizes to every big state: NY 254k · TX 194k · MI 153k · MD 123k · NJ 102k rows.

### Verification
- `npm run build` — ✓ compiled successfully.
- CA cache counts match the live Postgres aggregate exactly (csu 0/99843/99843, uc-system 0/56287/56287, Berkeley 1905/0/1905, …).
- Local prod server: `/ca/transfer` 200 in ~0.12s (Cache-Control confirms a dynamic render, not a static cache); `/nc/transfer` control 200 ✓.
- Staged only 2 code files + 50 regenerated caches — no other build-derived files.

### Scope / fork note
The goal flagged a fork: if the 10–39s were a cold-lambda/Supabase-connect spike rather than a fixable query, stop and re-scope. It is a **fixable query** (162k-row pagination → cache read), so I proceeded. Untouched (out of scope): course search (already fixed via `searchSections`), `loadTransferCoverage` (16 KB rollup — not the bottleneck), and the other read-path levers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
