### PR TITLE
perf(sitemap): cache getUniversitySlugsForSitemap — the last transfers full-scan

### DIFF
--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -633,6 +633,40 @@ async function _getUniversitiesWithCounts(state: string): Promise<
 export async function getUniversitySlugsForSitemap(
   state: string
 ): Promise<{ slug: string; totalCount: number }[]> {
+  // Fast path: pre-computed cache file from build-transfer-universities-cache.ts
+  // (wired into `npm run build`). Its `totalCount` is the filtered transferable
+  // count — no_credit and wildcard ('*') rows excluded — identical to both the
+  // Supabase query below and getUniversitiesWithCounts(). Reading the ~1 KB
+  // cache avoids paginating the entire transfers table (161K rows for CA, 254K
+  // for NY) during sitemap generation, the same #777 fix getUniversities() and
+  // getUniversitiesWithCounts() (PR #1206) already got. The totalCount
+  // type-guard falls through to Supabase for any cache written before #1206.
+  try {
+    const cachePath = path.join(
+      process.cwd(),
+      "data",
+      state,
+      "transfer-universities.json",
+    );
+    if (fs.existsSync(cachePath)) {
+      const cached = JSON.parse(fs.readFileSync(cachePath, "utf-8")) as {
+        slug: string;
+        totalCount?: number;
+      }[];
+      if (
+        Array.isArray(cached) &&
+        cached.length > 0 &&
+        typeof cached[0].totalCount === "number"
+      ) {
+        return cached
+          .map((c) => ({ slug: c.slug, totalCount: c.totalCount ?? 0 }))
+          .sort((a, b) => b.totalCount - a.totalCount);
+      }
+    }
+  } catch {
+    // Cache read/parse failed — fall through to Supabase.
+  }
+
   try {
     const counts = new Map<string, number>();
     let offset = 0;


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible — this is a backend speedup. The transfer sitemap (`/sitemap/transfer.xml`, the search-engine index of every "courses that transfer to University X" page) was rebuilt by scanning the **entire** transfer database — 161,680 rows for California, 254,448 for New York — each time it regenerated. It now reads a ~1 KB precomputed cache instead, so sitemap generation (and the deploys that trigger it) no longer pay a 100–250-query scan per big state.

## What changed technically

This is the **third and final** function in the issue-#777 / PR-#1206 cleanup. `getUniversities()` (#777) and `getUniversitiesWithCounts()` (#1206) already stopped paginating the `transfers` table by reading the precomputed `data/{state}/transfer-universities.json` cache; `getUniversitySlugsForSitemap()` was the last one still doing the full scan.

It now reads the `totalCount` field PR #1206 added to that cache. The sitemap's count is the **filtered** transferable count (`no_credit=false`, no wildcard `*`) — exactly what `totalCount` stores — so output is identical. A `typeof totalCount === "number"` guard falls back to the original Supabase pagination if a cache predates the field, so it's zero-regression.

### Verification
- Cache `totalCount` matches the live Postgres aggregate **exactly**: CA (csu-system 99843, uc-system 56287, Berkeley 1905, …) and NY (suny-empire-state 19310, cortland 16010, … — all 8 top values).
- `npm run build` — ✓ compiled successfully; no data files changed (main's cache already carries `totalCount`).
- Local prod server: `/sitemap/transfer.xml` → 200, all **394** transfer-hub URLs, **49ms** (spot-checked `/ca/transfer/to/csu-system`, `/ny/transfer/to/suny-empire-state`, `/nc/transfer/to/appstate`).

Single-file change (`lib/transfer.ts`). Builds on PR #1206 (already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
