### PR TITLE
perf(transfer): scope getCoursesForUniversity query — fix big-state transfer-hub 504s

### DIFF
--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -397,8 +397,14 @@ export async function getCoursesForUniversity(
   university: string,
   state: string
 ): Promise<TransferMapping[]> {
-  const mappings = await loadTransferMappings(state);
-  return mappings.filter((m) => m.university === university);
+  // Scope the fetch to this university via the indexed (state, university)
+  // query — idx_transfers_state_university — instead of loading the ENTIRE
+  // state's transfers and filtering in JS. The old path pulled every CA row
+  // (161,680 / ~30 MB / ~162 Supabase pages) to render a single university's
+  // hub page, so even a 642-mapping university 504'd at the function timeout.
+  // Same load-all-then-filter anti-pattern already fixed for getUniversities()
+  // (#777), getUniversitiesWithCounts() (#1206) and the sitemap (#1207).
+  return loadTransferMappingsByUniversity(state, university);
 }
 
 /** Get the list of all universities in the dataset.


### PR DESCRIPTION
## What changes for someone using the site

Transfer-hub pages on the big states stop timing out. Before this, `/ca/transfer/to/university-of-california-davis` — and every CA / NY / MI university page — returned a **15-second 504 error**, so students couldn't see which courses transfer to those schools at all. Now that page loads in **0.4 seconds**.

## What changed technically

The hub page calls `getCoursesForUniversity(university, state)`, which loaded the **entire** state's transfer table and filtered to one university in JavaScript. For California that meant pulling all **161,680 rows (~30 MB, ~162 Supabase pages)** to render a single university's page — so even a 642-mapping university hit the 15s function timeout.

It now delegates to `loadTransferMappingsByUniversity(state, university)` — the indexed (`idx_transfers_state_university`), per-university, cached query that already existed. Same "load-all-then-filter" anti-pattern already fixed for `getUniversities()` (#777), `getUniversitiesWithCounts()` (#1206), and the sitemap (#1207); the hub-page loader was the last one still doing it. Single caller, identical `TransferMapping[]` output.

### Before → after (cold prod 504 vs local production build)

| Page | mappings | before | after |
|---|---|---|---|
| `…/to/university-of-california-davis` | 642 | 504 / 15.1s | **200 / 0.41s** |
| `…/nc/…/to/appstate` (control) | 1,000 | 200 | 200 / 0.32s |
| `…/to/uc-system` | 56,287 | 504 / 15s | 200 / 8.9s |
| `…/to/csu-system` | 99,843 | 504 / 15.8s | 200 / 14s |

Content verified: the uc-davis page renders real mappings (e.g. `ROSS 912`), not an error.

### Known gap (named, not hidden)
The two **system-wide** CA aggregates (`uc-system`, `csu-system`) still load all ~56k–100k of *their own* rows for the per-page counts + subject breakdown, so they go from a hard 504 to a slow 200 (9–14s) — better, but `csu-system` may still be borderline against prod's timeout. A follow-up will source those counts from the `transfer-universities.json` cache (which now carries them) and cap the row fetch. Flagged separately.

Single-file change (`lib/transfer.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
