### PR TITLE
perf(transfer): cap hub-page mapping fetch — fix slow system-wide aggregate pages

### DIFF
--- a/app/[state]/transfer/to/[universitySlug]/page.tsx
+++ b/app/[state]/transfer/to/[universitySlug]/page.tsx
@@ -2,11 +2,12 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import type { Metadata } from "next";
 import {
-  getCoursesForUniversity,
+  loadTransferMappingsByUniversity,
   getUniversitiesWithCounts,
   trimMappingsForClient,
   capMappingsByRoundRobin,
   TRANSFER_HUB_MAX_CLIENT_MAPPINGS,
+  TRANSFER_HUB_SAMPLE_FETCH,
 } from "@/lib/transfer";
 import { loadInstitutions } from "@/lib/institutions";
 import { isValidState } from "@/lib/states/registry";
@@ -96,15 +97,27 @@ export default async function TransferHubPage(props: PageProps) {
   const uni = universities.find((u) => u.slug === universitySlug);
   if (!uni || uni.totalCount < MIN_TRANSFERABLE) notFound();
 
-  // Fetch all mappings for this university, filter to transferable only.
-  const allMappings = await getCoursesForUniversity(universitySlug, state);
-  const mappings: TransferMapping[] = allMappings.filter(
-    (m) =>
-      !m.no_credit &&
-      !(m.univ_course && m.univ_course.includes("*"))
-  );
+  // Headline counts come from the precomputed transfer-universities.json cache
+  // (uni.*, built by build-transfer-universities-cache.ts) — exact, with no row
+  // load. The page only needs actual rows to populate the browsable table + the
+  // subject filter, both of which are capped for display anyway, so we fetch a
+  // bounded SAMPLE rather than every mapping. CSU/UC system-wide pages (~99K /
+  // ~56K mappings, ~30 MB) used to load all of them just to render 2,500 rows
+  // and timed out. Universities at or under the sample cap fetch every row
+  // (unchanged); above it the table is a representative sample while these
+  // counts stay exact.
+  const directCount = uni.directCount;
+  const electiveCount = uni.electiveCount;
+  const totalMappingCount = uni.totalCount;
 
-  if (mappings.length < MIN_TRANSFERABLE) notFound();
+  const sampleRaw = await loadTransferMappingsByUniversity(
+    state,
+    universitySlug,
+    TRANSFER_HUB_SAMPLE_FETCH
+  );
+  const mappings: TransferMapping[] = sampleRaw.filter(
+    (m) => !m.no_credit && !(m.univ_course && m.univ_course.includes("*"))
+  );
 
   // Slim the payload for the client table. Three things are at play:
   //   1) Strip redundant per-row fields (cc_course, university, university_name,
@@ -113,11 +126,8 @@ export default async function TransferHubPage(props: PageProps) {
   //   2) Sort deterministically by subject + course number so the cap below
   //      produces a stable, alphabetized view within each subject.
   //   3) Cap to TRANSFER_HUB_MAX_CLIENT_MAPPINGS via round-robin across
-  //      subjects to stay under Vercel's 19 MB ISR pre-render limit. Some
-  //      universities (UMGC, Frostburg, UMBC) have tens of thousands of
-  //      mappings that bloat the RSC payload past the cap. Round-robin (vs
-  //      a naive top-N slice) preserves subject diversity so every subject
-  //      filter in the client is still populated.
+  //      subjects to stay under Vercel's 19 MB ISR pre-render limit and keep
+  //      every subject filter in the client populated.
   const sortedMappings = [...mappings].sort((a, b) => {
     const p = a.cc_prefix.localeCompare(b.cc_prefix);
     if (p !== 0) return p;
@@ -128,7 +138,6 @@ export default async function TransferHubPage(props: PageProps) {
     TRANSFER_HUB_MAX_CLIENT_MAPPINGS
   );
   const clientMappings = trimMappingsForClient(cappedMappings);
-  const totalMappingCount = mappings.length;
   const mappingsTruncated = totalMappingCount > clientMappings.length;
 
   // Build a lookup from CC course prefix → CC display name. We use the course
@@ -142,7 +151,9 @@ export default async function TransferHubPage(props: PageProps) {
   // existing /[state]/course/[code] page, which already lists colleges.
   const institutions = loadInstitutions(state);
 
-  // Subject breakdown (unique prefixes)
+  // Subject breakdown (unique prefixes), from the fetched sample. For
+  // universities above the sample cap this reflects the sample, not every row;
+  // the headline counts above stay exact.
   const subjectCounts = new Map<string, number>();
   for (const m of mappings) {
     subjectCounts.set(
@@ -153,10 +164,6 @@ export default async function TransferHubPage(props: PageProps) {
   const subjects = Array.from(subjectCounts.entries())
     .sort((a, b) => b[1] - a[1]);
 
-  // Type breakdown
-  const directCount = mappings.filter((m) => !m.is_elective).length;
-  const electiveCount = mappings.filter((m) => m.is_elective).length;
-
   // JSON-LD
   const siteUrl =
     process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
@@ -165,8 +172,8 @@ export default async function TransferHubPage(props: PageProps) {
     "@context": "https://schema.org",
     "@type": "ItemList",
     name: `${config.name} Community College Courses that Transfer to ${uni.name}`,
-    description: `${mappings.length} transferable courses from ${config.systemName} to ${uni.name}.`,
-    numberOfItems: mappings.length,
+    description: `${totalMappingCount} transferable courses from ${config.systemName} to ${uni.name}.`,
+    numberOfItems: totalMappingCount,
     url: `${siteUrl}/${state}/transfer/to/${universitySlug}`,
     itemListElement: mappings.slice(0, 25).map((m, i) => ({
       "@type": "ListItem",
@@ -222,7 +229,7 @@ export default async function TransferHubPage(props: PageProps) {
         params={{
           state,
           university: universitySlug,
-          mapping_count: mappings.length,
+          mapping_count: totalMappingCount,
           direct_count: directCount,
           elective_count: electiveCount,
         }}
@@ -264,7 +271,7 @@ export default async function TransferHubPage(props: PageProps) {
           Transfer to {uni.name}
         </h1>
         <p className="text-gray-600 dark:text-slate-400 mt-2 max-w-3xl">
-          {`${mappings.length} courses from ${config.name} community colleges (${config.systemName}) transfer to ${uni.name}. Browse the full list below, or filter by community college or subject to find the courses that fit your transfer plan.`}
+          {`${totalMappingCount} courses from ${config.name} community colleges (${config.systemName}) transfer to ${uni.name}. Browse the full list below, or filter by community college or subject to find the courses that fit your transfer plan.`}
         </p>
       </div>
 

--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -14,6 +14,19 @@ import { cached } from "./courses";
 export const TRANSFER_HUB_MAX_CLIENT_MAPPINGS = 2500;
 
 /**
+ * Upper bound on rows the hub page FETCHES to build its table + subject sample.
+ * The table is round-robin-capped to TRANSFER_HUB_MAX_CLIENT_MAPPINGS for
+ * display, so we never need every row — but we pull a larger pool than the
+ * display cap so the round-robin still has subjects to spread across. The
+ * CSU/UC system-wide pages (~99K / ~56K mappings) would otherwise load ~30 MB
+ * and time out (issue tracked after #1208). The page's headline direct/elective
+ * /total counts come from the transfer-universities.json cache instead, so
+ * capping the fetched sample only changes WHICH courses appear in the browsable
+ * table — never the totals. Universities at/under this cap fetch every row.
+ */
+export const TRANSFER_HUB_SAMPLE_FETCH = 12000;
+
+/**
  * Strip redundant fields before serializing to the client. On pages with
  * many thousands of mappings, these per-row fields add up to several MB
  * of wire payload for no user-visible benefit.


### PR DESCRIPTION
## What changes for someone using the site

The last slow transfer-hub pages get fast. After #1208 fixed per-campus pages, the **system-wide aggregate** pages still timed out or crawled: `/ca/transfer/to/csu-system` (the "transfers to CSU system-wide" page, 99,843 mappings) took **14 seconds**; `uc-system` took 8.9s. They now load in **~1.5 seconds**, showing the same exact totals.

## What changed technically

The page loaded *every* mapping for a university just to render a table that's **already capped to 2,500 rows** for display. For CSU that's ~30 MB / ~100 Supabase pages. It now:
- takes the exact **direct / elective / total** counts from the `transfer-universities.json` cache (`uni.*`, the fields PR #1206 added) — no row load; and
- fetches a **bounded sample** (`TRANSFER_HUB_SAMPLE_FETCH = 12,000`) via the `cap` param that `loadTransferMappingsByUniversity` already exposed (its own doc said loading all 99K rows "just to throw most of them away costs ~50s").

### Before → after (local production build)

| Page | mappings | before | after |
|---|---|---|---|
| `…/to/csu-system` | 99,843 | 14s | **1.6s** |
| `…/to/uc-system` | 56,287 | 8.9s | **1.3s** |
| `…/to/university-of-california-davis` (ctrl) | 642 | 0.4s | 0.13s |
| `…/nc/…/to/appstate` (ctrl) | 1,000 | 0.3s | 0.26s |

Verified csu-system renders the **exact** cache counts (99,843 total · 0 direct · 99,843 elective) with a real, populated table.

### Scope / known tradeoff (named, not hidden)
**24 universities** have >12,000 transferable mappings (CSU/UC system-wide, NIU, SIU, Frostburg, Morgan State, …). For those, the browsable table **and** the subject-chip counts now reflect the 12,000-row sample rather than every row — but the **headline direct/elective/total counts stay exact** (from the cache), and the table was *already* capped to 2,500 for display, so the client's search/filter coverage is unchanged. Universities at or under the cap (the vast majority) are byte-identical.

Two-file change (`lib/transfer.ts`, the hub page). Builds on #1206 (cache fields) + #1208 (scoped query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
