### PR TITLE
SSR unified course search for ?q= deep links

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -59,7 +59,7 @@ interface CourseGroup {
   prerequisite_courses: string[];
 }
 
-interface SearchResponse {
+export interface SearchResponse {
   courses: CourseGroup[];
   totalCourses: number;
   totalSections: number;
@@ -149,9 +149,13 @@ interface CourseSearchProps {
   collegeCount?: number;
   courseUrlMap?: Record<string, string>;
   defaultZip?: string;
+  // Server-rendered results for a ?q= deep link, seeded into `results` so the
+  // initial HTML already contains matching sections (SEO, no-JS, instant first
+  // paint). Null when there is no query or the server search found nothing.
+  initialResults?: SearchResponse | null;
 }
 
-export default function CourseSearchClient({ state, systemName, collegeCount, courseUrlMap, defaultZip }: CourseSearchProps) {
+export default function CourseSearchClient({ state, systemName, collegeCount, courseUrlMap, defaultZip, initialResults }: CourseSearchProps) {
   const searchParams = useSearchParams();
   const initialQuery = searchParams.get("q")?.replace(/\+/g, " ") || "";
   // Initialize filter state from URL so deep links like
@@ -250,10 +254,10 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
   const [transferLookup, setTransferLookup] = useState<Record<string, { university: string; type: string }[]> | null>(null);
   const [universities, setUniversities] = useState<{ slug: string; name: string }[]>([]);
 
-  const [results, setResults] = useState<SearchResponse | null>(null);
+  const [results, setResults] = useState<SearchResponse | null>(initialResults ?? null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
-  const [hasSearched, setHasSearched] = useState(false);
+  const [hasSearched, setHasSearched] = useState(!!initialResults);
   // Natural-language answer card. Populated from /api/[state]/ask in
   // parallel with the course search; null until a query has resolved or
   // when the classifier returned a non-actionable intent.
@@ -464,11 +468,29 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     doSearch(query);
   }
 
-  // Auto-search when loaded with ?q= parameter
+  // Auto-search when loaded with a ?q= deep link.
   useEffect(() => {
-    if (initialQuery) {
-      doSearch(initialQuery);
+    if (!initialQuery) return;
+    if (initialResults) {
+      // The server already rendered matching sections for this query and seeded
+      // them into `results`, so they're in the initial HTML. Skip the redundant
+      // section refetch — which would flash results→spinner→results and
+      // duplicate the query — and fetch only the natural-language answer card so
+      // the deep link still matches the interactive search experience.
+      fetch(`/api/${state}/ask?q=${encodeURIComponent(initialQuery)}`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => {
+          if (d?.answer) setAnswer(d.answer);
+          if (d?.secondaryAnswer) setSecondaryAnswer(d.secondaryAnswer);
+          if (d?.classification) setClassification(d.classification);
+        })
+        .catch(() => {});
+      return;
     }
+    // No server-rendered results (no keyword match, or a natural-language query
+    // the keyword search couldn't resolve). Run the full client search, which
+    // adds LLM query refinement and can rescue queries SSR left empty.
+    doSearch(initialQuery);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   function toggleExpand(courseKey: string, slug: string) {

--- a/app/[state]/courses/page.tsx
+++ b/app/[state]/courses/page.tsx
@@ -1,24 +1,53 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import CourseSearchClient from "./CourseSearchClient";
-import { getAllStates } from "@/lib/states/registry";
+import CourseSearchClient, { type SearchResponse } from "./CourseSearchClient";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { loadInstitutions } from "@/lib/institutions";
 import { getDistinctSubjects } from "@/lib/courses";
+import { searchCoursesAcrossColleges } from "@/lib/courses-search";
 import { getCurrentTerm, termLabel } from "@/lib/terms";
 import { subjectName } from "@/lib/subjects";
 
+// Render on demand for every request. Required to read `searchParams` (SSR of
+// ?q= course-search deep links) — without it the route stays in the default
+// SSG-with-dynamicParams bucket, where touching searchParams throws
+// DYNAMIC_SERVER_USAGE. This matches the sibling state routes (app/[state]/
+// page.tsx, schedule, transfer are all force-dynamic). The no-q landing stays
+// cheap: its data loaders (getDistinctSubjects, getCurrentTerm) are cached and
+// loadInstitutions is a file read, so each render is inexpensive uncached.
+export const dynamic = "force-dynamic";
+
 type Props = {
   params: Promise<{ state: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
+
+// searchParams values are string | string[] (a repeated key arrives as an
+// array). The course search treats each filter as a single value, mirroring the
+// /api/[state]/courses/search route, so collapse to the first occurrence.
+function firstParam(v: string | string[] | undefined): string | undefined {
+  return Array.isArray(v) ? v[0] : v;
+}
 
 export function generateStaticParams() {
   return [];
 }
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
   const { state } = await params;
   const config = requireStateConfig(state);
+  const q = firstParam((await searchParams).q)?.trim();
+  // Query-aware metadata so a shared or Googled course-search link has a
+  // descriptive title/snippet and self-canonicals to the query URL (filters are
+  // dropped from the canonical so day/time/zip variants consolidate to one page).
+  if (q && q.length >= 2) {
+    return {
+      title: `"${q}" Courses — Search All ${config.collegeCount} ${config.systemName} Colleges | ${config.branding.siteName}`,
+      description: `Find "${q}" course sections across all ${config.collegeCount} ${config.name} community colleges at once — compare schedule, location, format, and transfer credit.`,
+      keywords: config.branding.metaKeywords,
+      alternates: { canonical: `/${state}/courses?q=${encodeURIComponent(q)}` },
+    };
+  }
   return {
     title: `Find a Course — Search All ${config.collegeCount} ${config.systemName} Colleges | ${config.branding.siteName}`,
     description: `Search for courses across all ${config.collegeCount} ${config.name} community colleges at once. Find the best schedule, location, and format for auditing.`,
@@ -27,7 +56,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function CoursesPage({ params }: Props) {
+export default async function CoursesPage({ params, searchParams }: Props) {
   const { state } = await params;
   const config = requireStateConfig(state);
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
@@ -75,6 +104,51 @@ export default async function CoursesPage({ params }: Props) {
     courseUrlMap[inst.college_slug] = config.courseDiscoveryUrl(inst.college_slug, "__PREFIX__", "__NUMBER__");
   }
 
+  // Server-render the unified course search for ?q= deep links. Mirrors the
+  // /api/[state]/courses/search route's parsing (q / zip / mode / days / day /
+  // timeOfDay) and calls the same CA-504-safe SQL-predicate search, so the
+  // initial HTML contains real result rows — previously the only server content
+  // for /{state}/courses?q=… was the empty search form, leaving deep links,
+  // shared links, and Google results blank until client JS ran.
+  const sp = await searchParams;
+  const initialQuery = firstParam(sp.q)?.trim() ?? "";
+  let initialResults: SearchResponse | null = null;
+  if (initialQuery.length >= 2) {
+    const zip = firstParam(sp.zip)?.trim() || undefined;
+    const mode = firstParam(sp.mode)?.trim() || undefined;
+    const daysRaw = firstParam(sp.days)?.trim();
+    const singleDay = firstParam(sp.day)?.trim();
+    const days = daysRaw
+      ? daysRaw.split(",").map((d) => d.trim()).filter(Boolean)
+      : singleDay
+        ? [singleDay]
+        : undefined;
+    const todRaw = firstParam(sp.timeOfDay)?.trim();
+    const timeOfDay =
+      todRaw === "morning" || todRaw === "afternoon" || todRaw === "evening"
+        ? todRaw
+        : undefined;
+    try {
+      const r = await searchCoursesAcrossColleges(
+        currentTerm,
+        initialQuery,
+        institutions,
+        { mode, days, timeOfDay, zip },
+        50,
+        0,
+        state
+      );
+      // Only seed when the server search found sections. An empty match (or a
+      // natural-language query the keyword search can't resolve) is left null so
+      // the client runs its LLM-refined search and can still rescue the query.
+      if (r.courses.length > 0) initialResults = r;
+    } catch {
+      // A search failure must never break the page render — fall back to the
+      // client search by leaving initialResults null.
+      initialResults = null;
+    }
+  }
+
   return (
     <>
       <script
@@ -91,6 +165,7 @@ export default async function CoursesPage({ params }: Props) {
         collegeCount={config.collegeCount}
         courseUrlMap={courseUrlMap}
         defaultZip={config.defaultZip}
+        initialResults={initialResults}
       />
 
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">


### PR DESCRIPTION
## What changes for someone using the site

Open or share a course-search link like `communitycollegepath.com/nc/courses?q=psychology` and the page now shows **real course results immediately** — server-rendered into the page — instead of a blank search box that only fills in after JavaScript loads and runs a fetch.

Concretely, `/nc/courses?q=psychology` used to return a 173 KB shell with **0 result rows** (just the static "popular courses" links). It now returns the full result list in the initial HTML: *"406 sections of 11 courses at 55 colleges"* with PSY/SOC course cards already present. This matters for:

- **Shared & deep links** — paste a search link in a text or email and the recipient sees results, not an empty form.
- **Google** — search-result pages now have indexable content (the homepage already advertises `?q={search_term_string}` as a SearchAction target; until now that target rendered nothing server-side).
- **Perceived speed / no-JS** — first paint shows results; no spinner round-trip for the common case.

Filters carry through the URL server-side too: `/nc/courses?q=psychology&days=Tu,Th&timeOfDay=evening` renders the Tue/Thu-evening subset (1 card vs. 10 unfiltered) in the HTML. **All 51 states.**

## How it works

- **`app/[state]/courses/page.tsx`** now reads `searchParams`. When `q` (≥2 chars) is present it parses `q / zip / mode / days / day / timeOfDay` exactly like `app/api/[state]/courses/search/route.ts` and calls the **same** `searchCoursesAcrossColleges` backend (the CA-504-safe SQL-predicate search), passing the result to `CourseSearchClient` as a new `initialResults` prop. Results are only seeded when the search is **non-empty**, so a natural-language query the keyword search can't resolve is left `null` and the client's existing LLM-refined search still rescues it.
- Reading `searchParams` requires **`export const dynamic = "force-dynamic"`** — otherwise the route stays in the default SSG-with-`dynamicParams` bucket and touching `searchParams` throws `DYNAMIC_SERVER_USAGE`. This matches the sibling state routes (`/[state]`, `/[state]/schedule`, `/[state]/transfer` are already force-dynamic).
- **`CourseSearchClient.tsx`** seeds `results`/`hasSearched` from `initialResults`. On a seeded deep link it **skips the redundant section refetch** (which would flash results→spinner→results and duplicate the query) and fetches only the natural-language answer card, so behavior matches the interactive experience.
- `generateMetadata` is now query-aware (descriptive title/description, self-canonical to `?q=` with filters dropped).
- Incidental: removed an unused `getAllStates` import.

## Honest tradeoff — dynamic rendering & big-state cold render

Making the route `force-dynamic` means the **no-q landing page is no longer full-route-cached**. It stays cheap regardless: its data loaders (`getDistinctSubjects`, `getCurrentTerm`) are cached and `loadInstitutions` is a file read — measured **TTFB ~0.012s**.

The SSR search blocks first paint until it resolves. `searchSections` is cached (`lib/courses.ts`), so this is a **one-time cold cost per unique query**, then ~0.05s warm — and it's the *same* cached search the client already paid via the API, just relocated from a client spinner to the server render (not a total-time regression). Measured cold renders on a local prod build:

| Route | Cold total | Warm |
|---|---|---|
| `/nc/courses?q=psychology` | 0.03s | 0.03s |
| `/tx/courses?q=biology` | 2.9s | <0.1s |
| `/ca/courses?q=psychology` | 6.7s | ~0.05s |

So 45+ states are sub-second; only the very largest states (CA, TX) have a multi-second **first-visitor** cold render where the page waits before painting (vs. today's instant shell + spinner). **Follow-up (separate PR):** wrap the results region in a React `<Suspense>` boundary so the form + SEO directory stream immediately and results stream in — making the big-state first paint instant while keeping the SEO win. Out of scope here to keep this PR to the `initialResults` seed.

## Out of scope (named)
- `transfersTo`-filter SSR (still client-side via `/transfer/lookup`).
- Writing live filter changes back to the URL.
- The Suspense-streaming improvement above.

## Test plan
- [x] `npm run typecheck` clean; `eslint` clean on both files; `next build` succeeds.
- [x] `/nc/courses?q=psychology` raw HTML contains "406 sections of 11 courses at 55 colleges" + PSY/SOC cards (matches `/api/nc/courses/search`).
- [x] `days=Tu,Th&timeOfDay=evening` → filtered subset server-side (10 → 1 card).
- [x] No-q landing renders the SEO subject/college directory, 0 result cards, TTFB ~0.012s.
- [x] SSR-empty query (`?q=zzznotacourse`) and big-state CA both return 200 (no 504); empty falls back to client LLM rescue.
- [ ] Post-merge: confirm on prod `communitycollegepath.com/nc/courses?q=psychology` ships result rows in `curl` output.

**DO NOT MERGE yet** — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)