### PR TITLE
Empty-state recovery: offer a way forward when a filtered search finds nothing

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -59,11 +59,21 @@ interface CourseGroup {
   prerequisite_courses: string[];
 }
 
+export interface RecoverySuggestion {
+  drop: "mode" | "days" | "timeOfDay";
+  droppedLabel: string;
+  totalCourses: number;
+  totalSections: number;
+}
+
 export interface SearchResponse {
   courses: CourseGroup[];
   totalCourses: number;
   totalSections: number;
   totalColleges: number;
+  // Present only on an empty filtered result: how many sections come back if
+  // one filter is dropped (see lib/courses-search.ts). Powers the recovery CTAs.
+  recovery?: { suggestions: RecoverySuggestion[] };
 }
 
 interface IntentSummary {
@@ -290,6 +300,11 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
   // Pagination
   const [displayLimit, setDisplayLimit] = useState(10);
 
+  // Set true by an empty-state recovery CTA after it clears a filter; the effect
+  // below then re-runs the search. We can't clear-and-search in one handler
+  // because doSearch closes over the pre-clear filter value (stale closure).
+  const [recoveryPending, setRecoveryPending] = useState(false);
+
   const doSearch = useCallback(async (searchQuery: string) => {
     if (!searchQuery.trim() || searchQuery.trim().length < 2) {
       setError("Enter at least 2 characters to search.");
@@ -500,6 +515,15 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     // adds LLM query refinement and can rescue queries SSR left empty.
     doSearch(initialQuery);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Re-run the search after a recovery CTA cleared a filter. Runs post-render so
+  // doSearch now closes over the cleared filter value. The early return keeps a
+  // normal manual filter change (recoveryPending false) from auto-searching.
+  useEffect(() => {
+    if (!recoveryPending) return;
+    setRecoveryPending(false);
+    doSearch(query);
+  }, [recoveryPending, query, doSearch]);
 
   function toggleExpand(courseKey: string, slug: string) {
     const id = `${courseKey}::${slug}`;
@@ -781,6 +805,26 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
                     ? `Try removing the ${activeFilters.join(", ")} filter${activeFilters.length === 1 ? "" : "s"}.`
                     : "Try a different keyword or course code."}
                 </p>
+                {results.recovery && results.recovery.suggestions.length > 0 && (
+                  <div className="mt-4 flex flex-wrap justify-center gap-2">
+                    {results.recovery.suggestions.map((s) => (
+                      <button
+                        key={s.drop}
+                        type="button"
+                        onClick={() => {
+                          if (s.drop === "mode") setMode("");
+                          else if (s.drop === "days") setDays([]);
+                          else setTimeOfDay("");
+                          setRecoveryPending(true);
+                        }}
+                        className="rounded-full border border-teal-300 dark:border-teal-700 bg-teal-50 dark:bg-teal-900/30 px-3 py-1.5 text-xs font-medium text-teal-700 dark:text-teal-300 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition"
+                      >
+                        Show {s.totalSections.toLocaleString()}{" "}
+                        {s.totalSections === 1 ? "section" : "sections"} without the {s.droppedLabel} filter
+                      </button>
+                    ))}
+                  </div>
+                )}
               </div>
             );
           })()}

--- a/lib/courses-search.ts
+++ b/lib/courses-search.ts
@@ -30,6 +30,22 @@ export interface CollegeGroup {
   sections: CourseSection[];
 }
 
+// Empty-state recovery: when a query matches courses but the mode/days/timeOfDay
+// filters knock the result to zero, each suggestion reports how many
+// courses/sections would match if that ONE filter were dropped — so the UI can
+// offer "show N sections without the {evening} filter" instead of a dead end.
+export interface RecoverySuggestion {
+  drop: "mode" | "days" | "timeOfDay";
+  /** Human label for the dropped filter, e.g. "evening", "online", "day". */
+  droppedLabel: string;
+  totalCourses: number;
+  totalSections: number;
+}
+
+export interface SearchRecovery {
+  suggestions: RecoverySuggestion[];
+}
+
 /** Parse a search query into structured parts */
 export function parseQuery(q: string): {
   prefix: string | null;
@@ -156,6 +172,7 @@ export async function searchCoursesAcrossColleges(
   totalCourses: number;
   totalSections: number;
   totalColleges: number;
+  recovery?: SearchRecovery;
 }> {
   let { prefix, number, keyword } = parseQuery(query);
   // Push the query predicate into Postgres instead of loading every section
@@ -234,14 +251,19 @@ export async function searchCoursesAcrossColleges(
     return true;
   };
 
-  // Step 1: Apply the remaining JS-side filters to the server-narrowed set
-  // (prefix/number/keyword reflect the rescue's effective parse when it ran).
-  const matched = allCourses.filter((s) => {
+  // Step 1a: query match only (prefix/number/keyword reflect the rescue's
+  // effective parse when it ran). This is the set the mode/days/timeOfDay
+  // filters narrow — kept separate so empty-state recovery can re-count it
+  // with one filter dropped, without re-querying.
+  const queryMatched = allCourses.filter((s) => {
     if (prefix && s.course_prefix !== prefix) return false;
     if (number && s.course_number !== number) return false;
     if (keyword && !s.course_title.toLowerCase().includes(keyword)) return false;
-    return passesFilters(s);
+    return true;
   });
+
+  // Step 1b: apply the mode/days/timeOfDay hard filters.
+  const matched = queryMatched.filter(passesFilters);
 
   // Step 2: Group by course (prefix+number), then by college
   const courseMap = new Map<
@@ -344,5 +366,59 @@ export async function searchCoursesAcrossColleges(
   // Paginate
   const paginated = courseGroups.slice(offset, offset + limit);
 
-  return { courses: paginated, totalCourses, totalSections, totalColleges };
+  // Empty-state recovery. When the query DID match courses but the hard filters
+  // zeroed the result, re-count `queryMatched` (the same already-fetched set)
+  // with each applied filter dropped individually, so the UI can offer a way
+  // forward instead of a dead end. Skipped when the query itself matched
+  // nothing (queryMatched empty) — then "try a different keyword" is the right
+  // message, not "drop a filter".
+  let recovery: SearchRecovery | undefined;
+  if (totalCourses === 0 && queryMatched.length > 0) {
+    const applied: Array<"mode" | "days" | "timeOfDay"> = [];
+    if (filters.mode) applied.push("mode");
+    if (filters.days && filters.days.length > 0) applied.push("days");
+    if (filters.timeOfDay) applied.push("timeOfDay");
+
+    if (applied.length > 0) {
+      const okMode = (s: CourseSection) => !filters.mode || s.mode === filters.mode;
+      const okDays = (s: CourseSection) =>
+        !(filters.days && filters.days.length > 0) || sectionMatchesDays(s.days, filters.days);
+      const okTime = (s: CourseSection) =>
+        !filters.timeOfDay || matchesTimeOfDay(s.start_time, filters.timeOfDay);
+      // For each dropped filter, keep the OTHER two and count distinct courses + sections.
+      const keepPred: Record<"mode" | "days" | "timeOfDay", (s: CourseSection) => boolean> = {
+        mode: (s) => okDays(s) && okTime(s),
+        days: (s) => okMode(s) && okTime(s),
+        timeOfDay: (s) => okMode(s) && okDays(s),
+      };
+      const labelFor: Record<"mode" | "days" | "timeOfDay", string> = {
+        mode: filters.mode || "mode",
+        days: "day",
+        timeOfDay: filters.timeOfDay || "time",
+      };
+      const suggestions: RecoverySuggestion[] = applied
+        .map((drop) => {
+          const courseSet = new Set<string>();
+          let sections = 0;
+          for (const s of queryMatched) {
+            if (keepPred[drop](s)) {
+              courseSet.add(`${s.course_prefix}-${s.course_number}`);
+              sections++;
+            }
+          }
+          return { drop, droppedLabel: labelFor[drop], totalCourses: courseSet.size, totalSections: sections };
+        })
+        .filter((x) => x.totalSections > 0)
+        .sort((a, b) => b.totalSections - a.totalSections);
+      if (suggestions.length > 0) recovery = { suggestions };
+    }
+  }
+
+  return {
+    courses: paginated,
+    totalCourses,
+    totalSections,
+    totalColleges,
+    ...(recovery ? { recovery } : {}),
+  };
 }


### PR DESCRIPTION
## What changes for someone using the site

When you search for a course and your filters knock the result to **zero**, the page used to dead-end: *"No matching courses with the current filters. Try removing the day, evening filters."* — it named the filters but never told you what would actually work.

Now it shows **one-click buttons that do the math for you**. Search NC for `PSY 150`, filter to **Sunday + evening**, and instead of a dead end you get:

> **Show 190 sections without the evening filter** · **Show 3 sections without the day filter**

Clicking one drops that filter and re-runs the search. Every state, every course search.

## How it works

- **`lib/courses-search.ts`** — `searchCoursesAcrossColleges` already fetches the section set (cached) and *then* applies mode/days/timeOfDay as in-memory filters. I split that into `queryMatched` (query only) → `matched` (+ hard filters). When the grouped result is empty **and the query itself did match courses**, it re-counts `queryMatched` with each applied filter dropped individually — the **same already-fetched set, no extra database query** — and returns `recovery.suggestions` (distinct courses + sections per drop, non-empty, sorted by yield). If the *query* matched nothing (e.g. a typo), there's no recovery and the copy stays "try a different keyword."
- **`CourseSearchClient.tsx`** — renders the suggestions as CTAs in the empty state. Clicking clears that one filter and re-searches. (It routes through a small `recoveryPending` effect rather than clearing-and-searching in the same handler, because `doSearch` closes over the pre-clear filter value — a stale-closure that would otherwise re-search with the filter still applied.)
- **The API route needs no change** — it already spreads the search result, so `recovery` flows through.

## A correction worth noting

The lever's premise example ("PSY 150 + Tue/Thu + evening = 0 sections") turned out to be **wrong at the state level** — that's **2 sections** across all NC colleges; the "0" in the original note was scoped to *one* college (Central Piedmont), but this unified search is statewide. The feature is still valuable (constrained searches genuinely hit zero — e.g. Sunday-evening), so I built and verified against a real empty case (`PSY 150 + Sunday + evening = 0`).

## Test plan
- [x] `npm run typecheck` + `eslint` clean on both files; `next build` succeeds.
- [x] API: `/api/nc/courses/search?q=PSY 150&days=Su&timeOfDay=evening` → `totalCourses 0` + `recovery.suggestions` = [drop evening → 190 sections, drop day → 3]. **Cross-checked**: actually dropping each filter returns exactly 190 / 3 — the recovery counts match reality.
- [x] Control: `q=zzznotacourse` (query matches nothing) → no recovery.
- [x] Playwright (worktree prod server): both buttons render; clicking "Show 190 sections without the evening filter" clears the filter and lists **"190 sections of 1 course at 34 colleges"**.
- [ ] Post-merge: hit the prod API for the empty case and confirm `recovery` is present.

## Out of scope (named)
- Location/zip widening ("nearby colleges") — the unified search is already all-colleges, so there's no "this college" to widen from.
- Keyword fuzzy "did you mean" for typo'd queries.
- Recovery on other surfaces (planner, per-college pages).

**DO NOT MERGE yet** — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)