### PR TITLE
Show each college's city in course-search results

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -43,6 +43,7 @@ interface SectionResult {
 interface CollegeGroup {
   slug: string;
   name: string;
+  city: string | null;
   distance: number | null;
   auditAllowed: boolean | null;
   sections: SectionResult[];
@@ -933,6 +934,11 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
                                 <span className="font-medium text-gray-900 dark:text-slate-100 text-sm">
                                   {college.name}
                                 </span>
+                                {college.city && (
+                                  <span className="ml-2 text-xs text-gray-500 dark:text-slate-400">
+                                    {college.city}
+                                  </span>
+                                )}
                                 {college.distance !== null && (
                                   <span className="ml-2 text-xs text-gray-500 dark:text-slate-400">
                                     {college.distance} mi

--- a/lib/courses-search.ts
+++ b/lib/courses-search.ts
@@ -25,6 +25,9 @@ export interface CourseGroup {
 export interface CollegeGroup {
   slug: string;
   name: string;
+  /** "City, ST" from the college's primary campus address, or null if it can't
+   * be parsed. Lets a result card convey proximity even with no zip entered. */
+  city: string | null;
   distance: number | null;
   auditAllowed: boolean | null;
   sections: CourseSection[];
@@ -44,6 +47,24 @@ export interface RecoverySuggestion {
 
 export interface SearchRecovery {
   suggestions: RecoverySuggestion[];
+}
+
+/**
+ * Derive a "City, ST" label from a campus street address like
+ * "1247 Jimmie Kerr Road, Graham, NC 27253" → "Graham, NC". The city is the
+ * second-to-last comma segment (so multi-word cities like "Lake Jackson" and
+ * "Corpus Christi" survive); the state is the first token of the last segment
+ * (dropping the ZIP, including ZIP+4). Returns null when the address doesn't
+ * have at least street/city/"ST ZIP" parts, so the UI just omits it.
+ */
+export function cityFromAddress(address: string | null | undefined): string | null {
+  if (!address) return null;
+  const parts = address.split(",").map((p) => p.trim()).filter(Boolean);
+  if (parts.length < 3) return null;
+  const city = parts[parts.length - 2];
+  const stateAbbr = parts[parts.length - 1].split(/\s+/)[0];
+  if (!city || !stateAbbr) return null;
+  return `${city}, ${stateAbbr}`;
 }
 
 /** Parse a search query into structured parts */
@@ -329,6 +350,9 @@ export async function searchCoursesAcrossColleges(
       colleges.push({
         slug,
         name: inst?.name || slug,
+        // Primary-campus city, so a result conveys where the college is even
+        // when no zip was entered (no distance computed).
+        city: cityFromAddress(inst?.campuses?.[0]?.address),
         distance,
         auditAllowed: inst?.audit_policy?.allowed ?? null,
         sections,


### PR DESCRIPTION
## What changes for someone using the site

A course search lists colleges from across the **whole state**, but a result card only showed the college name — and a distance *only if you'd typed a zip code* (which is optional and unprompted). So a Charlotte student searching `PSY 150` saw:

> **Coastal Carolina Community College** — 1 section · T Th 5:30–7:40 PM
> **South Piedmont Community College** — 1 section · Th 6:00–7:15 PM

…with nothing to tell them that Coastal Carolina is in **Jacksonville, ~180 miles away**, while South Piedmont is the local one. For a "find a class **near me**" task — the literal north-star — that's a trap.

Now every result shows the college's **city** next to its name:

> Coastal Carolina Community College · **Jacksonville, NC**
> South Piedmont Community College · **Polkton, NC**

No zip required, **all 51 states**. (When a zip *is* entered, the existing "X mi" distance still shows alongside.)

This came out of re-walking the Charlotte goldenpath on prod: with the search/streaming/empty-state work already shipped this session, proximity legibility was the weakest remaining link.

## How it works

- **`lib/courses-search.ts`** — adds `city` to `CollegeGroup`. A new `cityFromAddress()` derives `"City, ST"` from the college's primary campus address (`inst.campuses[0].address`, e.g. `"1247 Jimmie Kerr Road, Graham, NC 27253"` → `"Graham, NC"`): the city is the second-to-last comma segment (so multi-word cities like "Lake Jackson" / "Corpus Christi" survive), the state is the first token of the last segment (dropping the ZIP / ZIP+4). Returns `null` if the address doesn't parse, so the UI just omits it. Populated in the existing result build loop right where `inst` is already in scope.
- **`CourseSearchClient.tsx`** — renders the city (muted) next to the college name, before the existing distance.
- The API route returns the search output verbatim, so `city` flows through with no change.

## Test plan
- [x] `npm run typecheck` + `eslint` clean; `next build` succeeds.
- [x] API (NC goldenpath): Coastal Carolina → `"Jacksonville, NC"`, South Piedmont → `"Polkton, NC"`.
- [x] Spot-checked TX (`Alvin, TX`, `Texas City, TX`) and CA (`Oroville, CA`, `San Pablo, CA`) — multi-word cities parse correctly.
- [x] Defensive: **0 null cities across 210 CA colleges** for a MATH search — no `undefined` leakage; addresses parse cleanly statewide.
- [x] Playwright (worktree prod server): the city renders next to each college, no "undefined"; with `zip=28202` the "X mi" distance still appears alongside.
- [ ] Post-merge: hit the prod API for the NC goldenpath and confirm `city` is present.

## Out of scope (named)
- Auto-seeding the zip from IP geolocation to **distance-sort** results by default (the homepage already IP-detects the *state*; extending to an approximate location is a separate, geo-source-dependent follow-up).
- Zip-field prominence, a map view, per-college pages.

**DO NOT MERGE yet** — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)