### PR TITLE
Live filters on course search: Day/Time/Mode/Zip apply instantly

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import type { CourseMode } from "@/lib/types";
@@ -301,12 +301,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
   // Pagination
   const [displayLimit, setDisplayLimit] = useState(10);
 
-  // Set true by an empty-state recovery CTA after it clears a filter; the effect
-  // below then re-runs the search. We can't clear-and-search in one handler
-  // because doSearch closes over the pre-clear filter value (stale closure).
-  const [recoveryPending, setRecoveryPending] = useState(false);
-
-  const doSearch = useCallback(async (searchQuery: string) => {
+  const doSearch = useCallback(async (searchQuery: string, opts?: { keepAnswer?: boolean }) => {
     if (!searchQuery.trim() || searchQuery.trim().length < 2) {
       setError("Enter at least 2 characters to search.");
       return;
@@ -316,11 +311,15 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     setError("");
     setHasSearched(true);
     setDisplayLimit(10);
-    // Reset previous answer card before either fetch resolves so a stale
-    // card never lingers under a new query.
-    setAnswer(null);
-    setSecondaryAnswer(null);
-    setClassification(null);
+    // Reset previous answer card before either fetch resolves so a stale card
+    // never lingers under a new query. Skipped on a filter-only re-search
+    // (keepAnswer): the query is unchanged, so resetting would just flash the
+    // card out and back to the same content.
+    if (!opts?.keepAnswer) {
+      setAnswer(null);
+      setSecondaryAnswer(null);
+      setClassification(null);
+    }
 
     const trimmed = searchQuery.trim();
     // The user query may be natural language ("Computer Science classes on
@@ -517,14 +516,41 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     doSearch(initialQuery);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Re-run the search after a recovery CTA cleared a filter. Runs post-render so
-  // doSearch now closes over the cleared filter value. The early return keeps a
-  // normal manual filter change (recoveryPending false) from auto-searching.
+  // Keep refs to the latest doSearch + query so the debounced auto-apply below
+  // invokes the current closure (which sees the just-changed filter), not a
+  // stale one captured when the timer was scheduled.
+  const doSearchRef = useRef(doSearch);
+  const queryRef = useRef(query);
   useEffect(() => {
-    if (!recoveryPending) return;
-    setRecoveryPending(false);
-    doSearch(query);
-  }, [recoveryPending, query, doSearch]);
+    doSearchRef.current = doSearch;
+    queryRef.current = query;
+  });
+
+  // Live filters: re-run the search (debounced) whenever Day / Time / Mode / Zip
+  // changes after a search exists — so they behave like the Transfers-to filter
+  // (instant) instead of silently needing a second click of Search. This also
+  // makes the empty-state recovery CTAs work: they just clear a filter and let
+  // this fire. Keyed only on these four (NOT doSearch) so a Transfers-to change
+  // — which recreates doSearch but is applied client-side — doesn't trigger a
+  // server re-search. Guards: skip the initial mount / deep-link seeding; only
+  // after a real search; valid query; whole-or-empty zip; and not while a search
+  // is in flight (when doSearch syncs LLM-extracted filters into state — that
+  // must not loop back into another search).
+  const liveFiltersReady = useRef(false);
+  useEffect(() => {
+    if (!liveFiltersReady.current) {
+      liveFiltersReady.current = true;
+      return;
+    }
+    if (!hasSearched || loading) return;
+    if (queryRef.current.trim().length < 2) return;
+    if (zip !== "" && zip.length !== 5) return;
+    const t = setTimeout(
+      () => doSearchRef.current(queryRef.current, { keepAnswer: true }),
+      400
+    );
+    return () => clearTimeout(t);
+  }, [mode, days, timeOfDay, zip]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function toggleExpand(courseKey: string, slug: string) {
     const id = `${courseKey}::${slug}`;
@@ -813,10 +839,10 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
                         key={s.drop}
                         type="button"
                         onClick={() => {
+                          // Clear the filter; the live-filter effect re-searches.
                           if (s.drop === "mode") setMode("");
                           else if (s.drop === "days") setDays([]);
                           else setTimeOfDay("");
-                          setRecoveryPending(true);
                         }}
                         className="rounded-full border border-teal-300 dark:border-teal-700 bg-teal-50 dark:bg-teal-900/30 px-3 py-1.5 text-xs font-medium text-teal-700 dark:text-teal-300 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition"
                       >


### PR DESCRIPTION
## What changes for someone using the site

On the course search, changing **"Transfers to"** updated results instantly — but changing **Day, Time, Mode, or Zip did nothing** until you found and re-clicked the **Search** button. A student would set Time = "Evening (after 5 PM)", see the same results sitting there, and reasonably conclude the site was broken — or that there *were* no evening classes.

Now all four filters re-search **automatically** (debounced ~400ms) the moment you change them — one consistent "live filters" model, matching how "Transfers to" already behaved. So toggling **Thu**, picking **Evening**, or typing a **zip** updates the list immediately. All 51 states.

This came out of the goldenpath re-walk: with search/streaming/recovery/proximity already shipped, the filter-apply inconsistency was the last clear friction in the search flow.

## How it works

`app/[state]/courses/CourseSearchClient.tsx` — a debounced `useEffect` keyed on `[mode, days, timeOfDay, zip]` re-runs the search ~400ms after a change. Three things make it safe:

- **No stale closures.** It calls `doSearch`/`query` through refs, so the debounced timer invokes the *current* closure (which sees the just-changed filter), not the one captured when the timer was scheduled.
- **Transfers-to stays client-side.** The effect is keyed only on the four server filters — *not* on `doSearch` — so a "Transfers to" change (which recreates `doSearch` but is applied via the existing client-side `useMemo`) doesn't trigger a server re-search.
- **No loops / spurious fires.** It skips the initial mount + deep-link seeding (a `ready` ref), only fires after a real search, requires a valid query and a whole-or-empty zip (a partial `"282"` does nothing), and bails while a search is in flight — which is exactly when `doSearch` syncs LLM-extracted filters into state, a change that must not loop back into another search.

It also **subsumes #1242's `recoveryPending` workaround**: the empty-state recovery CTAs now simply clear a filter and let this effect re-search, so that extra state + effect are removed. `doSearch` gained a small `keepAnswer` option so a filter-only re-search doesn't flash the natural-language answer card out and back.

## Test plan (local prod build, NC, Playwright)
- [x] `typecheck` + `eslint` clean; `next build` succeeds.
- [x] Time = Evening (no Search click) auto-updates **331 → 3 sections**.
- [x] 4 rapid day toggles **debounce to ONE** `/courses/search` request (not 4).
- [x] Partial zip `"282"` fires **0** requests; full zip `"28202"` fires **1**.
- [x] Empty-state recovery CTA ("without the evening filter") clears the filter and lists **190 sections** — still works via the new effect.
- [x] Transfers-to = UNC Charlotte → **0** server requests (client-side), results still filter to UNCC.
- [ ] Post-merge: on prod, set a filter without clicking Search and confirm results update.

## Out of scope (named)
- Writing the active filters into the URL (separate lever).
- The `/ask` LLM classifier still re-fires on a filter change (it's cached, and `keepAnswer` prevents the card flicker) — a section-only re-search path is a possible future optimization, not needed here.

**DO NOT MERGE yet** — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)