### PR TITLE
Schedule builder: honor Time of day for async/online sections

### DIFF
--- a/lib/schedule.ts
+++ b/lib/schedule.ts
@@ -354,9 +354,21 @@ function filterSections(
     // (async sections pass through)
     if (!isAsync && (dayMask & ~availableDayMask) !== 0) continue;
 
-    // Time window filter (async sections pass through)
-    if (!isAsync) {
-      if (startMin < timeWindow.startMin || endMin > timeWindow.endMin) continue;
+    // Time window filter. Timed sections must fall inside the requested window.
+    // Async / no-meeting-time sections normally "fit any schedule" and pass
+    // through — BUT when the student narrowed Time of day (Morning/Afternoon/
+    // Evening, i.e. a window tighter than all-day), they're asking for classes
+    // that MEET then. An async course has no meeting time, so letting it pass
+    // silently ignored that availability: picking "Evening" returned a wall of
+    // anytime-online courses that don't meet in the evening. Keep async only
+    // when Time is "Any" (full-day window) or the student explicitly wants
+    // online/zoom/hybrid.
+    const timeConstrained = timeWindow.startMin > 0 || timeWindow.endMin < 1440;
+    const wantsOnline = modeFilter === "online" || modeFilter === "hybrid";
+    if (isAsync) {
+      if (timeConstrained && !wantsOnline) continue;
+    } else if (startMin < timeWindow.startMin || endMin > timeWindow.endMin) {
+      continue;
     }
 
     // Distance filter


### PR DESCRIPTION
## What changes for someone using the site

The Smart Schedule Builder (`/{state}/schedule`) was silently ignoring a student's stated availability. Set **Time of day = Evening** and it returned "**20 conflict-free schedules**" — but every one was an **Async/Online** course, which has no meeting time and so vacuously satisfied the time filter. A working student who can only attend evenings was shown a wall of anytime-online courses that don't meet then, presented identically to real timed classes. The only way to discover there were actually ~0 real evening classes was to switch Modality to In-Person.

Now picking a specific Time of day returns classes that **actually meet then**. For NC:
- **ENG + Evening** now surfaces real evening sections meeting at **6:00 PM / 8:45 PM** (previously buried under the async-online wall).
- **PSY / MAT + Evening** honestly show "Only 0 matching courses found" with recovery guidance, instead of a misleading list of online courses.
- A student who *wants* online still gets it: **Evening + Modality = Online** keeps the anytime-online courses.

All 51 states.

## How it works

`lib/schedule.ts` (`filterSections`) had an explicit comment — *"Time window filter (async sections pass through)"* — letting any async / no-meeting-time section satisfy the time filter (the only place they were excluded was Modality = In-Person, which is why that revealed the truth). The fix: async sections now pass the time-window filter **only** when Time is "Any" (the full-day window `{0, 1440}`) or the student explicitly chose online/zoom/hybrid:

```ts
const timeConstrained = timeWindow.startMin > 0 || timeWindow.endMin < 1440;
const wantsOnline = modeFilter === "online" || modeFilter === "hybrid";
if (isAsync) {
  if (timeConstrained && !wantsOnline) continue;   // narrowed time + not online -> drop
} else if (startMin < timeWindow.startMin || endMin > timeWindow.endMin) {
  continue;
}
```

Timed sections are untouched. The existing "No sections match your constraints… (wider time window)" message now correctly fires for an over-constrained timed search.

## Test plan (local prod build, NC, Playwright)
- [x] `typecheck` clean; `next build` succeeds (7 pre-existing lint warnings in the file, none from this change).
- [x] ENG + Evening (Any Mode) → returns real evening classes (6:00 PM, 8:45 PM), no async-online wall.
- [x] PSY / MAT + Evening (Any Mode) → "Only 0 matching" + recovery (was "20 conflict-free schedules" of async-online).
- [x] Evening + Modality = Online → still returns the online courses.
- [x] Time = Any, and PSY+ENG multi-subject → unchanged.
- [ ] Post-merge: on prod `/nc/schedule`, +PSY + Evening + In-Person vs Any Mode now agree (no async wall).

## Out of scope (named)
- The **day-availability** subset gate has the same async issue, but its default is Mon–Fri (not all-7), so excluding async there would disrupt the default search — a separate change.
- The misleading **"M T W Th F Sa Su"** all-days display on async rows.
- The **missing export** (the homepage promises "export when you're ready to register" and "drag onto a weekly grid", but the builder is constraint-based and has neither).

**DO NOT MERGE yet** — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)