### PR TITLE
Stop async/online sections displaying as if they meet every day

### DIFF
--- a/app/[state]/college/[id]/instructor/[slug]/page.tsx
+++ b/app/[state]/college/[id]/instructor/[slug]/page.tsx
@@ -99,11 +99,12 @@ function expandDays(days: string): string {
 
 function formatSchedule(s: CourseSection): string {
   const hasTime = isValidTime(s.start_time) && isValidTime(s.end_time);
-  if (!s.days && !hasTime) return "Asynchronous / Online";
+  // No valid meeting time = no real schedule, regardless of the `days` field
+  // (async/online rows arrive with an all-days "M T W Th F Sa Su" placeholder).
+  if (!hasTime) return "No set meeting time";
   const days = s.days ? expandDays(s.days) : "";
-  const time = hasTime ? `${s.start_time}\u2013${s.end_time}` : "";
-  if (days && time) return `${days} ${time}`;
-  return days || time || "Asynchronous / Online";
+  const time = `${s.start_time}\u2013${s.end_time}`;
+  return days ? `${days} ${time}` : time;
 }
 
 // ---------------------------------------------------------------------------

--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -123,11 +123,12 @@ function expandDays(days: string): string {
 
 function formatSchedule(s: CourseSection): string {
   const hasTime = isValidTime(s.start_time) && isValidTime(s.end_time);
-  if (!s.days && !hasTime) return "Asynchronous / Online";
+  // No valid meeting time = no real schedule, regardless of the `days` field
+  // (async/online rows arrive with an all-days "M T W Th F Sa Su" placeholder).
+  if (!hasTime) return "No set meeting time";
   const days = s.days ? expandDays(s.days) : "";
-  const time = hasTime ? `${s.start_time}\u2013${s.end_time}` : "";
-  if (days && time) return `${days} ${time}`;
-  return days || time || "Asynchronous / Online";
+  const time = `${s.start_time}\u2013${s.end_time}`;
+  return days ? `${days} ${time}` : time;
 }
 
 // ---------------------------------------------------------------------------

--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import type { CourseMode } from "@/lib/types";
 import type { Answer } from "@/lib/search-intent/answer";
-import { expandDays } from "@/lib/time-utils";
+import { formatMeeting } from "@/lib/time-utils";
 import { termCodeFromLabel } from "@/lib/term-label";
 import { bestTransferEntry } from "@/lib/transfer-rank";
 import dynamic from "next/dynamic";
@@ -105,21 +105,8 @@ const MODE_STYLES: Record<CourseMode, { bg: string; text: string; label: string 
 
 // DAY_OPTIONS removed — replaced by DayToggle component
 
-function isValidTime(t: string): boolean {
-  return !!t && t !== "TBA" && t !== "0:00 AM" && t !== "0:00 PM";
-}
-
 function formatSchedule(s: SectionResult): string {
-  const hasTime = isValidTime(s.start_time) && isValidTime(s.end_time);
-  if (!s.days && !hasTime) {
-    return "Asynchronous / Online";
-  }
-  const days = s.days ? expandDays(s.days) : "";
-  const time = hasTime ? `${s.start_time}\u2013${s.end_time}` : "";
-  if (days && time) return `${days} ${time}`;
-  if (days) return days;
-  if (time) return time;
-  return "Asynchronous / Online";
+  return formatMeeting(s.days, s.start_time, s.end_time);
 }
 
 // The LLM emits compact single-letter day codes per the classifier prompt

--- a/app/[state]/starting-soon/StartingSoonClient.tsx
+++ b/app/[state]/starting-soon/StartingSoonClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import type { CourseMode } from "@/lib/types";
-import { expandDays } from "@/lib/time-utils";
+import { formatMeeting } from "@/lib/time-utils";
 
 // ---------------------------------------------------------------------------
 // Types matching the API response
@@ -85,21 +85,8 @@ const WINDOW_OPTIONS = [
   { value: 60, label: "Next 2 months" },
 ];
 
-function isValidTime(t: string): boolean {
-  return !!t && t !== "TBA" && t !== "0:00 AM" && t !== "0:00 PM";
-}
-
 function formatSchedule(s: SectionResult): string {
-  const hasTime = isValidTime(s.start_time) && isValidTime(s.end_time);
-  if (!s.days && !hasTime) return "Asynchronous / Online";
-  const days = s.days ? expandDays(s.days) : "";
-  const time = hasTime
-    ? `${s.start_time}\u2013${s.end_time}`
-    : "";
-  if (days && time) return `${days} ${time}`;
-  if (days) return days;
-  if (time) return time;
-  return "Asynchronous / Online";
+  return formatMeeting(s.days, s.start_time, s.end_time);
 }
 
 function daysAwayLabel(days: number): string {

--- a/components/CourseTable.tsx
+++ b/components/CourseTable.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useCallback, useEffect } from "react";
 import type { CourseSection, CourseMode } from "@/lib/types";
 import { getCourseStatus, formatStartInfo, isInProgress, type CourseStatus } from "@/lib/course-status";
-import { expandDays } from "@/lib/time-utils";
+import { formatMeeting } from "@/lib/time-utils";
 import DayToggle from "@/components/DayToggle";
 import PrereqChain from "@/components/PrereqChain";
 import { subjectName } from "@/lib/subjects";
@@ -68,21 +68,8 @@ function getUniqueModes(courses: CourseSection[]): CourseMode[] {
   return Array.from(modes).sort() as CourseMode[];
 }
 
-function isValidTime(t: string): boolean {
-  return !!t && t !== "TBA" && t !== "0:00 AM" && t !== "0:00 PM";
-}
-
 function formatSchedule(course: CourseSection): string {
-  const hasTime = isValidTime(course.start_time) && isValidTime(course.end_time);
-  if (!course.days && !hasTime) {
-    return "Asynchronous / Online";
-  }
-  const days = course.days ? expandDays(course.days) : "";
-  const time = hasTime ? `${course.start_time}\u2013${course.end_time}` : "";
-  if (days && time) return `${days} ${time}`;
-  if (days) return days;
-  if (time) return time;
-  return "Asynchronous / Online";
+  return formatMeeting(course.days, course.start_time, course.end_time);
 }
 
 function courseMatchesDays(courseDays: string, filterDays: string[]): boolean {

--- a/components/schedule/ScheduleResults.tsx
+++ b/components/schedule/ScheduleResults.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import type { GeneratedSchedule, ScheduleResponse, ScheduleSection } from "@/lib/types";
 import WeeklyCalendar from "./WeeklyCalendar";
 import ScoreBar from "./ScoreBar";
-import { isValidTime, expandDays } from "@/lib/time-utils";
+import { isValidTime, formatMeeting } from "@/lib/time-utils";
 import SectionSeats from "@/components/SectionSeats";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { createClient } from "@/lib/supabase/client";
@@ -32,12 +32,7 @@ const TRANSFER_STYLES: Record<string, { bg: string; text: string; label: string 
 };
 
 function formatSchedule(days: string, startTime: string, endTime: string): string {
-  const hasTime = isValidTime(startTime) && isValidTime(endTime);
-  if (!days && !hasTime) return "Async / Online";
-  const d = days ? expandDays(days) : "";
-  const time = hasTime ? `${startTime}\u2013${endTime}` : "";
-  if (d && time) return `${d} ${time}`;
-  return d || time || "Async / Online";
+  return formatMeeting(days, startTime, endTime);
 }
 
 function scoreColor(score: number): string {

--- a/lib/time-utils.ts
+++ b/lib/time-utils.ts
@@ -102,6 +102,27 @@ export function isValidTime(t: string): boolean {
 }
 
 /**
+ * Format a section's meeting for display: "Tu Th 5:30 PM–7:40 PM", or just the
+ * time when days are absent. A section with NO valid start/end time has no real
+ * meeting schedule — return "No set meeting time" regardless of its `days`
+ * field. (Async/online sections arrive with a "M T W Th F Sa Su" all-days
+ * placeholder; keying off `!days` instead let that print as if the class met
+ * every day.) Stays mode-agnostic — the Online/In-Person badge shown beside this
+ * conveys modality. Single source of truth: every section row should call this.
+ */
+export function formatMeeting(
+  days: string,
+  startTime: string,
+  endTime: string,
+): string {
+  const hasTime = isValidTime(startTime) && isValidTime(endTime);
+  if (!hasTime) return "No set meeting time";
+  const d = days ? expandDays(days) : "";
+  const time = `${startTime}–${endTime}`;
+  return d ? `${d} ${time}` : time;
+}
+
+/**
  * Compute the day bitmask for a day string like "M W F" or compact "MWF" / "TuTh".
  */
 export function daysToBitmask(days: string): number {


### PR DESCRIPTION
## What changes for someone using the site

Self-paced online classes were displaying as if they met **all seven days**. A student searching `PSY 150` saw rows like:

> PSY 150 · **M Tu W Th F Sa Su** · Online

…which reads as "meets every day." In reality those are async/online sections with **no set meeting time** — the data just stores them with an all-days placeholder. Now they read:

> PSY 150 · **No set meeting time** · Online

Classes with a real meeting time are unchanged ("Tu Th 5:30 PM–7:40 PM"). This shows up across the course search, the schedule builder, the per-course page, the course table, the starting-soon list, and instructor pages — **all 51 states**.

## How it works

Six near-identical `formatSchedule()` helpers each only treated a section as async when its `days` field was **empty** (`if (!days && !hasTime)`). But async/online sections arrive with `days="M T W Th F Sa Su"` (non-empty) and an empty `start_time` — so they fell through to printing the day string. The correct signal is **no valid meeting time**.

- **`lib/time-utils.ts`** — new shared `formatMeeting(days, start, end)`: no valid time → `"No set meeting time"` regardless of the `days` field; otherwise the normal days+time string. Single source of truth so this can't drift back. Mode-agnostic (the Online/In-Person badge beside it conveys modality).
- Replaced the duplicated `formatSchedule()` with `formatMeeting` at the four sites already on the terse shared `expandDays` format (course search, schedule results, `CourseTable`, starting-soon), and deleted their now-dead local `isValidTime`/`expandDays`.
- `course/[code]/page.tsx` and the instructor page use a **local** `expandDays` that renders full day names ("Mon Tue", clearer for first-gen readers) — fixed the async detection **in place** there so their format is unchanged, just no longer all-7-days for no-time sections.

## Test plan (local prod build, NC, Playwright)
- [x] `typecheck` clean; `eslint` clean on touched files (1 pre-existing unrelated warning); `next build` succeeds.
- [x] `/nc/courses?q=PSY 150` (online) → rows read "No set meeting time", NOT "M Tu W Th F Sa Su".
- [x] `/nc/schedule` built schedule → async sections read "No set meeting time"; a timed section (ENG) still shows its day + PM time.
- [x] No "all 7 days" string regressed on the course page / starting-soon.
- [ ] Post-merge: on prod, an online section in course search reads "No set meeting time".

## Out of scope (named)
- The `WeeklyCalendar` time-grid (a no-time section can't be placed on a time grid — separate handling).
- Fixing the underlying scraped data (the all-days placeholder) — the display fix is correct regardless, but normalizing the data is a possible follow-up.
- Unifying the two day-name formats ("M Tu" vs "Mon Tue") across the site — intentionally left as-is.

**DO NOT MERGE yet** — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)