### PR TITLE
Program pages: reframe transfer majors instead of empty earnings columns

### DIFF
--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -184,6 +184,21 @@ export default async function ProgramPage(props: PageProps) {
           x.outcomes.earnings1YrMedian != null),
     );
 
+  // A program only has outcomes worth a table column if at least one college
+  // actually reports awards or earnings. Transfer-academic programs (Psychology,
+  // Liberal Arts…) have CIP codes but community colleges don't award the degree
+  // (students transfer first), so every Awards/Earnings cell is "—". Gate the
+  // columns on real data and reframe to the transfer pathway instead of showing
+  // a wall of dashes that reads as "broken" / "this major earns nothing".
+  const hasOutcomes = data.colleges.some((c) => {
+    const o = outcomesByCollege[c.collegeCode];
+    return (
+      (o?.awardsLevel1 ?? 0) + (o?.awardsLevel2 ?? 0) > 0 ||
+      o?.earnings5YrMedian != null ||
+      o?.earnings1YrMedian != null
+    );
+  });
+
   const itemListLd = {
     "@context": "https://schema.org",
     "@type": "ItemList",
@@ -383,6 +398,19 @@ export default async function ProgramPage(props: PageProps) {
               ones transfer to the school you want, and what&rsquo;s open now.
             </p>
           )}
+          {!hasOutcomes && (
+            <p className="mb-4 rounded-lg border border-teal-200 dark:border-teal-800 bg-teal-50 dark:bg-teal-900/20 px-3 py-2 text-sm text-teal-800 dark:text-teal-300">
+              {program.name} is a transfer program — community colleges offer the
+              coursework; you earn the degree, and its earnings, at a four-year
+              university.{" "}
+              <Link
+                href={`/${state}/transfer`}
+                className="font-medium underline hover:no-underline"
+              >
+                See where it transfers &rarr;
+              </Link>
+            </p>
+          )}
           <div className="rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden bg-white dark:bg-slate-900">
             <table className="w-full text-left text-sm">
               <thead className="bg-gray-50 dark:bg-slate-800 text-xs uppercase tracking-wider text-gray-500 dark:text-slate-400">
@@ -393,7 +421,7 @@ export default async function ProgramPage(props: PageProps) {
                   </th>
                   <th className="px-4 py-2.5 font-medium text-right">Courses</th>
                   <th className="px-4 py-2.5 font-medium text-right">Online</th>
-                  {program.cips.length > 0 && (
+                  {hasOutcomes && (
                     <>
                       <th
                         className="px-4 py-2.5 font-medium text-right"
@@ -448,7 +476,7 @@ export default async function ProgramPage(props: PageProps) {
                       <td className="px-4 py-2.5 text-right text-gray-600 dark:text-slate-400">
                         {c.onlineCount > 0 ? c.onlineCount : "—"}
                       </td>
-                      {program.cips.length > 0 && (
+                      {hasOutcomes && (
                         <>
                           <td className="px-4 py-2.5 text-right text-gray-600 dark:text-slate-400">
                             {awards > 0 ? awards : "—"}


### PR DESCRIPTION
## What changes for someone using the site

On a program page for a **transfer major** like `/nc/program/psychology`, the college-comparison table showed **"Awards/yr"** and **"5-yr earnings"** columns that were entirely **"—"** for every college. To a first-gen student that reads as "broken" — or worse, "this major earns nothing."

It's actually correct: community colleges offer psychology (and Liberal Arts, English, Math…) as **transfer coursework**, not a degree they grant — so the federal College Scorecard has no completion awards or earnings for it. Now, instead of a wall of dashes, those pages show a short note:

> **Psychology is a transfer program** — community colleges offer the coursework; you earn the degree, and its earnings, at a four-year university. **See where it transfers →**

…linking to the Transfer finder. **Career/CTE programs are unchanged** — Business Administration ($47,440) and Computer Science ($50,984) still show their real per-college earnings, because the data is there.

## How it works

`app/[state]/program/[slug]/page.tsx` rendered the two outcome columns whenever the program had CIP codes (`program.cips.length > 0`) — regardless of whether *any* college actually reported anything. The fix gates them on real data:

```ts
const hasOutcomes = data.colleges.some((c) => {
  const o = outcomesByCollege[c.collegeCode];
  return (o?.awardsLevel1 ?? 0) + (o?.awardsLevel2 ?? 0) > 0
      || o?.earnings5YrMedian != null || o?.earnings1YrMedian != null;
});
```

- The Awards/yr + 5-yr-earnings columns (header and body cells) now render only when `hasOutcomes`.
- When `!hasOutcomes`, a teal reframe note + a link to `/{state}/transfer` replaces them.

This mirrors a pattern the page already used — the national-benchmark earnings header only renders when it finds non-null earnings. One file.

## Test plan (local prod build, NC, Playwright)
- [x] `typecheck` + `eslint` clean; `next build` succeeds.
- [x] `/nc/program/psychology` → Awards/Earnings columns **hidden**; transfer reframe note + working `/nc/transfer` link; table is 4 clean columns.
- [x] `/nc/program/business-administration` and `/computer-science` → columns **kept** with real earnings ($47,440 / $50,984); **no** reframe note.
- [ ] Post-merge: on prod, psychology shows the reframe and business keeps its earnings.

## Out of scope (named)
- Changing the underlying Scorecard data (the sparsity is real — CCs don't award these degrees).
- The national-benchmark earnings header (already conditionally hidden when earnings are null).
- Per-column granularity (a program with awards but no earnings keeps both columns; the awards column is still informative and the earnings tooltip already explains "—").

**DO NOT MERGE yet** — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)