### PR TITLE
schedule: resolve subject names + multi-word phrases to courses (all states)

### DIFF
--- a/lib/__tests__/schedule.test.ts
+++ b/lib/__tests__/schedule.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   parseSubjectQueries,
+  matchesSubjectQuery,
   parseTimeWindow,
   combinations,
   hasTimeConflict,
@@ -48,6 +49,7 @@ describe("parseSubjectQueries", () => {
     expect(parseSubjectQueries(["PSY 200", "ART 101"])).toEqual({
       exactCourses: ["PSY-200", "ART-101"],
       subjectPrefixes: [],
+      keywordGroups: [],
     });
   });
 
@@ -55,19 +57,15 @@ describe("parseSubjectQueries", () => {
     expect(parseSubjectQueries(["BIO", "art"])).toEqual({
       exactCourses: [],
       subjectPrefixes: ["BIO", "ART"],
+      keywordGroups: [],
     });
-  });
-
-  it("treats free text as keyword search", () => {
-    const result = parseSubjectQueries(["psychology"]);
-    expect(result.exactCourses).toEqual([]);
-    expect(result.subjectPrefixes).toEqual(["PSYCHOLOGY"]);
   });
 
   it("supports mixed exact + prefix input", () => {
     expect(parseSubjectQueries(["PSY 200", "BIO"])).toEqual({
       exactCourses: ["PSY-200"],
       subjectPrefixes: ["BIO"],
+      keywordGroups: [],
     });
   });
 
@@ -75,7 +73,105 @@ describe("parseSubjectQueries", () => {
     expect(parseSubjectQueries(["psy200"])).toEqual({
       exactCourses: ["PSY-200"],
       subjectPrefixes: [],
+      keywordGroups: [],
     });
+  });
+
+  it("treats 'math' as a prefix (matches MATH sections even when titles omit 'math')", () => {
+    expect(parseSubjectQueries(["math"])).toEqual({
+      exactCourses: [],
+      subjectPrefixes: ["MATH"],
+      keywordGroups: [],
+    });
+  });
+
+  it("resolves a subject NAME to its prefixes AND keeps a keyword group", () => {
+    const result = parseSubjectQueries(["psychology"]);
+    expect(result.exactCourses).toEqual([]);
+    expect(result.subjectPrefixes.slice().sort()).toEqual(["PSY", "PSYC"]);
+    expect(result.keywordGroups).toEqual([["psychology"]]);
+  });
+
+  it("strips filler words ('history courses' → resolves history, drops 'courses')", () => {
+    const result = parseSubjectQueries(["history courses"]);
+    expect(result.subjectPrefixes.slice().sort()).toEqual(["AMH", "HIS", "HIST"]);
+    expect(result.keywordGroups).toEqual([["history"]]);
+  });
+
+  it("keeps all meaningful tokens for AND-matching ('intro to psychology')", () => {
+    const result = parseSubjectQueries(["intro to psychology"]);
+    expect(result.keywordGroups).toEqual([["intro", "psychology"]]);
+    expect(result.subjectPrefixes.slice().sort()).toEqual(["PSY", "PSYC"]);
+  });
+
+  it("ignores a query that is only filler ('courses')", () => {
+    expect(parseSubjectQueries(["courses"])).toEqual({
+      exactCourses: [],
+      subjectPrefixes: [],
+      keywordGroups: [],
+    });
+  });
+
+  it("leaves unknown free text as a title-only keyword group", () => {
+    const result = parseSubjectQueries(["underwater basket weaving"]);
+    expect(result.subjectPrefixes).toEqual([]);
+    expect(result.keywordGroups).toEqual([["underwater", "basket", "weaving"]]);
+  });
+});
+
+describe("matchesSubjectQuery", () => {
+  const match = (
+    prefix: string,
+    title: string,
+    opts: { exact?: string[]; prefixes?: string[]; groups?: string[][] } = {}
+  ) =>
+    matchesSubjectQuery(
+      prefix,
+      title,
+      `${prefix}-101`,
+      new Set(opts.exact ?? []),
+      new Set(opts.prefixes ?? []),
+      opts.groups ?? []
+    );
+
+  it("matches an exact course code", () => {
+    expect(match("HIST", "World History", { exact: ["HIST-101"] })).toBe(true);
+  });
+
+  it("matches by course prefix (typed or synonym-resolved)", () => {
+    expect(
+      match("HIST", "United States History to 1877", { prefixes: ["HIST"] })
+    ).toBe(true);
+  });
+
+  it("matches a keyword group present in the title", () => {
+    expect(
+      match("HIST", "United States History to 1877", { groups: [["history"]] })
+    ).toBe(true);
+  });
+
+  it("matches via TITLE when the prefix is unmapped (FL biology = BSC)", () => {
+    expect(match("BSC", "General Biology I", { groups: [["biology"]] })).toBe(true);
+  });
+
+  it("requires ALL tokens in a group (AND semantics)", () => {
+    expect(
+      match("HIST", "United States History to 1877", {
+        groups: [["world", "history"]],
+      })
+    ).toBe(false);
+    expect(
+      match("HIST", "World History Since 1500", { groups: [["world", "history"]] })
+    ).toBe(true);
+  });
+
+  it("does not match unrelated courses", () => {
+    expect(
+      match("MATH", "College Algebra", {
+        groups: [["history"]],
+        prefixes: ["HIST"],
+      })
+    ).toBe(false);
   });
 });
 

--- a/lib/__tests__/subjects.test.ts
+++ b/lib/__tests__/subjects.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { subjectPrefixesForName, subjectName } from "../subjects";
+
+describe("subjectPrefixesForName", () => {
+  const sorted = (xs: string[]) => xs.slice().sort();
+
+  it("resolves a subject name to every prefix that carries it", () => {
+    expect(sorted(subjectPrefixesForName("history"))).toEqual(["AMH", "HIS", "HIST"]);
+    expect(sorted(subjectPrefixesForName("mathematics"))).toEqual([
+      "MAC",
+      "MAT",
+      "MATH",
+      "MTH",
+    ]);
+    expect(sorted(subjectPrefixesForName("english"))).toEqual(["ENC", "ENG", "ENGL"]);
+    expect(sorted(subjectPrefixesForName("biology"))).toEqual(["BIO", "BIOL", "BSC"]);
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(sorted(subjectPrefixesForName("  History "))).toEqual(["AMH", "HIS", "HIST"]);
+  });
+
+  it("resolves colloquial aliases", () => {
+    expect(sorted(subjectPrefixesForName("poli sci"))).toEqual(["POL", "POLS"]);
+    expect(subjectPrefixesForName("psych")).toContain("PSY");
+    expect(subjectPrefixesForName("stats")).toContain("STAT");
+  });
+
+  it("returns [] for unknown names or empty input", () => {
+    expect(subjectPrefixesForName("nonsense")).toEqual([]);
+    expect(subjectPrefixesForName("")).toEqual([]);
+  });
+
+  it("stays in sync with the new FL/TX prefixes added to SUBJECT_NAMES", () => {
+    expect(subjectName("AMH")).toBe("History");
+    expect(subjectName("MAC")).toBe("Mathematics");
+    expect(subjectName("BSC")).toBe("Biology");
+    expect(subjectName("ENC")).toBe("English");
+    expect(subjectName("GOVT")).toBe("Government");
+  });
+});

--- a/lib/schedule.ts
+++ b/lib/schedule.ts
@@ -23,6 +23,7 @@ import { getZipCoordinates, calculateDistance } from "./geo";
 import { parseTimeToMinutes, daysToBitmask } from "./time-utils";
 import { isInProgress } from "./course-status";
 import { getCurrentTerm } from "./terms";
+import { subjectPrefixesForName } from "./subjects";
 import { bestTransferEntry } from "./transfer-rank";
 import { describeSeats } from "./seats";
 const MAX_RESULTS = 20;
@@ -92,7 +93,7 @@ export async function generateSchedules(
   }
 
   // Parse subject queries
-  const { exactCourses, subjectPrefixes } = parseSubjectQueries(
+  const { exactCourses, subjectPrefixes, keywordGroups } = parseSubjectQueries(
     request.subjects
   );
 
@@ -116,6 +117,7 @@ export async function generateSchedules(
     allSections,
     exactCourses,
     subjectPrefixes,
+    keywordGroups,
     availableDayMask,
     timeWindow,
     request.mode || "any",
@@ -195,6 +197,9 @@ export async function generateSchedules(
   if (allSections.length === 0) {
     message =
       "No course data available for this term yet. Check back soon — new schedules are added regularly.";
+  } else if (candidateCourses === 0) {
+    message =
+      "No courses matched your subjects. Check the course code (e.g. HIST) or try a broader term.";
   } else if (candidateCourses < request.maxCourses) {
     message = `Only ${candidateCourses} matching course${candidateCourses === 1 ? "" : "s"} found. Try adding more subjects or reducing max courses to ${candidateCourses}.`;
   } else if (results.length === 0 && candidates.length > 0) {
@@ -222,12 +227,34 @@ export async function generateSchedules(
 // Subject query parsing
 // ---------------------------------------------------------------------------
 
+/**
+ * Filler words stripped from free-text subject queries before matching, so a
+ * natural phrase like "history courses" or "intro to psychology" reduces to its
+ * meaningful tokens (["history"], ["intro","psychology"]).
+ */
+const SUBJECT_FILLER_WORDS = new Set([
+  "course",
+  "courses",
+  "class",
+  "classes",
+  "the",
+  "of",
+  "to",
+  "and",
+  "for",
+  "in",
+  "a",
+  "an",
+]);
+
 export function parseSubjectQueries(subjects: string[]): {
   exactCourses: string[]; // e.g. ["PSY-200", "ART-101"]
-  subjectPrefixes: string[]; // e.g. ["BIO"]
+  subjectPrefixes: string[]; // clean prefixes + prefixes resolved from names
+  keywordGroups: string[][]; // tokenized free text, AND-matched against titles
 } {
   const exactCourses: string[] = [];
   const subjectPrefixes: string[] = [];
+  const keywordGroups: string[][] = [];
 
   for (const raw of subjects) {
     const trimmed = raw.trim().toUpperCase();
@@ -235,19 +262,71 @@ export function parseSubjectQueries(subjects: string[]): {
     const exact = trimmed.match(/^([A-Z]{2,4})\s*(\d{3})$/);
     if (exact) {
       exactCourses.push(`${exact[1]}-${exact[2]}`);
-    } else {
-      // "ART" or "art" or "psychology" (keyword)
-      const prefix = trimmed.match(/^([A-Z]{2,4})$/);
-      if (prefix) {
-        subjectPrefixes.push(prefix[1]);
-      } else {
-        // Treat as keyword — match against prefix or title
-        subjectPrefixes.push(trimmed);
+      continue;
+    }
+    // "ART" or "art" — a bare course prefix
+    const prefix = trimmed.match(/^([A-Z]{2,4})$/);
+    if (prefix) {
+      subjectPrefixes.push(prefix[1]);
+      continue;
+    }
+
+    // Free text ("history courses", "intro to psychology"): tokenize, drop
+    // filler, then both (a) resolve the subject NAME to course prefixes and
+    // (b) keep the cleaned tokens to AND-match against course titles. The two
+    // are complementary — prefixes catch titles that omit the word; title
+    // tokens catch states whose prefixes aren't in the name map.
+    const tokens = raw
+      .toLowerCase()
+      .split(/\s+/)
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0 && !SUBJECT_FILLER_WORDS.has(t));
+    if (tokens.length === 0) continue;
+
+    // Try the whole cleaned phrase first ("computer science"), then each token.
+    const synonymPrefixes = new Set<string>(
+      subjectPrefixesForName(tokens.join(" "))
+    );
+    if (synonymPrefixes.size === 0) {
+      for (const tok of tokens) {
+        for (const p of subjectPrefixesForName(tok)) synonymPrefixes.add(p);
+      }
+    }
+    for (const p of synonymPrefixes) subjectPrefixes.push(p);
+
+    keywordGroups.push(tokens);
+  }
+
+  return { exactCourses, subjectPrefixes, keywordGroups };
+}
+
+/**
+ * Does a course match the parsed subject query? A match is any of:
+ *  - exact course code (e.g. "HIST-101")
+ *  - course prefix (clean prefix or one resolved from a subject name)
+ *  - a keyword group where every token is a substring of the title (or equals
+ *    the prefix) — AND semantics, so "world history" needs both words.
+ */
+export function matchesSubjectQuery(
+  coursePrefix: string,
+  courseTitle: string,
+  courseKey: string,
+  exactSet: Set<string>,
+  prefixSet: Set<string>,
+  keywordGroups: string[][]
+): boolean {
+  if (exactSet.size > 0 && exactSet.has(courseKey)) return true;
+  if (prefixSet.has(coursePrefix)) return true;
+  if (keywordGroups.length > 0) {
+    const titleLower = courseTitle.toLowerCase();
+    const prefixLower = coursePrefix.toLowerCase();
+    for (const group of keywordGroups) {
+      if (group.every((t) => titleLower.includes(t) || t === prefixLower)) {
+        return true;
       }
     }
   }
-
-  return { exactCourses, subjectPrefixes };
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -290,6 +369,7 @@ function filterSections(
   allSections: CourseSection[],
   exactCourses: string[],
   subjectPrefixes: string[],
+  keywordGroups: string[][],
   availableDayMask: number,
   timeWindow: { startMin: number; endMin: number },
   modeFilter: string,
@@ -303,9 +383,6 @@ function filterSections(
 ): { sections: EnrichedSection[]; filteredFullCount: number } {
   const exactSet = new Set(exactCourses);
   const prefixSet = new Set(subjectPrefixes);
-  // For keyword search: lowercase prefixes that don't look like course codes
-  const keywords = subjectPrefixes.filter((p) => p.length > 4 || !/^[A-Z]+$/.test(p));
-  const keywordsLower = keywords.map((k) => k.toLowerCase());
 
   const results: EnrichedSection[] = [];
   let filteredFullCount = 0;
@@ -314,23 +391,18 @@ function filterSections(
     const courseKey = `${s.course_prefix}-${s.course_number}`;
 
     // Subject/course matching
-    let matched = false;
-    if (exactSet.size > 0 && exactSet.has(courseKey)) {
-      matched = true;
+    if (
+      !matchesSubjectQuery(
+        s.course_prefix,
+        s.course_title,
+        courseKey,
+        exactSet,
+        prefixSet,
+        keywordGroups
+      )
+    ) {
+      continue;
     }
-    if (!matched && prefixSet.has(s.course_prefix)) {
-      matched = true;
-    }
-    if (!matched && keywordsLower.length > 0) {
-      const titleLower = s.course_title.toLowerCase();
-      for (const kw of keywordsLower) {
-        if (titleLower.includes(kw)) {
-          matched = true;
-          break;
-        }
-      }
-    }
-    if (!matched) continue;
 
     // Date filter: skip sections that already started (unless opted in)
     if (!includeInProgress && isInProgress(s.start_date)) continue;

--- a/lib/subjects.ts
+++ b/lib/subjects.ts
@@ -38,6 +38,7 @@ const SUBJECT_NAMES: Record<string, string> = {
   // English & Communications
   ENG: "English",
   ENGL: "English",
+  ENC: "English", // FL (e.g. ENC 1101)
   COM: "Communications",
   COMM: "Communications",
   JOU: "Journalism",
@@ -63,12 +64,14 @@ const SUBJECT_NAMES: Record<string, string> = {
   MAT: "Mathematics",
   MATH: "Mathematics",
   MTH: "Mathematics",
+  MAC: "Mathematics", // FL (e.g. MAC 1105)
   STA: "Statistics",
   STAT: "Statistics",
 
   // Sciences
   BIO: "Biology",
   BIOL: "Biology",
+  BSC: "Biology", // FL (e.g. BSC 1010)
   CHE: "Chemistry",
   CHEM: "Chemistry",
   PHY: "Physics",
@@ -88,9 +91,11 @@ const SUBJECT_NAMES: Record<string, string> = {
   SOC: "Sociology",
   HIS: "History",
   HIST: "History",
+  AMH: "History", // FL (American History, e.g. AMH 2010)
   POL: "Political Science",
   POLS: "Political Science",
   GOV: "Government",
+  GOVT: "Government", // TX (e.g. GOVT 2305)
   ANT: "Anthropology",
   ANTH: "Anthropology",
   GEG: "Geography",
@@ -194,4 +199,47 @@ export function subjectName(prefix: string): string {
  */
 export function hasSubjectName(prefix: string): boolean {
   return prefix.toUpperCase() in SUBJECT_NAMES;
+}
+
+/**
+ * Reverse of SUBJECT_NAMES: human-readable name (lowercased) → the course
+ * prefixes that carry it. Derived once from SUBJECT_NAMES so the two never
+ * drift. One name can map to several prefixes (e.g. "history" → HIS, HIST, AMH).
+ */
+const NAME_TO_PREFIXES: Record<string, string[]> = (() => {
+  const map: Record<string, string[]> = {};
+  for (const [prefix, name] of Object.entries(SUBJECT_NAMES)) {
+    const key = name.toLowerCase();
+    (map[key] ??= []).push(prefix);
+  }
+  return map;
+})();
+
+/**
+ * Colloquial / abbreviated subject names → their canonical SUBJECT_NAMES entry.
+ * Only entries that survive prefix parsing matter here: a query of 4 or fewer
+ * letters (e.g. "bio", "econ") is treated as a course prefix upstream and never
+ * reaches this resolver, so this list focuses on the multi-word and >4-letter
+ * forms a student is likely to type.
+ */
+const SUBJECT_ALIASES: Record<string, string> = {
+  "poli sci": "political science",
+  polisci: "political science",
+  "comp sci": "computer science",
+  compsci: "computer science",
+  psych: "psychology",
+  stats: "statistics",
+  maths: "mathematics",
+};
+
+/**
+ * Resolve a free-text subject NAME to the course prefixes that represent it.
+ * e.g. "history" → ["HIS","HIST","AMH"], "poli sci" → ["POL","POLS"].
+ * Returns [] when the query isn't a recognized subject name.
+ */
+export function subjectPrefixesForName(query: string): string[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  const canonical = SUBJECT_ALIASES[q] ?? q;
+  return NAME_TO_PREFIXES[canonical] ?? [];
 }


### PR DESCRIPTION
## What changes for someone using the site

On the **Smart Schedule Builder** (`/{state}/schedule`), typing a subject in plain English now works. Before this, typing "history courses", "english classes", or "intro to psychology" returned **"Only 0 matching courses found"** in *every* state — even though the data was there. The builder only understood a bare prefix (`HIST`) or an exact code (`HIST 101`). Now:

- **"history courses"** → resolves to history sections (CA: **0 → 735** courses)
- **"math"** → matches MATH sections even though their titles read "College Algebra", not "math"
- **"biology courses"** in Florida → matches FL's `BSC` sections (**0 → 127**)

And when nothing genuinely matches, the empty state no longer gives the nonsensical advice to "reduce max courses to **0**" — it now reads: *"No courses matched your subjects. Check the course code (e.g. HIST) or try a broader term."*

## How it works (technical)

The matcher is one shared algorithm (`lib/schedule.ts`) behind the `[state]/schedule/build` route, so both the bug and the fix are national. Two complementary changes:

1. **Tokenize + filler-strip free text.** `parseSubjectQueries` now splits a phrase into tokens, drops filler words (`course`, `class`, `the`, `of`, `to`, …), and AND-matches the remaining tokens against course titles (extracted into a pure, tested `matchesSubjectQuery`). Previously it substring-matched the *entire phrase* against titles, so "history courses" looked for the literal string "history courses" — which appears in no title.
2. **Resolve subject NAMES → prefixes.** New `subjectPrefixesForName()` in `lib/subjects.ts`, derived by *inverting* the existing `SUBJECT_NAMES` map (no parallel map to drift): "history" → HIS/HIST/AMH, "math" → MAT/MATH/MTH. This catches courses whose titles omit the word (math titles rarely say "math").

The two paths complement each other: prefix resolution catches titles that omit the word; title-token matching catches states whose prefixes aren't in the map (FL uses ENC/MAC/BSC). I also extended `SUBJECT_NAMES` with five high-traffic FL/TX prefixes (ENC→English, MAC→Mathematics, BSC→Biology, AMH→History, GOVT→Government) — which also improves those subjects' SEO page titles.

## Out of scope
- Quick-add chip / placeholder redesign (the UX nudge that leads users to hand-type phrases).
- The separate CA `loadAllCourses` performance issue.

## Test plan
- **`lib/__tests__/subjects.test.ts`** (new): `subjectPrefixesForName` resolves names + aliases to prefix sets (incl. the new FL/TX prefixes); returns `[]` for unknowns.
- **`lib/__tests__/schedule.test.ts`**: updated `parseSubjectQueries` for the new `keywordGroups` field; new cases for filler-stripping, synonym resolution, AND-semantics, "math"-as-prefix, unknown free text; new `matchesSubjectQuery` suite (exact / prefix / title / FL-BSC fallback / AND / no-match).
- `npm run lint` → 0 errors · `npx tsc --noEmit` → clean · `npm run build` → clean.
- **Live, real Supabase data** (local dev on this branch): CA "history courses" 0→735, CA "math" →557, FL "biology courses" 0→127, genuine no-match → new empty-state copy.

## Files
- `lib/subjects.ts` — +5 prefixes; `NAME_TO_PREFIXES`, `SUBJECT_ALIASES`, `subjectPrefixesForName()`.
- `lib/schedule.ts` — `parseSubjectQueries` returns `keywordGroups`; new exported `matchesSubjectQuery`; `filterSections` uses it; empty-state copy fix.
- `lib/__tests__/schedule.test.ts`, `lib/__tests__/subjects.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
