### PR TITLE
feat(planner): "Add to planner" from course search + program pages

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -21,6 +21,7 @@ import { createClient } from "@/lib/supabase/client";
 import { track } from "@/lib/analytics";
 import AdUnit from "@/components/AdUnit";
 import { stashFavoriteDraft, favoriteDedupKey } from "@/lib/anon-draft";
+import { plannerHref } from "@/lib/planner-link";
 
 // ---------------------------------------------------------------------------
 // Types matching the API response
@@ -901,6 +902,20 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
                           prereqText={course.prerequisite_text}
                         />
                       )}
+                      <Link
+                        href={plannerHref(state, [`${course.prefix} ${course.number}`])}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          track("planner_add", { state, source: "search", count: 1 });
+                        }}
+                        className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs font-medium text-teal-600 dark:text-teal-400 hover:bg-teal-50 dark:hover:bg-teal-900/30 transition"
+                        title="Add this course to your semester planner"
+                      >
+                        <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                        </svg>
+                        Add to planner
+                      </Link>
                       <button
                         type="button"
                         onClick={(e) => { e.stopPropagation(); toggleBookmark(course); }}

--- a/components/ProgramRequirements.tsx
+++ b/components/ProgramRequirements.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import Link from "next/link";
 import { countRealCourses, programSlug, PLAN_MIN_COURSES } from "@/lib/programs/plan-shared";
+import { plannerHref } from "@/lib/planner-link";
+import { track } from "@/lib/analytics";
 import type { ProgramRequirement } from "@/lib/types";
 import type { Institution } from "@/lib/types";
 
@@ -41,6 +43,14 @@ function ProgramCard({
     collegeId && countRealCourses(program) >= PLAN_MIN_COURSES
       ? `/${state}/college/${collegeId}/program/${programSlug(program)}`
       : null;
+
+  // Every primary course across the program's requirement groups, as
+  // "PREFIX NUMBER" codes, for the "Plan all required courses" deep link into
+  // the semester planner. plannerHref de-dupes + caps at 100.
+  const allCourseCodes = program.requirement_groups.flatMap((g) =>
+    g.courses.map((c) => `${c.prefix} ${c.number}`),
+  );
+  const planAllHref = plannerHref(state, allCourseCodes);
 
   return (
     <div className="rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900">
@@ -108,6 +118,25 @@ function ProgramCard({
             <p className="text-sm text-gray-600 dark:text-slate-400">
               {program.description}
             </p>
+          )}
+
+          {planAllHref && (
+            <Link
+              href={planAllHref}
+              onClick={() =>
+                track("planner_add", {
+                  state,
+                  source: "program_all",
+                  count: Math.min(allCourseCodes.length, 100),
+                })
+              }
+              className="inline-flex items-center gap-1.5 rounded-lg border border-teal-200 dark:border-teal-800 bg-teal-50 dark:bg-teal-900/20 px-3 py-1.5 text-xs font-semibold text-teal-700 dark:text-teal-300 hover:bg-teal-100 dark:hover:bg-teal-900/40 transition"
+            >
+              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+              </svg>
+              Plan all required courses
+            </Link>
           )}
 
           {program.requirement_groups.length === 0 ? (
@@ -292,6 +321,16 @@ function RequirementGroupBlock({
                     ))}
                   </span>
                 )}
+                <Link
+                  href={plannerHref(state, [`${course.prefix} ${course.number}`])}
+                  onClick={() =>
+                    track("planner_add", { state, source: "program_course", count: 1 })
+                  }
+                  className="text-[11px] font-medium text-gray-400 dark:text-slate-500 hover:text-teal-600 dark:hover:text-teal-400 hover:underline whitespace-nowrap"
+                  title="Add this course to your semester planner"
+                >
+                  + plan
+                </Link>
               </li>
             ))}
           </ul>

--- a/components/SemesterPlanner.tsx
+++ b/components/SemesterPlanner.tsx
@@ -560,14 +560,31 @@ export default function SemesterPlanner({
   );
   const [anyStale, setAnyStale] = useState(false);
 
+  // Whether the planner was opened with courses pre-seeded via ?targets=
+  // (e.g. from an "Add to planner" link on course search / a program page).
+  const hasInitialTargets = (initialTargets?.length ?? 0) > 0;
+
   // Fetch all courses on mount
   useEffect(() => {
     async function load() {
       try {
         const res = await fetch(`/api/${state}/prereqs/courses`);
-        if (!res.ok) throw new Error("Failed to load courses");
-        const data = await res.json();
-        setAllCourses(data.courses);
+        if (res.ok) {
+          const data = await res.json();
+          setAllCourses(data.courses);
+        } else if (res.status === 404) {
+          // State has no prerequisite dataset. The planner can still render
+          // courses seeded via ?targets= as standalone nodes — just without an
+          // auto-sequenced prerequisite chain. Only show the "not available"
+          // error when nothing was seeded, so an "Add to planner" hand-off
+          // into such a state isn't a dead-end.
+          setAllCourses([]);
+          if (!hasInitialTargets) {
+            setError("Prerequisite data not available for this state");
+          }
+        } else {
+          throw new Error("Failed to load courses");
+        }
       } catch {
         setError("Prerequisite data not available for this state");
       } finally {
@@ -575,7 +592,7 @@ export default function SemesterPlanner({
       }
     }
     load();
-  }, [state]);
+  }, [state, hasInitialTargets]);
 
   // Build lookup map
   const lookup = useMemo(() => {

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -35,6 +35,7 @@ export type AnalyticsEvent =
   | "plan_save"
   | "plan_delete"
   | "plan_duplicate"
+  | "planner_add"
   // Saved items
   | "course_bookmark_add"
   | "course_bookmark_remove"

--- a/lib/planner-link.ts
+++ b/lib/planner-link.ts
@@ -1,0 +1,23 @@
+/**
+ * Deep-link helper for the semester planner.
+ *
+ * The planner (app/[state]/plan/PlannerClient.tsx) reads ?targets= from the
+ * URL — a comma-separated list of "PREFIX NUMBER" course codes (e.g.
+ * "ACCT 2301,ACCT 2302") — and seeds them as plan targets. This builds that
+ * link so course-search results and program requirement lists can hand a
+ * student's selected course(s) straight into the planner instead of making
+ * them re-type codes by hand.
+ *
+ * Codes are trimmed, de-duplicated, and capped at 100 to mirror the planner's
+ * own slice(0, 100) and keep the URL bounded. Each code is percent-encoded and
+ * the codes are joined with literal commas, matching the planner's split(",").
+ * Returns "" for an empty list so a caller can skip rendering the affordance.
+ */
+export function plannerHref(state: string, codes: string[]): string {
+  const unique = Array.from(
+    new Set(codes.map((c) => c.trim()).filter(Boolean)),
+  ).slice(0, 100);
+  if (unique.length === 0) return "";
+  const param = unique.map(encodeURIComponent).join(",");
+  return `/${state}/plan?targets=${param}`;
+}


### PR DESCRIPTION
## What changes for a student

When you find a class in **course search** (e.g. search "accounting" on `/tx/courses`), each result now has an **"+ Add to planner"** button. Click it and the **semester planner** opens with that course already loaded — and it auto-sequences the prerequisites into a term-by-term plan. No more copying course codes by hand.

On a **program page** (e.g. `/tx/program/accounting`), each required course gets a small **"+ plan"** link, and a **"Plan all required courses"** button loads the program's whole required-course list into the planner at once.

Before this, course search and the planner were disconnected: the homepage promises "search → plan", but a student had to manually re-type every course code into the planner. This wires those steps together.

## How it works

The planner **already** reads a `?targets=ACCT 2301,ACCT 2302` list from the URL and seeds it (`app/[state]/plan/PlannerClient.tsx`). This PR mostly just builds links to that existing entry point:

- **`lib/planner-link.ts`** — one shared `plannerHref(state, codes)` helper. Trims, de-dupes, caps at 100 (matching the planner's own `slice(0, 100)`), percent-encodes each code, joins with literal commas to match the planner's `split(",")`.
- **`CourseSearchClient.tsx`** — an "Add to planner" link in each course-result header, beside the existing bookmark button.
- **`ProgramRequirements.tsx`** — a "Plan all required courses" header link (full required list) + a per-course "+ plan" link on each requirement row.
- **`analytics.ts`** — registers a `planner_add` event so we can see whether the lever gets used.

### One robustness fix (and a pre-existing dead-end it closes)
A few states (e.g. **WA**, **MT**) declare prereqs in config but their aggregated prereq data is empty, so `/api/{state}/prereqs/courses` returns **404** and the planner showed *"Prerequisite data not available for this state."* An unconditional "Add to planner" link would have dead-ended there. So `SemesterPlanner` now: on a 404, **with** seeded `?targets=` it renders those courses as standalone nodes (no prereq chain) instead of erroring; **without** targets it keeps the informative message. This incidentally fixes the pre-existing dead-end where those states' home-page "Plan" card already linked to the same error page. It's a ~6-line change to the existing fetch, not a planner redesign.

## Test plan (run against the worktree dev server)
- `npm run typecheck` ✅ · `eslint` on all touched files ✅
- **URL contract round-trip** — `plannerHref` output parsed back through the planner's exact `split/trim/filter/slice` logic: single, multi, dupes+blanks, 100-cap, empty → all correct.
- **Full flow (Playwright, /tx):** course search shows 10 "Add to planner" links → first href = `/tx/plan?targets=ACCT%202301` → click → planner seeds ACCT 2301 and auto-sequences a 4-semester plan. Program page renders "Plan all required courses" (13 codes) + 13 per-course "+ plan" links.
- **No-prereq state (WA):** hand-off `?targets=ENGL 101` shows the course (no error); bare `/wa/plan` keeps the "not available" message; TX still sequences. ✅
- No runtime errors from the change in the dev console (only a pre-existing `/ask` Groq rate-limit warning, unrelated).

## Known gaps (v1)
- Single-course "Add to planner" links **replace** rather than accumulate across separate clicks — clicking course A then course B opens the planner with B, not A+B. "Plan all required courses" passes the full list at once. A cross-page cart is intentionally out of scope.
- "Plan all required courses" includes every listed course across requirement groups, including elective-menu options (the planner sequences them all). Fine for v1; a "required-only" pass could come later.
- Not wired into the schedule builder or the program-page transfer link — separate concerns.

**DO NOT MERGE — opened for review.**
