### PR TITLE
schedule: quick-add chips from subject-vocab (data-accurate breadth, 26 states)

### DIFF
--- a/app/[state]/schedule/page.tsx
+++ b/app/[state]/schedule/page.tsx
@@ -3,6 +3,8 @@ import ScheduleClient from "./ScheduleClient";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getUniversities } from "@/lib/transfer";
 import { getAvailableTermsForDisplay } from "@/lib/terms";
+import { loadSubjectVocab } from "@/lib/programs/subject-vocab";
+import { quickAddSubjectsForState } from "@/lib/schedule-chips";
 
 type Props = {
   params: Promise<{ state: string }>;
@@ -44,10 +46,13 @@ export default async function SchedulePage({ params }: Props) {
     // Terms unavailable — term selector will be hidden
   }
 
-  // Extract just the prefixes from popularCourses (e.g. "ENG 111" → "ENG")
-  const quickAddSubjects = [
-    ...new Set(config.popularCourses.map((c) => c.split(" ")[0])),
-  ];
+  // Quick-add chips: curated popularCourses prefixes first, then the state's
+  // most-offered subjects from the precomputed subject vocab. Falls back to
+  // just the popularCourses prefixes when no vocab exists for the state.
+  const quickAddSubjects = quickAddSubjectsForState(
+    loadSubjectVocab(state),
+    config.popularCourses
+  );
 
   return (
     <ScheduleClient

--- a/lib/__tests__/schedule-chips.test.ts
+++ b/lib/__tests__/schedule-chips.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { quickAddSubjectsForState } from "../schedule-chips";
+
+const vocab = (prefixes: string[]) => ({
+  subjects: prefixes.map((prefix) => ({ prefix })),
+});
+
+describe("quickAddSubjectsForState", () => {
+  it("returns exactly the popularCourses prefixes when no vocab (no regression)", () => {
+    // CA-style popularCourses: C-ID codes, ENGL duplicated.
+    expect(
+      quickAddSubjectsForState(null, [
+        "ENGL C1000",
+        "COMM C1000",
+        "STAT C1000",
+        "ENGL C1001",
+        "PSYC C1000",
+        "POLS C1000",
+      ])
+    ).toEqual(["ENGL", "COMM", "STAT", "PSYC", "POLS"]);
+  });
+
+  it("puts curated popularCourses prefixes first, then fills breadth from vocab", () => {
+    const result = quickAddSubjectsForState(
+      vocab(["BIO", "ENG", "HIS", "PSY", "CHM", "SOC"]),
+      ["ENG 111", "MTH 154", "BIO 101"]
+    );
+    // popularCourses first (ENG, MTH, BIO), then vocab order, skipping dups.
+    expect(result).toEqual(["ENG", "MTH", "BIO", "HIS", "PSY", "CHM", "SOC"]);
+  });
+
+  it("de-duplicates prefixes across both sources", () => {
+    expect(
+      quickAddSubjectsForState(vocab(["ENG", "BIO"]), [
+        "ENG 111",
+        "ENG 112",
+        "BIO 101",
+      ])
+    ).toEqual(["ENG", "BIO"]);
+  });
+
+  it("caps the total at the limit (default 8), preserving order", () => {
+    const result = quickAddSubjectsForState(
+      vocab(["AAA", "BBB", "CCC", "DDD", "EEE", "FFF", "GGG", "HHH", "III"]),
+      ["ENG 111", "MTH 154"]
+    );
+    expect(result).toHaveLength(8);
+    expect(result).toEqual([
+      "ENG",
+      "MTH",
+      "AAA",
+      "BBB",
+      "CCC",
+      "DDD",
+      "EEE",
+      "FFF",
+    ]);
+  });
+
+  it("respects a custom limit", () => {
+    expect(
+      quickAddSubjectsForState(vocab(["BIO", "HIS", "PSY"]), ["ENG 111"], 2)
+    ).toEqual(["ENG", "BIO"]);
+  });
+
+  it("uppercases, trims, and ignores empty entries", () => {
+    expect(quickAddSubjectsForState(vocab(["bio"]), ["eng 111", ""])).toEqual([
+      "ENG",
+      "BIO",
+    ]);
+  });
+});

--- a/lib/schedule-chips.ts
+++ b/lib/schedule-chips.ts
@@ -1,0 +1,53 @@
+/**
+ * Quick-add subject chips for the Smart Schedule Builder.
+ *
+ * Curated popularCourses prefixes come first — they highlight each state's
+ * key transfer courses. Then the state's most-offered subjects from the
+ * precomputed subject vocabulary fill out the breadth, so a student sees
+ * Biology / English / Math / History instead of a sparse, SEO-tuned set.
+ *
+ * When no vocab exists for the state (Supabase-first states have no
+ * data/{state}/subject-vocab.json), this returns exactly the popularCourses
+ * prefixes — identical to the previous behavior, so there is no regression.
+ */
+
+/** Minimal structural shape of a loaded subject-vocab (see lib/programs/subject-vocab). */
+interface SubjectVocabLike {
+  subjects: { prefix: string }[];
+}
+
+/**
+ * Build the quick-add chip list for a state: curated popularCourses prefixes
+ * first, then the most-offered subjects from `vocab` (which is already sorted
+ * by section_count descending), de-duplicated and capped at `limit`.
+ */
+export function quickAddSubjectsForState(
+  vocab: SubjectVocabLike | null,
+  popularCourses: string[],
+  limit = 8
+): string[] {
+  const chips: string[] = [];
+  const seen = new Set<string>();
+
+  const add = (raw: string) => {
+    // popularCourses entries are course codes ("ENG 111", "ENGL C1000");
+    // vocab entries are bare prefixes ("BIO"). Take the leading token.
+    const prefix = raw.split(" ")[0]?.trim().toUpperCase();
+    if (!prefix || seen.has(prefix)) return;
+    seen.add(prefix);
+    chips.push(prefix);
+  };
+
+  // 1. Curated highlights first.
+  for (const c of popularCourses) add(c);
+
+  // 2. Fill remaining slots with the state's most-offered subjects.
+  if (vocab) {
+    for (const s of vocab.subjects) {
+      if (chips.length >= limit) break;
+      add(s.prefix);
+    }
+  }
+
+  return chips.slice(0, limit);
+}


### PR DESCRIPTION
## What changes for someone using the site

On the **Smart Schedule Builder** (`/{state}/schedule`), the "quick-add" subject chips under the search box now reflect each state's **most-offered subjects** instead of a sparse, SEO-tuned list. Previously the chips came from each state's curated `popularCourses`, so California showed only `ENGL / COMM / STAT / PSYC / POLS` — no Math, Biology, or History — which is exactly what pushed students to hand-type "history courses" in the first place.

Now, for example, **Virginia** shows `ENG · MTH · BIO · HIS · PSY · ECO · SDV · ART` — the curated transfer courses first, then the subjects actually offered most across the state's colleges.

**Honest scope:** this improves the **26 states that have on-disk catalog data** (`data/{state}/subject-vocab.json`). The **24 Supabase-first states — including CA and TX — have no vocab file**, so their chips are **unchanged** (no regression). Generating vocab for those states is a separate follow-up. Note: the *matching* fix from #1249 already means typed subject names work everywhere; this PR is about making the chips a better starting point where we can.

## How it works (technical)

- New pure helper **`lib/schedule-chips.ts` → `quickAddSubjectsForState(vocab, popularCourses, limit=8)`**: takes the unique `popularCourses` prefixes first (curated highlights), then appends the state's subjects from `loadSubjectVocab(state)` — which is pre-sorted by `section_count` (most-offered first) — de-duplicated and capped at 8. If `vocab` is `null`, it returns exactly the `popularCourses` prefixes (the prior behavior).
- **`app/[state]/schedule/page.tsx`**: replaces the inline `popularCourses`-only derivation with a call to the helper, passing `loadSubjectVocab(state)`. `loadSubjectVocab` is a cheap, memoized synchronous file read — no new DB load on this `force-dynamic` page.

## Out of scope
- Generating `subject-vocab.json` for the 24 Supabase-first states (the CA/TX fix) — separate, bigger change to `build-subject-vocab.ts`.
- Showing friendly subject names ("History") instead of prefixes ("HIS") on chips.

## Test plan
- **`lib/__tests__/schedule-chips.test.ts`** (new, 6 cases): popularCourses-first ordering, vocab fills breadth, cross-source de-dup, cap at 8 with order preserved, custom limit, uppercasing/trim/empty handling, and the `vocab === null` → unchanged path.
- `npx tsc --noEmit` clean · ESLint clean on changed files · `npm run build` clean.
- **Live (worktree dev server):** `/va/schedule` renders `ENG, MTH, BIO, HIS, PSY, ECO, SDV, ART` (SDV/ART sourced from vocab); `/ca/schedule` renders the unchanged `ENGL, COMM, STAT, PSYC, POLS`.

## Files
- `lib/schedule-chips.ts` (new) — `quickAddSubjectsForState` helper.
- `app/[state]/schedule/page.tsx` — wire the helper + `loadSubjectVocab`.
- `lib/__tests__/schedule-chips.test.ts` (new) — unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
